### PR TITLE
Clean filter tests with separate configurations

### DIFF
--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterWebFilterFactoryTests.java
@@ -37,6 +37,12 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import static org.springframework.cloud.gateway.test.TestUtils.getMap;
 import static org.springframework.web.reactive.function.BodyExtractors.toMono;
 
+
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/HystrixWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/HystrixWebFilterFactoryTests.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -37,9 +38,15 @@ import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles(profiles = "hystrix-web-filter")
 public class HystrixWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToWebFilterFactoryTests.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -37,9 +38,15 @@ import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("redirect-to-web")
 public class RedirectToWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveNonProxyHeadersWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveNonProxyHeadersWebFilterFactoryTests.java
@@ -41,7 +41,6 @@ import reactor.test.StepVerifier;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
-//TODO: why does this break other tests if not in a profile?
 @ActiveProfiles("removenonproxyheaders")
 @DirtiesContext
 public class RemoveNonProxyHeadersWebFilterFactoryTests extends BaseWebClientTests {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestHeaderWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestHeaderWebFilterFactoryTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,9 +38,15 @@ import static org.springframework.web.reactive.function.BodyExtractors.toMono;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("remove-request-header-filter")
 public class RemoveRequestHeaderWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveResponseHeaderWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveResponseHeaderWebFilterFactoryTests.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -34,9 +35,15 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("remove-response-header")
 public class RemoveResponseHeaderWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RewritePathWebFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RewritePathWebFilterFactoryIntegrationTests.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -35,9 +36,15 @@ import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("rewrite-path-filter")
 public class RewritePathWebFilterFactoryIntegrationTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersWebFilterFactoryTests.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -45,9 +46,15 @@ import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("secure-headers-filter")
 public class SecureHeadersWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetPathWebFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetPathWebFilterFactoryIntegrationTests.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -35,9 +36,16 @@ import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("set-path-filter")
 public class SetPathWebFilterFactoryIntegrationTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetResponseWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetResponseWebFilterFactoryTests.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -35,9 +36,15 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("set-response-filter")
 public class SetResponseWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetStatusWebFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetStatusWebFilterFactoryTests.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
@@ -35,9 +36,15 @@ import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
+/**
+ * @author Spencer Gibb
+ * @author Biju Kunjummen
+ */
+
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
+@ActiveProfiles("set-status-filter")
 public class SetStatusWebFilterFactoryTests extends BaseWebClientTests {
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/resources/application-hystrix-web-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-hystrix-web-filter.yml
@@ -1,0 +1,18 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: hystrix_failure_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.hystrixfailure.org
+        filters:
+        - Hystrix=failcmd
+
+      # =====================================
+      - id: hystrix_success_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.hystrixsuccess.org
+        filters:
+        - Hystrix=successcmd

--- a/spring-cloud-gateway-core/src/test/resources/application-redirect-to-web.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-redirect-to-web.yml
@@ -1,0 +1,16 @@
+spring:
+  cloud:
+    gateway:
+      default-filters:
+      - AddResponseHeader=X-Response-Default-Foo, Default-Bar
+      - PrefixPath=/httpbin
+
+      # TODO: breakup configuration for individual tests (though some are reused)
+      routes:
+      # =====================================
+      - id: redirect_to_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.redirectto.org
+        filters:
+        - RedirectTo=302, http://example.org

--- a/spring-cloud-gateway-core/src/test/resources/application-remove-request-header-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-remove-request-header-filter.yml
@@ -2,9 +2,10 @@ spring:
   cloud:
     gateway:
       routes:
-      - id: add_request_header_test
+      - id: remove_request_header_test
         uri: ${test.uri}
         predicates:
         - Path=/headers
         filters:
-        - AddRequestHeader=X-Request-Foo, Bar
+        - RemoveRequestHeader=X-Request-Foo
+        

--- a/spring-cloud-gateway-core/src/test/resources/application-remove-response-header.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-remove-response-header.yml
@@ -1,0 +1,12 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: remove_response_header_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.removereresponseheader.org
+        - Path=/headers
+        filters:
+        - AddResponseHeader=X-Request-Foo, Bar
+        - RemoveResponseHeader=X-Request-Foo

--- a/spring-cloud-gateway-core/src/test/resources/application-removenonproxyheaders.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-removenonproxyheaders.yml
@@ -1,4 +1,3 @@
-
 spring:
   cloud:
     gateway:

--- a/spring-cloud-gateway-core/src/test/resources/application-request-parameter-web-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-request-parameter-web-filter.yml
@@ -1,7 +1,3 @@
-test:
-  hostport: httpbin.org:80
-  uri: lb://testservice
-
 spring:
   cloud:
     gateway:

--- a/spring-cloud-gateway-core/src/test/resources/application-rewrite-path-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-rewrite-path-filter.yml
@@ -1,0 +1,14 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: rewrite_path_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.baz.org
+        - RemoteAddr=127.0.0.1/24
+        filters:
+        # $\ is being used as an escape
+        - RewritePath=/foo/(?<segment>.*), /$\{segment}
+        - AddRequestHeader=X-Request-Foo, Bar
+        - AddRequestHeader=X-Request-Baz, Bat

--- a/spring-cloud-gateway-core/src/test/resources/application-secure-headers-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-secure-headers-filter.yml
@@ -2,9 +2,10 @@ spring:
   cloud:
     gateway:
       routes:
-      - id: add_request_header_test
+      - id: secure_headers_test
         uri: ${test.uri}
         predicates:
+        - Host=**.secureheaders.org
         - Path=/headers
         filters:
-        - AddRequestHeader=X-Request-Foo, Bar
+        - SecureHeaders

--- a/spring-cloud-gateway-core/src/test/resources/application-set-path-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-set-path-filter.yml
@@ -1,0 +1,11 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: set_path_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.setpath.org
+        - Path=/foo/{segment}
+        filters:
+        - SetPath=/{segment}

--- a/spring-cloud-gateway-core/src/test/resources/application-set-response-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-set-response-filter.yml
@@ -1,0 +1,13 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: set_response_header_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.setreresponseheader.org
+        - Path=/headers
+        filters:
+        - AddResponseHeader=X-Request-Foo, Bar1
+        - AddResponseHeader=X-Request-Foo, Bar2
+        - SetResponseHeader=X-Request-Foo, Bar

--- a/spring-cloud-gateway-core/src/test/resources/application-set-status-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-set-status-filter.yml
@@ -1,0 +1,22 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: set_status_int_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.setstatusint.org
+        - Path=/headers
+        filters:
+        - name: SetStatus
+          args:
+            status: 401
+
+      # =====================================
+      - id: set_status_string_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.setstatusstring.org
+        - Path=/headers
+        filters:
+        - SetStatus=BAD_REQUEST

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -1,7 +1,5 @@
 test:
   hostport: httpbin.org:80
-#  hostport: localhost:5000
-#  uri: http://${test.hostport}
   uri: lb://testservice
 
 spring:
@@ -10,8 +8,6 @@ spring:
       default-filters:
       - AddResponseHeader=X-Response-Default-Foo, Default-Bar
       - PrefixPath=/httpbin
-
-      # TODO: breakup configuration for individual tests (though some are reused)
       routes:
       # =====================================
       - host_example_to_httpbin=${test.uri}, Host=**.example.org
@@ -32,15 +28,6 @@ spring:
         - AddResponseHeader=X-Response-Foo, Bar
 
       # =====================================
-      - id: add_request_header_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.addrequestheader.org
-        - Path=/headers
-        filters:
-        - AddRequestHeader=X-Request-Foo, Bar
-
-      # =====================================
       - id: add_request_parameter_test
         uri: ${test.uri}
         predicates:
@@ -59,22 +46,6 @@ spring:
         - AddResponseHeader=X-Request-Foo, Bar
 
       # =====================================
-      - id: hystrix_failure_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.hystrixfailure.org
-        filters:
-        - Hystrix=failcmd
-
-      # =====================================
-      - id: hystrix_success_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.hystrixsuccess.org
-        filters:
-        - Hystrix=successcmd
-
-      # =====================================
       - id: load_balancer_client_test
         uri: lb://myservice
         predicates:
@@ -86,94 +57,6 @@ spring:
         predicates:
         - Method=GET
         - Host=**.method.org
-
-      # =====================================
-      - id: redirect_to_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.redirectto.org
-        filters:
-        - RedirectTo=302, http://example.org
-
-      # =====================================
-      - id: remove_request_header_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.removerequestheader.org
-        - Path=/headers
-        filters:
-        - RemoveRequestHeader=X-Request-Foo
-
-      # =====================================
-      - id: remove_response_header_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.removereresponseheader.org
-        - Path=/headers
-        filters:
-        - AddResponseHeader=X-Request-Foo, Bar
-        - RemoveResponseHeader=X-Request-Foo
-
-      # =====================================
-      - id: secure_headers_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.secureheaders.org
-        - Path=/headers
-        filters:
-        - SecureHeaders
-
-      # =====================================
-      - id: set_path_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.setpath.org
-        - Path=/foo/{segment}
-        filters:
-        - SetPath=/{segment}
-
-      # =====================================
-      - id: set_response_header_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.setreresponseheader.org
-        - Path=/headers
-        filters:
-        - AddResponseHeader=X-Request-Foo, Bar1
-        - AddResponseHeader=X-Request-Foo, Bar2
-        - SetResponseHeader=X-Request-Foo, Bar
-
-      # =====================================
-      - id: set_status_int_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.setstatusint.org
-        - Path=/headers
-        filters:
-        - name: SetStatus
-          args:
-            status: 401
-
-      # =====================================
-      - id: set_status_string_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.setstatusstring.org
-        - Path=/headers
-        filters:
-        - SetStatus=BAD_REQUEST
-
-      # =====================================
-      - id: rewrite_path_test
-        uri: ${test.uri}
-        predicates:
-        - Host=**.baz.org
-        - RemoteAddr=127.0.0.1/24
-        filters:
-        # $\ is being used as an escape
-        - RewritePath=/foo/(?<segment>.*), /$\{segment}
-        - AddRequestHeader=X-Request-Foo, Bar
-        - AddRequestHeader=X-Request-Baz, Bat
 
       # =====================================
       - id: default_path_to_httpbin


### PR DESCRIPTION
This PR completes the work started here - https://github.com/spring-cloud-incubator/spring-cloud-gateway/pull/45 - all filter tests now use a different configuration file.