### PR TITLE
Supports kotlin based dsl for routes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
 		<module>spring-cloud-gateway-core</module>
 		<module>spring-cloud-starter-gateway</module>
 		<module>spring-cloud-gateway-sample</module>
+		<module>spring-cloud-gateway-kotlin-extensions</module>
 		<module>docs</module>
 	</modules>
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Routes.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Routes.java
@@ -60,7 +60,7 @@ public class Routes {
 		private final Route.Builder builder = Route.builder();
 		private final LocatorBuilder locatorBuilder;
 
-		RouteSpec(LocatorBuilder locatorBuilder) {
+		private RouteSpec(LocatorBuilder locatorBuilder) {
 			this.locatorBuilder = locatorBuilder;
 		}
 
@@ -84,7 +84,7 @@ public class Routes {
 			return predicateBuilder();
 		}
 
-		PredicateSpec predicateBuilder() {
+		private PredicateSpec predicateBuilder() {
 			return new PredicateSpec(this.builder, this.locatorBuilder);
 		}
 
@@ -95,7 +95,7 @@ public class Routes {
 		private final Route.Builder routeBuilder;
 		private LocatorBuilder locatorBuilder;
 
-		PredicateSpec(Route.Builder routeBuilder, LocatorBuilder locatorBuilder) {
+		private PredicateSpec(Route.Builder routeBuilder, LocatorBuilder locatorBuilder) {
 			this.routeBuilder = routeBuilder;
 			this.locatorBuilder = locatorBuilder;
 		}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Routes.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Routes.java
@@ -60,7 +60,7 @@ public class Routes {
 		private final Route.Builder builder = Route.builder();
 		private final LocatorBuilder locatorBuilder;
 
-		private RouteSpec(LocatorBuilder locatorBuilder) {
+		RouteSpec(LocatorBuilder locatorBuilder) {
 			this.locatorBuilder = locatorBuilder;
 		}
 
@@ -84,7 +84,7 @@ public class Routes {
 			return predicateBuilder();
 		}
 
-		private PredicateSpec predicateBuilder() {
+		PredicateSpec predicateBuilder() {
 			return new PredicateSpec(this.builder, this.locatorBuilder);
 		}
 
@@ -95,7 +95,7 @@ public class Routes {
 		private final Route.Builder routeBuilder;
 		private LocatorBuilder locatorBuilder;
 
-		private PredicateSpec(Route.Builder routeBuilder, LocatorBuilder locatorBuilder) {
+		PredicateSpec(Route.Builder routeBuilder, LocatorBuilder locatorBuilder) {
 			this.routeBuilder = routeBuilder;
 			this.locatorBuilder = locatorBuilder;
 		}

--- a/spring-cloud-gateway-kotlin-extensions/pom.xml
+++ b/spring-cloud-gateway-kotlin-extensions/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.springframework.cloud</groupId>
+		<artifactId>spring-cloud-gateway</artifactId>
+		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<relativePath>..</relativePath> <!-- lookup parent from repository -->
+	</parent>
+	<artifactId>spring-cloud-gateway-kotlin-extensions</artifactId>
+	<packaging>jar</packaging>
+	<name>Spring Cloud Gateway Kotlin Extensions</name>
+	<description>Spring Cloud Gateway Kotlin Extensions</description>
+	<properties>
+		<main.basedir>${basedir}/..</main.basedir>
+		<kotlin.version>1.1.4-3</kotlin.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-gateway-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib-jre8</artifactId>
+			<version>${kotlin.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.projectreactor</groupId>
+			<artifactId>reactor-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+	
+	<build>
+    	<sourceDirectory>src/main/kotlin</sourceDirectory>
+    	<testSourceDirectory>src/test/kotlin</testSourceDirectory>
+		<plugins>
+			<plugin>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<configuration>
+					<jvmTarget>1.8</jvmTarget>
+				</configuration>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<version>${kotlin.version}</version>
+
+				<executions>
+					<execution>
+						<id>compile</id>
+						<phase>compile</phase>
+						<goals> 
+							<goal>compile</goal> 
+						</goals>
+					</execution>
+
+					<execution>
+						<id>test-compile</id>
+						<phase>test-compile</phase>
+						<goals> 
+							<goal>test-compile</goal> 
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+    	</plugins>
+	</build>
+</project>

--- a/spring-cloud-gateway-kotlin-extensions/src/main/kotlin/org/springframework/cloud/gateway/route/GatewayDsl.kt
+++ b/spring-cloud-gateway-kotlin-extensions/src/main/kotlin/org/springframework/cloud/gateway/route/GatewayDsl.kt
@@ -3,10 +3,37 @@ package org.springframework.cloud.gateway.route
 import reactor.core.publisher.Flux
 import java.util.function.Predicate
 
+/**
+ * A Kotlin based DSL to configure a [RouteLocator]
+ * 
+ * Example:
+ * ```
+ * val routeLocator = gateway {
+ *   route {
+ *      id("test")
+ *      uri("http://httpbin.org:80")
+ *      predicate(host("**.abc.org") and path("/image/png"))
+ *      add(addResponseHeader("X-TestHeader", "foobar"))
+ *   }
+ * }
+ * ```
+ * 
+ * @author Biju Kunjummen
+ */
+fun gateway(routeLocator: RouteLocatorDsl.() -> Unit) = RouteLocatorDsl().apply(routeLocator).build()
 
-class RoutesDsl {
+
+/**
+ * Provider for [RouteLocator] DSL functionality
+ */
+class RouteLocatorDsl {
     private val routes = mutableListOf<Route>()
 
+    /**
+     * DSL to add a route to the [RouteLocator]
+     * 
+     * @see [Route.Builder]
+     */
     fun route(init: Route.Builder.() -> Unit) {
         routes += Route.builder().apply(init).build()
     }
@@ -15,8 +42,15 @@ class RoutesDsl {
         return RouteLocator { Flux.fromIterable(this.routes) }
     }
 
+    /**
+     * A helper to return a composed [Predicate] that tests against this [Predicate] AND the [other] predicate
+     */
     infix fun <T> Predicate<T>.and(other: Predicate<T>) = this.and(other)
+
+    /**
+     * A helper to return a composed [Predicate] that tests against this [Predicate] OR the [other] predicate
+     */
     infix fun <T> Predicate<T>.or(other: Predicate<T>) = this.or(other)
 }
 
-fun gateway(routes: RoutesDsl.() -> Unit) = RoutesDsl().apply(routes).build()
+

--- a/spring-cloud-gateway-kotlin-extensions/src/main/kotlin/org/springframework/cloud/gateway/route/GatewayDsl.kt
+++ b/spring-cloud-gateway-kotlin-extensions/src/main/kotlin/org/springframework/cloud/gateway/route/GatewayDsl.kt
@@ -1,0 +1,22 @@
+package org.springframework.cloud.gateway.route
+
+import reactor.core.publisher.Flux
+import java.util.function.Predicate
+
+
+class RoutesDsl {
+    private val routes = mutableListOf<Route>()
+
+    fun route(init: Route.Builder.() -> Unit) {
+        routes += Route.builder().apply(init).build()
+    }
+
+    fun build(): RouteLocator {
+        return RouteLocator { Flux.fromIterable(this.routes) }
+    }
+
+    infix fun <T> Predicate<T>.and(other: Predicate<T>) = this.and(other)
+    infix fun <T> Predicate<T>.or(other: Predicate<T>) = this.or(other)
+}
+
+fun gateway(routes: RoutesDsl.() -> Unit) = RoutesDsl().apply(routes).build()

--- a/spring-cloud-gateway-kotlin-extensions/src/test/kotlin/org/springframework/cloud/gateway/route/GatewayDslTests.kt
+++ b/spring-cloud-gateway-kotlin-extensions/src/test/kotlin/org/springframework/cloud/gateway/route/GatewayDslTests.kt
@@ -1,0 +1,44 @@
+package org.springframework.cloud.gateway.route
+
+import org.junit.Test
+import org.springframework.cloud.gateway.filter.factory.WebFilterFactories.addResponseHeader
+import org.springframework.cloud.gateway.handler.predicate.RoutePredicates.host
+import org.springframework.cloud.gateway.handler.predicate.RoutePredicates.path
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.web.server.ServerWebExchange
+import reactor.test.StepVerifier
+import java.net.URI
+
+class GatewayDslTests {
+
+
+    @Test
+    fun testSampleRouteDsl() {
+        val routeLocator = gateway {
+            route {
+                id("test")
+                uri("http://httpbin.org:80")
+                predicate(host("**.abc.org") and path("/image/png"))
+                add(addResponseHeader("X-TestHeader", "foobar"))
+            }
+
+            route {
+                id("test2")
+                uri("http://httpbin.org:80")
+                predicate(path("/image/webp"))
+                add(addResponseHeader("X-AnotherHeader", "baz"))
+                add(addResponseHeader("X-AnotherHeader-2", "baz-2"))
+            }
+        }
+
+        val sampleExchange: ServerWebExchange = MockServerHttpRequest.get("/image/webp").header("Host", "test.abc.org").toExchange()
+        val matchingRoute = routeLocator.routes.filter({ r -> r.predicate.test(sampleExchange) }).next()
+
+        StepVerifier
+                .create(matchingRoute)
+                .expectNextMatches({ r -> 
+                    r.id == "test2" && r.webFilters.size == 2 && r.uri == URI.create("http://httpbin.org:80")})
+                .expectComplete()
+                .verify()
+    }
+}


### PR DESCRIPTION
Supports #57  - This is a PR just to show an early version of the DSL for defining routes using the Kotlin DSL. A sample configuration looks like this:

```
gateway {
            route {
                id("test")
                uri("http://httpbin.org:80")
                predicate(host("**.abc.org") and path("/image/png"))
                add(addResponseHeader("X-TestHeader", "foobar"))
            }

            route {
                id("test2")
                uri("http://httpbin.org:80")
                predicate(path("/image/webp"))
                add(addResponseHeader("X-AnotherHeader", "baz"))
                add(addResponseHeader("X-AnotherHeader-2", "baz-2"))
            }
        }

```