### PR TITLE
Change predicate pattern to match paths better

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
@@ -60,7 +60,7 @@ public class DiscoveryClientRouteDefinitionLocator implements RouteDefinitionLoc
 					// add a predicate that matches the url at /serviceId*
 					PredicateDefinition predicate = new PredicateDefinition();
 					predicate.setName(normalizePredicateName(PathRoutePredicateFactory.class));
-					predicate.addArg(PATTERN_KEY, "/" + serviceId + "*");
+					predicate.addArg(PATTERN_KEY, "/" + serviceId + "/*");
 					routeDefinition.getPredicates().add(predicate);
 
 					//TODO: support for other default predicates


### PR DESCRIPTION
Not much to it, but had me scratching my head for a while, hopefully of use....
`gateway-root/my-app/my-endpoint`
was resolving to 
`my-app-root/my-app`
now it resolves to 
`my-app-root/my-endpoint`
