### PR TITLE
Adds support for function paramters for gateway kotlin dsl

### DIFF
--- a/spring-cloud-gateway-core/src/main/kotlin/org/springframework/cloud/gateway/route/GatewayDsl.kt
+++ b/spring-cloud-gateway-core/src/main/kotlin/org/springframework/cloud/gateway/route/GatewayDsl.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.springframework.cloud.gateway.route
 
 import reactor.core.publisher.Flux
@@ -9,8 +26,7 @@ import java.util.function.Predicate
  * Example:
  * ```
  * val routeLocator = gateway {
- *   route {
- *      id("test")
+ *   route(id = "test") {
  *      uri("http://httpbin.org:80")
  *      predicate(host("**.abc.org") and path("/image/png"))
  *      add(addResponseHeader("X-TestHeader", "foobar"))
@@ -34,8 +50,12 @@ class RouteLocatorDsl {
 	 *
 	 * @see [Route.Builder]
 	 */
-	fun route(init: Route.Builder.() -> Unit) {
-		routes += Route.builder().apply(init).build()
+	fun route(id: String? = null, order: Int = 0, uri: String? = null, init: Route.Builder.() -> Unit) {
+		val builder = Route.builder()
+		if (uri != null) {
+			builder.uri(uri)
+		}
+		routes += builder.id(id).order(order).apply(init).build()
 	}
 
 	fun build(): RouteLocator {

--- a/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/GatewayDslTests.kt
+++ b/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/GatewayDslTests.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.springframework.cloud.gateway.route
 
 import org.junit.Test
@@ -13,7 +30,7 @@ import java.net.URI
 class GatewayDslTests {
 
 	@Test
-	fun testSampleRouteDsl() {
+	fun sampleRouteDsl() {
 		val routeLocator = gateway {
 			route {
 				id("test")
@@ -50,6 +67,28 @@ class GatewayDslTests {
 		StepVerifier.create(filteredRoutes)
 				.expectNextMatches({ r ->
 					r.id == "test2" && r.filters.size == 2 && r.uri == URI.create("http://httpbin.org:80")
+				})
+				.expectComplete()
+				.verify()
+	}
+
+	@Test
+	fun dslWithFunctionParameters() {
+		val routerLocator = gateway {
+			route(id = "test", order = 10, uri = "http://httpbin.org") {
+				predicate(host("**.abc.org"))
+			}
+		}
+
+		StepVerifier.create(routerLocator.routes)
+				.expectNextMatches({ r ->
+					r.id == "test" &&
+							r.uri == URI.create("http://httpbin.org") &&
+							r.order == 10 &&
+							r.order == 10 &&
+							r.predicate.test(MockServerWebExchange
+									.from(MockServerHttpRequest
+											.get("/someuri").header("Host", "test.abc.org")))
 				})
 				.expectComplete()
 				.verify()

--- a/spring-cloud-gateway-sample/pom.xml
+++ b/spring-cloud-gateway-sample/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.cloud.gateway</groupId>
@@ -9,6 +10,10 @@
 
 	<name>Spring Cloud Gateway Sample</name>
 	<description>Spring Cloud Gateway Sample</description>
+
+	<properties>
+		<kotlin.version>1.1.51</kotlin.version>
+	</properties>
 
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
@@ -50,9 +55,102 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-stdlib</artifactId>
+			<version>${kotlin.version}</version>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>org.jetbrains.kotlin</groupId>
+			<artifactId>kotlin-reflect</artifactId>
+			<version>${kotlin.version}</version>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<artifactId>kotlin-maven-plugin</artifactId>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<version>${kotlin.version}</version>
+				<configuration>
+					<compilerPlugins>
+						<plugin>spring</plugin>
+					</compilerPlugins>
+					<jvmTarget>1.8</jvmTarget>
+				</configuration>
+				<executions>
+					<execution>
+						<id>compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<source>src/main/java</source>
+								<source>src/main/kotlin</source>
+							</sourceDirs>
+						</configuration>
+					</execution>
+					<execution>
+						<id>test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>test-compile</goal>
+						</goals>
+						<configuration>
+							<sourceDirs>
+								<source>src/test/java</source>
+								<source>src/test/kotlin</source>
+							</sourceDirs>
+						</configuration>
+					</execution>
+				</executions>
+				<dependencies>
+					<dependency>
+						<groupId>org.jetbrains.kotlin</groupId>
+						<artifactId>kotlin-maven-allopen</artifactId>
+						<version>${kotlin.version}</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<compilerArgs>
+						<arg>-parameters</arg>
+					</compilerArgs>
+				</configuration>
+				<executions>
+					<!-- Replacing default-compile as it is treated specially by maven -->
+					<execution>
+						<id>default-compile</id>
+						<phase>none</phase>
+					</execution>
+					<!-- Replacing default-testCompile as it is treated specially by maven -->
+					<execution>
+						<id>default-testCompile</id>
+						<phase>none</phase>
+					</execution>
+					<execution>
+						<id>java-compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>compile</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>java-test-compile</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>testCompile</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<artifactId>maven-deploy-plugin</artifactId>
 				<configuration>

--- a/spring-cloud-gateway-sample/src/main/java/org/springframework/cloud/gateway/sample/GatewaySampleApplication.java
+++ b/spring-cloud-gateway-sample/src/main/java/org/springframework/cloud/gateway/sample/GatewaySampleApplication.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.Routes;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.RequestPredicates;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -39,10 +40,12 @@ import static org.springframework.tuple.TupleBuilder.tuple;
  */
 @SpringBootConfiguration
 @EnableAutoConfiguration
+@Import(AdditionalRoutes.class)
 public class GatewaySampleApplication {
 
 	@Bean
 	public RouteLocator customRouteLocator(ThrottleGatewayFilterFactory throttle) {
+		//@formatter:off
 		return Routes.locator()
 				.route("test")
 					.predicate(host("**.abc.org").and(path("/image/png")))
@@ -61,6 +64,7 @@ public class GatewaySampleApplication {
 							"refillUnit", "SECONDS")))
 					.uri("http://httpbin.org:80")
 				.build();
+		////@formatter:on
 	}
 
 	@Bean

--- a/spring-cloud-gateway-sample/src/main/kotlin/org/springframework/cloud/gateway/sample/AdditionalRoutes.kt
+++ b/spring-cloud-gateway-sample/src/main/kotlin/org/springframework/cloud/gateway/sample/AdditionalRoutes.kt
@@ -1,0 +1,23 @@
+package org.springframework.cloud.gateway.sample
+
+import org.springframework.cloud.gateway.filter.factory.GatewayFilters.addResponseHeader
+import org.springframework.cloud.gateway.handler.predicate.RoutePredicates.host
+import org.springframework.cloud.gateway.handler.predicate.RoutePredicates.path
+import org.springframework.cloud.gateway.route.RouteLocator
+import org.springframework.cloud.gateway.route.gateway
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class AdditionalRoutes {
+
+	@Bean
+	fun additionalRouteLocator(): RouteLocator = gateway {
+		route(id = "test-kotlin") {
+			uri("http://httpbin.org:80")
+			predicate(host("kotlin.abc.org") and path("/image/png"))
+			add(addResponseHeader("X-TestHeader", "foobar"))
+		}
+	}
+
+}


### PR DESCRIPTION
#97 - This PR adds support to specify id, uri, order as function parameters

Additionally the sample now contains a kotlin dsl based `routelocator`