### PR TITLE
Fix source code which in document

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -651,7 +651,7 @@ For some usages of the gateway, properties will be adequate, but some production
 === Fluent Java Routes API
 To allow for simple configuration in Java, there is a fluent API defined in the `Routes` class.
 
-.Config.java
+.GatewaySampleApplication.java
 [source,java]
 ----
 // static imports from GatewayFilters and RoutePredicates
@@ -659,15 +659,21 @@ To allow for simple configuration in Java, there is a fluent API defined in the 
 public RouteLocator customRouteLocator(ThrottleGatewayFilterFactory throttle) {
     return Routes.locator()
             .route("test")
-                .uri("http://httpbin.org:80")
                 .predicate(host("**.abc.org").and(path("/image/png")))
                 .addResponseHeader("X-TestHeader", "foobar")
-                .and()
-            .route("test2")
                 .uri("http://httpbin.org:80")
+            .route("test2")
                 .predicate(path("/image/webp"))
                 .add(addResponseHeader("X-AnotherHeader", "baz"))
-                .and()
+                .uri("http://httpbin.org:80")
+            .route("test3")
+                .order(-1)
+                .predicate(host("**.throttle.org").and(path("/get")))
+                .add(throttle.apply(tuple().of("capacity", 1,
+                     "refillTokens", 1,
+                     "refillPeriod", 10,
+                     "refillUnit", "SECONDS")))
+                .uri("http://httpbin.org:80")
             .build();
 }
 ----


### PR DESCRIPTION
There is not `Config.java` in source, and it has some mistakes according `Routes.java`. The right source which use fluent API defined in the `Routes` class is `GatewaySampleApplication.java`.