### PR TITLE
replace ReactiveHttpOutputMessage.setComplete

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestRateLimiterGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestRateLimiterGatewayFilterFactory.java
@@ -22,6 +22,7 @@ import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.cloud.gateway.filter.ratelimit.RateLimiter;
 import org.springframework.http.HttpStatus;
 import org.springframework.tuple.Tuple;
+import reactor.core.publisher.Mono;
 
 /**
  * User Request Rate Limiter filter. See https://stripe.com/blog/rate-limiters and
@@ -60,7 +61,7 @@ public class RequestRateLimiterGatewayFilterFactory implements GatewayFilterFact
 				return chain.filter(exchange);
 			}
 			exchange.getResponse().setStatusCode(HttpStatus.TOO_MANY_REQUESTS);
-			return exchange.getResponse().setComplete();
+			return Mono.empty();
 		}));
 	}
 


### PR DESCRIPTION
Using Mono.empty to indicate the process complete instead of ReactiveHttpOutputMessage.setComplete as from the java doc is not recommended