### PR TITLE
Fixes null pointer exception when routing by header and header is mis…

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactory.java
@@ -15,7 +15,8 @@
  *
  */
 
-package org.springframework.cloud.gateway.handler.predicate;
+package org.springframework.cloud.gateway.handler.predicate
+		;
 
 import java.util.Arrays;
 import java.util.List;
@@ -47,9 +48,11 @@ public class HeaderRoutePredicateFactory implements RoutePredicateFactory {
 	public Predicate<ServerWebExchange> apply(String header, String regexp) {
 		return exchange -> {
 			List<String> values = exchange.getRequest().getHeaders().get(header);
-			for (String value : values) {
-				if (value.matches(regexp)) {
-					return true;
+			if (values != null) {
+				for (String value : values) {
+					if (value.matches(regexp)) {
+						return true;
+					}
 				}
 			}
 			return false;

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactoryTest.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.gateway.handler.predicate;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
+import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.client.ClientResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DirtiesContext
+public class HeaderRoutePredicateFactoryTest extends BaseWebClientTests {
+
+    @Test
+    public void headerRouteWorks() {
+        Mono<ClientResponse> result = webClient.get()
+                .uri("/get")
+                .header("Foo", "bar")
+                .exchange();
+
+        StepVerifier.create(result)
+                .consumeNextWith(
+                        response -> {
+                            assertStatus(response, HttpStatus.OK);
+                            HttpHeaders httpHeaders = response.headers().asHttpHeaders();
+                            assertThat(httpHeaders.getFirst(HANDLER_MAPPER_HEADER))
+                                    .isEqualTo(RoutePredicateHandlerMapping.class.getSimpleName());
+                            assertThat(httpHeaders.getFirst(ROUTE_ID_HEADER))
+                                    .isEqualTo("header_test");
+                        })
+                .expectComplete()
+                .verify(DURATION);
+    }
+
+	@Test
+	public void headerRouteIgnoredWhenHeaderMissing() {
+		Mono<ClientResponse> result = webClient.get()
+				.uri("/get")
+				// no headers set. Test used to throw a null pointer exception.
+				.exchange();
+
+		StepVerifier.create(result)
+				.consumeNextWith(
+						response -> {
+							assertStatus(response, HttpStatus.OK);
+							HttpHeaders httpHeaders = response.headers().asHttpHeaders();
+							assertThat(httpHeaders.getFirst(HANDLER_MAPPER_HEADER))
+									.isEqualTo(RoutePredicateHandlerMapping.class.getSimpleName());
+							assertThat(httpHeaders.getFirst(ROUTE_ID_HEADER))
+									.isEqualTo("default_path_to_httpbin");
+						})
+				.expectComplete()
+				.verify(DURATION);
+	}
+
+    @EnableAutoConfiguration
+    @SpringBootConfiguration
+    @Import(DefaultTestConfig.class)
+    public static class TestConfig { }
+
+}

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -193,6 +193,11 @@ spring:
         - AddRequestHeader=X-Request-Baz, Bat
 
       # =====================================
+      - id: header_test
+        uri: ${test.uri}
+        predicates:
+        - Header=Foo, .*
+      # =====================================
       - id: default_path_to_httpbin
         uri: ${test.uri}
         order: 10000


### PR DESCRIPTION
A configuration like the following threw a NPE in HeaderRoutePredicateFactory.java when that header was missing in the request.

`
    @SpringBootApplication
    public class GatewayDemoApplication {

        @Bean
        public RouteLocator myRoutes(RouteLocatorBuilder builder) {
            return builder.routes()
                    .route(r -> r.header("Foo", "bar").uri("http://httpbin.org:80/get"))
                    .build();
        }
    
        public static void main(String[] args) {
            SpringApplication.run(GatewayDemoApplication.class, args);
        }
    }
`
