### PR TITLE
Removes hop headers after routing call

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -196,10 +196,8 @@ public class GatewayAutoConfiguration {
 
 		@Bean
 		public NettyRoutingFilter routingFilter(HttpClient httpClient,
-				ObjectProvider<List<HttpHeadersFilter>> headersFilters,
-				RemoveHopByHopHeadersFilter removeHopByHopHeadersFilter) {
-			return new NettyRoutingFilter(httpClient, headersFilters,
-					removeHopByHopHeadersFilter);
+												ObjectProvider<List<HttpHeadersFilter>> headersFilters) {
+			return new NettyRoutingFilter(httpClient, headersFilters);
 		}
 
 		@Bean

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -196,8 +196,10 @@ public class GatewayAutoConfiguration {
 
 		@Bean
 		public NettyRoutingFilter routingFilter(HttpClient httpClient,
-												ObjectProvider<List<HttpHeadersFilter>> headersFilters) {
-			return new NettyRoutingFilter(httpClient, headersFilters);
+				ObjectProvider<List<HttpHeadersFilter>> headersFilters,
+				RemoveHopByHopHeadersFilter removeHopByHopHeadersFilter) {
+			return new NettyRoutingFilter(httpClient, headersFilters,
+					removeHopByHopHeadersFilter);
 		}
 
 		@Bean

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -60,8 +61,8 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 
 
 		HttpHeaders headers = exchange.getRequest().getHeaders();
-		HttpHeaders filtered = HttpHeadersFilter.filter(getHeadersFilters(),
-				exchange.getRequest());
+		HttpHeaders filtered = HttpHeadersFilter.filter(getHeadersFilters(), headers,
+				exchange);
 
 		List<String> protocols = headers.get(SEC_WEBSOCKET_PROTOCOL);
 		if (protocols != null) {
@@ -82,9 +83,9 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 			filters = new ArrayList<>();
 		}
 
-		filters.add(request -> {
+		filters.add((headers, exchange) -> {
 			HttpHeaders filtered = new HttpHeaders();
-			request.getHeaders().entrySet().stream()
+			headers.entrySet().stream()
 					.filter(entry -> !entry.getKey().toLowerCase().startsWith("sec-websocket"))
 					.forEach(header -> filtered.addAll(header.getKey(), header.getValue()));
 			return filtered;

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/DownStreamPath.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/DownStreamPath.java
@@ -1,0 +1,5 @@
+package org.springframework.cloud.gateway.filter.headers;
+
+public enum DownStreamPath {
+	REQUEST, RESPONSE
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -33,6 +33,7 @@ import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
 
 public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 
@@ -44,8 +45,9 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	}
 
 	@Override
-	public HttpHeaders filter(ServerHttpRequest request) {
-		HttpHeaders original = request.getHeaders();
+	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
+		ServerHttpRequest request = exchange.getRequest();
+		HttpHeaders original = input;
 		HttpHeaders updated = new HttpHeaders();
 
 		// copy all headers except Forwarded

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
@@ -70,12 +70,9 @@ public class RemoveHopByHopHeadersFilter implements HttpHeadersFilter, Ordered {
 	@Override
 	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
 		HttpHeaders filtered = new HttpHeaders();
-		List<String> connection = input.getConnection();
-		Set<String> toFilter = new HashSet<>(connection);
-		toFilter.addAll(this.headers);
-
+		
 		input.entrySet().stream()
-				.filter(entry -> !toFilter.contains(entry.getKey().toLowerCase()))
+				.filter(entry -> !this.headers.contains(entry.getKey().toLowerCase()))
 				.forEach(entry -> filtered.addAll(entry.getKey(), entry.getValue()));
 
 		return filtered;

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
@@ -69,7 +69,10 @@ public class RemoveHopByHopHeadersFilter implements HttpHeadersFilter, Ordered {
 
 	@Override
 	public HttpHeaders filter(ServerHttpRequest request) {
-		HttpHeaders original = request.getHeaders();
+		return filter(request.getHeaders());
+	}
+	
+	public HttpHeaders filter(HttpHeaders original) {
 		HttpHeaders filtered = new HttpHeaders();
 		List<String> connection = original.getConnection();
 		Set<String> toFilter = new HashSet<>(connection);

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -24,6 +24,7 @@ import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
 
 @ConfigurationProperties("spring.cloud.gateway.x-forwarded")
 public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
@@ -163,8 +164,9 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	}
 
 	@Override
-	public HttpHeaders filter(ServerHttpRequest request) {
-		HttpHeaders original = request.getHeaders();
+	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
+		ServerHttpRequest request = exchange.getRequest();
+		HttpHeaders original = input;
 		HttpHeaders updated = new HttpHeaders();
 
 		original.entrySet().stream()

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import org.springframework.cloud.gateway.filter.headers.ForwardedHeadersFilter.Forwarded;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,7 +52,7 @@ public class ForwardedHeadersFilterTests {
 
 		ForwardedHeadersFilter filter = new ForwardedHeadersFilter();
 
-		HttpHeaders headers = filter.filter(request);
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
 		assertThat(headers.get(FORWARDED_HEADER)).hasSize(1);
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/HttpHeadersFilterMixedDownstreamTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/HttpHeadersFilterMixedDownstreamTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.gateway.filter.headers;
+
+import org.junit.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Biju Kunjummen
+ */
+public class HttpHeadersFilterMixedDownstreamTests {
+
+	@Test
+	public void relevantDownstreamFiltersShouldActOnHeaders() {
+		MockServerHttpRequest mockRequest = MockServerHttpRequest.get("/get")
+				.header("header1", "value1").header("header2", "value2")
+				.header("header3", "value3").build();
+
+		HttpHeadersFilter filter1 = filterRemovingHeaders(DownStreamPath.RESPONSE,
+				"header1");
+
+		HttpHeadersFilter filter2 = filterRemovingHeaders(DownStreamPath.REQUEST,
+				"header2");
+
+		HttpHeaders result = HttpHeadersFilter.filter(Arrays.asList(filter1, filter2),
+				mockRequest.getHeaders(), MockServerWebExchange.from(mockRequest),
+				DownStreamPath.REQUEST);
+
+		assertThat(result).containsOnlyKeys("header1", "header3");
+	}
+	
+	private HttpHeadersFilter filterRemovingHeaders(DownStreamPath downStreamPath,
+			String... headerNames) {
+		Set<String> headerNamesSet = new HashSet<>(Arrays.asList(headerNames));
+		HttpHeadersFilter filter = new HttpHeadersFilter() {
+			@Override
+			public HttpHeaders filter(HttpHeaders headers, ServerWebExchange exchange) {
+				HttpHeaders result = new HttpHeaders();
+				headers.entrySet().forEach(entry -> {
+					if (!headerNamesSet.contains(entry.getKey())) {
+						result.put(entry.getKey(), entry.getValue());
+					}
+				});
+				return result;
+			}
+
+			@Override
+			public boolean supports(DownStreamPath path) {
+				return path.equals(downStreamPath);
+			}
+		};
+		return filter;
+	}
+}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/HttpHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/HttpHeadersFilterTests.java
@@ -17,47 +17,43 @@
 
 package org.springframework.cloud.gateway.filter.headers;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb
+ * @author Biju Kunjummen
  */
 public class HttpHeadersFilterTests {
 
 	@Test
 	public void httpHeadersFilterTests() {
 		MockServerHttpRequest request = MockServerHttpRequest
-				.get("http://localhost:8080/get")
-				.header("X-A", "aValue")
-				.header("X-B", "bValue")
-				.header("X-C", "cValue")
-				.build();
+				.get("http://localhost:8080/get").header("X-A", "aValue")
+				.header("X-B", "bValue").header("X-C", "cValue").build();
 
 		List<HttpHeadersFilter> filters = Arrays.asList(
-				r -> HttpHeadersFilterTests.this.filter(r, "X-A"),
-                r -> HttpHeadersFilterTests.this.filter(r, "X-B")
-		);
+				(h, e) -> HttpHeadersFilterTests.this.filter(h, "X-A"),
+				(h, e) -> HttpHeadersFilterTests.this.filter(h, "X-B"));
 
-		HttpHeaders headers = HttpHeadersFilter.filter(filters, request);
+		HttpHeaders headers = HttpHeadersFilter.filter(filters, request.getHeaders(),
+				MockServerWebExchange.from(request));
 
 		assertThat(headers).containsOnlyKeys("X-C");
 	}
 
-	private HttpHeaders filter(ServerHttpRequest request, String keyToFilter) {
-		HttpHeaders original = request.getHeaders();
+	private HttpHeaders filter(HttpHeaders input, String keyToFilter) {
 		HttpHeaders filtered = new HttpHeaders();
 
-		original.entrySet().stream()
-                .filter(entry -> !entry.getKey().equals(keyToFilter))
-                .forEach(entry -> filtered.addAll(entry.getKey(), entry.getValue()));
+		input.entrySet().stream().filter(entry -> !entry.getKey().equals(keyToFilter))
+				.forEach(entry -> filtered.addAll(entry.getKey(), entry.getValue()));
 
 		return filtered;
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilterTests.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.junit.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.gateway.filter.headers.RemoveHopByHopHeadersFilter.HEADERS_REMOVED_ON_REQUEST;
@@ -37,10 +38,10 @@ public class RemoveHopByHopHeadersFilterTests {
 	public void happyPath() {
 		MockServerHttpRequest.BaseBuilder<?> builder = MockServerHttpRequest
 				.get("http://localhost/get");
-
+		
 		HEADERS_REMOVED_ON_REQUEST.forEach(header -> builder.header(header, header+"1"));
 
-		testFilter(builder.build());
+		testFilter(MockServerWebExchange.from(builder));
 	}
 
 	@Test
@@ -50,7 +51,7 @@ public class RemoveHopByHopHeadersFilterTests {
 
 		HEADERS_REMOVED_ON_REQUEST.forEach(header -> builder.header(header.toLowerCase(), header+"1"));
 
-		testFilter(builder.build());
+		testFilter(MockServerWebExchange.from(builder));
 	}
 
 	@Test
@@ -62,12 +63,12 @@ public class RemoveHopByHopHeadersFilterTests {
 		builder.header(HttpHeaders.UPGRADE, "WebSocket");
 		builder.header("Keep-Alive", "timeout:5");
 
-		testFilter(builder.build(), "upgrade", "keep-alive");
+		testFilter(MockServerWebExchange.from(builder), "upgrade", "keep-alive");
 	}
 
-	private void testFilter(MockServerHttpRequest request, String... additionalHeaders) {
+	private void testFilter(MockServerWebExchange exchange, String... additionalHeaders) {
 		RemoveHopByHopHeadersFilter filter = new RemoveHopByHopHeadersFilter();
-		HttpHeaders headers = filter.filter(request);
+		HttpHeaders headers = filter.filter(exchange.getRequest().getHeaders(), exchange);
 
 		Set<String> toRemove = new HashSet<>(HEADERS_REMOVED_ON_REQUEST);
 		toRemove.addAll(Arrays.asList(additionalHeaders));

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.gateway.filter.headers.XForwardedHeadersFilter.X_FORWARDED_FOR_HEADER;
@@ -46,7 +47,7 @@ public class XForwardedHeadersFilterTests {
 
 		XForwardedHeadersFilter filter = new XForwardedHeadersFilter();
 
-		HttpHeaders headers = filter.filter(request);
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
 		assertThat(headers).containsKeys(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
 				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER);
@@ -67,7 +68,7 @@ public class XForwardedHeadersFilterTests {
 
 		XForwardedHeadersFilter filter = new XForwardedHeadersFilter();
 
-		HttpHeaders headers = filter.filter(request);
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
 		assertThat(headers).containsKeys(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
 				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER);
@@ -91,7 +92,7 @@ public class XForwardedHeadersFilterTests {
 
 		XForwardedHeadersFilter filter = new XForwardedHeadersFilter();
 
-		HttpHeaders headers = filter.filter(request);
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
 		assertThat(headers).containsKeys(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
 				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER);
@@ -119,7 +120,7 @@ public class XForwardedHeadersFilterTests {
 		filter.setPortAppend(false);
 		filter.setProtoAppend(false);
 
-		HttpHeaders headers = filter.filter(request);
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
 		assertThat(headers).containsKeys(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
 				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER);
@@ -143,7 +144,7 @@ public class XForwardedHeadersFilterTests {
 		filter.setPortEnabled(false);
 		filter.setProtoEnabled(false);
 
-		HttpHeaders headers = filter.filter(request);
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
 		assertThat(headers).isEmpty();
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
@@ -41,6 +41,7 @@ public class PathRoutePredicateFactoryTests extends BaseWebClientTests {
 				.exchange()
 				.expectStatus().isOk()
 				.expectHeader().valueEquals(HANDLER_MAPPER_HEADER, RoutePredicateHandlerMapping.class.getSimpleName())
+				.expectHeader().valueEquals("transfer-encoding", "chunked")
 				.expectHeader().valueEquals(ROUTE_ID_HEADER, "default_path_to_httpbin");
 	}
 


### PR DESCRIPTION
Fixes #217 - `RemoveHopByHopHeadersFilter` is called after routing response is received