### PR TITLE
Bugfix: when no such cookie exists, match should return false instead…

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactory.java
@@ -48,6 +48,9 @@ public class CookieRoutePredicateFactory extends AbstractRoutePredicateFactory<C
 	public Predicate<ServerWebExchange> apply(Config config) {
 		return exchange -> {
 			List<HttpCookie> cookies = exchange.getRequest().getCookies().get(config.name);
+			if (cookies == null) {
+				return false;
+			}
 			for (HttpCookie cookie : cookies) {
 				if (cookie.getValue().matches(config.regexp)) {
 					return true;


### PR DESCRIPTION
… of fail.