### PR TITLE
Disable default WebFlux CORS handling

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -749,6 +749,31 @@ public RouteLocator customRouteLocator(RouteLocatorBuilder builder, ThrottleGate
 
 This style also allows for more custom predicate assertions. The predicates defined by `RouteDefinitionLocator` beans are combined using logical `and`. By using the fluent Java API, you can use the `and()`, `or()` and `negate()` operators on the `Predicate` class.
 
+=== CORS configuration
+
+By default the Gateway will route CORS requests to destinations unchanged. You can define CORS policy in the gateway by employing `CorsWebFilter` from Spring WebFlux:
+[source,java]
+----
+@Bean
+CorsWebFilter corsFilter() {
+
+    CorsConfiguration config = new CorsConfiguration();
+
+    // Possibly...
+    // config.applyPermitDefaultValues()
+
+    config.setAllowCredentials(true);
+    config.addAllowedOrigin("http://domain1.com");
+    config.addAllowedHeader("");
+    config.addAllowedMethod("");
+
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", config);
+
+    return new CorsWebFilter(source);
+}
+----
+
 === DiscoveryClient Route Definition Locator
 
 The Gateway can be configured to create routes based on services registered with a `DiscoveryClient` compatible service registry.

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -22,6 +22,7 @@ import java.util.function.Function;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.CorsUtils;
 import org.springframework.web.reactive.handler.AbstractHandlerMapping;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -66,6 +67,22 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 						logger.trace("No RouteDefinition found for [" + getExchangeDesc(exchange) + "]");
 					}
 				})));
+	}
+
+	@Override
+	public Mono<Object> getHandler(ServerWebExchange exchange) {
+		return getHandlerInternal(exchange).map(handler -> {
+			if (CorsUtils.isCorsRequest(exchange.getRequest())) {
+				CorsConfiguration corsConfiguration = getCorsConfiguration(handler, exchange);
+				if (corsConfiguration != null) {
+					boolean isValid = getCorsProcessor().process(corsConfiguration, exchange);
+					if (!isValid || CorsUtils.isPreFlightRequest(exchange.getRequest())) {
+						return Mono.empty();
+					}
+				}
+			}
+			return handler;
+		});
 	}
 
 	@Override


### PR DESCRIPTION
WebFlux CORS handling is inappropriate for the gateway. This change allows backend service to decide on what to respond on CORS requests.
If proper support is needed in the gateway this should be implemented with a GatewayFilter. Meanwhile you can implement it in your gateway application like described in WebFlux docs:
```java
    @Bean
    public CorsWebFilter corsFilter() {
        CorsConfiguration config = new CorsConfiguration();
        config.addAllowedMethod(HttpMethod.POST);
        config.addAllowedOrigin("*");

        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource(new PathPatternParser());
        source.registerCorsConfiguration("/**", config);

        return new CorsWebFilter(source);
    }

```