### PR TITLE
Fixes duplicate route add issue with dsl

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/RouteLocatorBuilder.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/RouteLocatorBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gateway.route.builder;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -42,43 +41,35 @@ public class RouteLocatorBuilder {
 
 	public static class Builder {
 
-		private List<Route> routes = new ArrayList<>();
+		private List<Route.Builder> routes = new ArrayList<>();
 		private ConfigurableApplicationContext context;
 
 		public Builder(ConfigurableApplicationContext context) {
 			this.context = context;
 		}
 
-		public Builder route(String id, Function<PredicateSpec, Builder> fn) {
-			return fn.apply(new RouteSpec(this).id(id));
-		}
-
-		public Builder route(Function<PredicateSpec, Builder> fn) {
-			return fn.apply(new RouteSpec(this).randomId());
-		}
-
-		private void add(Route route) {
-			this.routes.add(route);
-		}
-
-		Builder uri(Route.Builder builder, String uri) {
-			Route route = builder.uri(uri).build();
-			add(route);
+		public Builder route(String id, Function<PredicateSpec, Route.Builder> fn) {
+			Route.Builder routeBuilder = fn.apply(new RouteSpec(this).id(id));
+			add(routeBuilder);
 			return this;
 		}
 
-		Builder uri(Route.Builder builder, URI uri) {
-			Route route = builder.uri(uri).build();
-			add(route);
+		public Builder route(Function<PredicateSpec, Route.Builder> fn) {
+			Route.Builder routeBuilder = fn.apply(new RouteSpec(this).randomId());
+			add(routeBuilder);
 			return this;
 		}
-
+		
 		public RouteLocator build() {
-			return () -> Flux.fromIterable(this.routes);
+			return () -> Flux.fromIterable(this.routes).map(routeBuilder -> routeBuilder.build());
 		}
 
 		ConfigurableApplicationContext getContext() {
 			return context;
+		}
+
+		void add(Route.Builder route) {
+			routes.add(route);
 		}
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/UriSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/UriSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 the original author or authors.
+ * Copyright 2013-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,12 +29,12 @@ public class UriSpec {
 		this.builder = builder;
 	}
 
-	public RouteLocatorBuilder.Builder uri(String uri) {
-		return this.builder.uri(this.routeBuilder, uri);
+	public Route.Builder uri(String uri) {
+		return this.routeBuilder.uri(uri);
 	}
 
-	public RouteLocatorBuilder.Builder uri(URI uri) {
-		return this.builder.uri(this.routeBuilder, uri);
+	public Route.Builder uri(URI uri) {
+		return this.routeBuilder.uri(uri);
 	}
 
 

--- a/spring-cloud-gateway-core/src/main/kotlin/org/springframework/cloud/gateway/route/builder/RouteDsl.kt
+++ b/spring-cloud-gateway-core/src/main/kotlin/org/springframework/cloud/gateway/route/builder/RouteDsl.kt
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.route.builder
 
+import org.springframework.cloud.gateway.route.Route
 import org.springframework.cloud.gateway.route.RouteLocator
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder.RouteSpec
 import java.util.function.Predicate
@@ -65,10 +66,14 @@ class RouteLocatorDsl(val builder: RouteLocatorBuilder) {
 			RouteSpec(routes).id(id)
 		}
 		predicateSpec.order(order)
-		predicateSpec.apply(init)
 		if (uri != null) {
 			predicateSpec.uri(uri)
 		}
+		
+		predicateSpec.apply(init)
+		
+		val route: Route.Builder = predicateSpec.routeBuilder
+		routes.add(route)
 	}
 
 	fun build(): RouteLocator {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/builder/RouteBuilderTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/builder/RouteBuilderTests.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.springframework.cloud.gateway.route.builder;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringRunner;
+import reactor.test.StepVerifier;
+
+import java.net.URI;
+
+/**
+ * @author Biju Kunjummen
+ */
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class RouteBuilderTests {
+
+	@Autowired
+	private RouteLocatorBuilder routeLocatorBuilder;
+
+	@Test
+	public void testASetOfRoutes() {
+		RouteLocator routeLocator = this.routeLocatorBuilder.routes()
+				.route("test1", r -> r.host("*.somehost.org").and().path("/somepath")
+						.filters(f -> f.addRequestHeader("header1", "header-value-1"))
+						.uri("http://someuri"))
+				.route("test2", r -> r.host("*.somehost2.org")
+						.filters(f -> f.addResponseHeader("header-response-1",
+								"header-response-1"))
+						.uri("https://httpbin.org:9090"))
+				.build();
+
+		StepVerifier.create(routeLocator.getRoutes())
+				.expectNextMatches(
+						r -> r.getId().equals("test1") && r.getFilters().size() == 1
+								&& r.getUri().equals(URI.create("http://someuri:80")))
+				.expectNextMatches(
+						r -> r.getId().equals("test2") && r.getFilters().size() == 1
+								&& r.getUri()
+										.equals(URI.create("https://httpbin.org:9090")))
+				.expectComplete().verify();
+	}
+
+	@EnableAutoConfiguration
+	@Configuration
+	public static class SpringConfig {
+	}
+}

--- a/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/builder/RouteDslTests.kt
+++ b/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/builder/RouteDslTests.kt
@@ -84,17 +84,28 @@ class RouteDslTests {
 	@Test
 	fun dslWithFunctionParameters() {
 		val routerLocator = builder.routes {
-			route(id = "test", order = 10, uri = "http://httpbin.org") {
+			route(id = "test1", order = 10, uri = "http://httpbin.org") {
 				host("**.abc.org")
+			}
+			route(id = "test2", order = 10, uri = "http://someurl") {
+				host("**.abc.org")
+				uri("http://override-url")
 			}
 		}
 
 		StepVerifier.create(routerLocator.routes)
 				.expectNextMatches({ r ->
-					r.id == "test" &&
+					r.id == "test1" &&
 							r.uri == URI.create("http://httpbin.org:80") &&
 							r.order == 10 &&
-							r.id == "test" &&
+							r.predicate.test(MockServerWebExchange
+									.from(MockServerHttpRequest
+											.get("/someuri").header("Host", "test.abc.org")))
+				})
+				.expectNextMatches({ r ->
+					r.id == "test2" &&
+							r.uri == URI.create("http://override-url:80") &&
+							r.order == 10 &&
 							r.predicate.test(MockServerWebExchange
 									.from(MockServerHttpRequest
 											.get("/someuri").header("Host", "test.abc.org")))


### PR DESCRIPTION
Fixes an issue with dsl's where if the `uri` is invoked twice then two routes get added in, say with kotlin dsl - 

```
route(id = "test2", order = 10, uri = "http://someurl") {
    host("**.abc.org")
    uri("http://override-url")
}

```
would end up adding two routes without this fix. 