### PR TITLE
Rename to CloudFoundryRouteServiceRoutePredicateFactory

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/CloudFoundryRouteServiceRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/CloudFoundryRouteServiceRoutePredicateFactory.java
@@ -9,7 +9,7 @@ import org.springframework.web.server.ServerWebExchange;
  * @see <a href="https://docs.cloudfoundry.org/services/route-services.html">Cloud Foundry Route Service documentation</a>.
  * @author Andrew Fitzgerald
  */
-public class CloudFoundryRouteServicePredicateFactory extends
+public class CloudFoundryRouteServiceRoutePredicateFactory extends
 		AbstractRoutePredicateFactory<Object> {
 
 	public static final String X_CF_FORWARDED_URL = "X-CF-Forwarded-Url";
@@ -17,7 +17,7 @@ public class CloudFoundryRouteServicePredicateFactory extends
 	public static final String X_CF_PROXY_METADATA = "X-CF-Proxy-Metadata";
 	private final HeaderRoutePredicateFactory factory = new HeaderRoutePredicateFactory();
 
-	public CloudFoundryRouteServicePredicateFactory() {
+	public CloudFoundryRouteServiceRoutePredicateFactory() {
 		super(Object.class);
 	}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CloudFoundryRouteServiceRoutePredicateFactoryTest.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CloudFoundryRouteServiceRoutePredicateFactoryTest.java
@@ -13,24 +13,24 @@ import org.springframework.web.server.ServerWebExchange;
 /**
  * @author Andrew Fitzgerald
  */
-public class CloudFoundryRouteServicePredicateFactoryTest {
+public class CloudFoundryRouteServiceRoutePredicateFactoryTest {
 
 	private Predicate<ServerWebExchange> predicate;
 
 	@Before
 	public void setUp() throws Exception {
-		CloudFoundryRouteServicePredicateFactory factory = new CloudFoundryRouteServicePredicateFactory();
+		CloudFoundryRouteServiceRoutePredicateFactory factory = new CloudFoundryRouteServiceRoutePredicateFactory();
 		predicate = factory.apply(factory.newConfig());
 	}
 
 	@Test
 	public void itReturnsTrueWithAllHeadersPresent() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("someurl")
-				.header(CloudFoundryRouteServicePredicateFactory.X_CF_FORWARDED_URL,
+				.header(CloudFoundryRouteServiceRoutePredicateFactory.X_CF_FORWARDED_URL,
 						"url")
-				.header(CloudFoundryRouteServicePredicateFactory.X_CF_PROXY_METADATA,
+				.header(CloudFoundryRouteServiceRoutePredicateFactory.X_CF_PROXY_METADATA,
 						"metadata")
-				.header(CloudFoundryRouteServicePredicateFactory.X_CF_PROXY_SIGNATURE,
+				.header(CloudFoundryRouteServiceRoutePredicateFactory.X_CF_PROXY_SIGNATURE,
 						"signature")
 				.build();
 		MockServerWebExchange exchange = MockServerWebExchange.from(request);
@@ -41,9 +41,9 @@ public class CloudFoundryRouteServicePredicateFactoryTest {
 	@Test
 	public void itReturnsFalseWithAHeadersMissing() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("someurl")
-				.header(CloudFoundryRouteServicePredicateFactory.X_CF_FORWARDED_URL,
+				.header(CloudFoundryRouteServiceRoutePredicateFactory.X_CF_FORWARDED_URL,
 						"url")
-				.header(CloudFoundryRouteServicePredicateFactory.X_CF_PROXY_METADATA,
+				.header(CloudFoundryRouteServiceRoutePredicateFactory.X_CF_PROXY_METADATA,
 						"metadata")
 				.build();
 		MockServerWebExchange exchange = MockServerWebExchange.from(request);


### PR DESCRIPTION
`CloudFoundryRouteServicePredicateFactory` does not comply the naming convention

```
2018-04-15 02:33:27.912  INFO 70338 --- [  restartedMain] o.s.c.g.r.RouteDefinitionRouteLocator    : Loaded RoutePredicateFactory [CloudFoundryRouteServicePredicateFactory]
2018-04-15 02:33:27.912  INFO 70338 --- [  restartedMain] o.s.c.g.r.RouteDefinitionRouteLocator    : Loaded RoutePredicateFactory [After]
...
```