### PR TITLE
Add the ability to change request uri dynamically in filters

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -51,6 +51,7 @@ import org.springframework.cloud.gateway.filter.factory.PreserveHostHeaderGatewa
 import org.springframework.cloud.gateway.filter.factory.RedirectToGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RemoveRequestHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RemoveResponseHeaderGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.RequestHeaderToRequestUriGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RequestRateLimiterGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RetryGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RewritePathGatewayFilterFactory;
@@ -511,6 +512,11 @@ public class GatewayAutoConfiguration {
 	@Bean
 	public StripPrefixGatewayFilterFactory stripPrefixGatewayFilterFactory() {
 		return new StripPrefixGatewayFilterFactory();
+	}
+
+	@Bean
+	public RequestHeaderToRequestUriGatewayFilterFactory requestHeaderToRequestUriGatewayFilterFactory() {
+		return new RequestHeaderToRequestUriGatewayFilterFactory();
 	}
 
 	@Configuration

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AbstractChangeRequestUriGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AbstractChangeRequestUriGatewayFilterFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
+import org.springframework.cloud.gateway.filter.RouteToRequestUrlFilter;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+
+/**
+ * This filter changes the request uri by
+ * {@link #determineRequestUri(ServerWebExchange, T)} logic.
+ *
+ * @author Toshiaki Maki
+ */
+public abstract class AbstractChangeRequestUriGatewayFilterFactory<T>
+		extends AbstractGatewayFilterFactory<T> {
+	private final int order;
+
+	public AbstractChangeRequestUriGatewayFilterFactory(Class<T> clazz, int order) {
+		super(clazz);
+		this.order = order;
+	}
+
+	public AbstractChangeRequestUriGatewayFilterFactory(Class<T> clazz) {
+		this(clazz, RouteToRequestUrlFilter.ROUTE_TO_URL_FILTER_ORDER + 1);
+	}
+
+	protected abstract Optional<URI> determineRequestUri(ServerWebExchange exchange,
+			T config);
+
+	public GatewayFilter apply(T config) {
+		return new OrderedGatewayFilter((exchange, chain) -> {
+			Optional<URI> uri = this.determineRequestUri(exchange, config);
+			uri.ifPresent(u -> {
+				Map<String, Object> attributes = exchange.getAttributes();
+				attributes.put(GATEWAY_REQUEST_URL_ATTR, u);
+			});
+			return chain.filter(exchange);
+		}, this.order);
+	}
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactory.java
@@ -1,0 +1,49 @@
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * This filter changes the request uri by a request header
+ *
+ * @author Toshiaki Maki
+ */
+public class RequestHeaderToRequestUriGatewayFilterFactory extends
+		AbstractChangeRequestUriGatewayFilterFactory<AbstractGatewayFilterFactory.NameConfig> {
+	private final Logger log = LoggerFactory
+			.getLogger(RequestHeaderToRequestUriGatewayFilterFactory.class);
+
+	public RequestHeaderToRequestUriGatewayFilterFactory() {
+		super(NameConfig.class);
+	}
+
+	@Override
+	public List<String> shortcutFieldOrder() {
+		return Arrays.asList(NAME_KEY);
+	}
+
+	@Override
+	protected Optional<URI> determineRequestUri(ServerWebExchange exchange,
+			NameConfig config) {
+		String requestUrl = exchange.getRequest().getHeaders().getFirst(config.getName());
+		return Optional.ofNullable(requestUrl).map(url -> {
+			try {
+				return new URL(url).toURI();
+			}
+			catch (MalformedURLException | URISyntaxException e) {
+				log.info("Request url is invalid : url={}, error={}", requestUrl,
+						e.getMessage());
+				return null;
+			}
+		});
+	}
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -19,12 +19,15 @@ package org.springframework.cloud.gateway.route.builder;
 import java.net.URI;
 import java.net.URL;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractChangeRequestUriGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.AddRequestHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.AddRequestParameterGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.AddResponseHeaderGatewayFilterFactory;
@@ -34,6 +37,7 @@ import org.springframework.cloud.gateway.filter.factory.PreserveHostHeaderGatewa
 import org.springframework.cloud.gateway.filter.factory.RedirectToGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RemoveRequestHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RemoveResponseHeaderGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.RequestHeaderToRequestUriGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RequestRateLimiterGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RetryGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RewritePathGatewayFilterFactory;
@@ -246,6 +250,24 @@ public class GatewayFilterSpec extends UriSpec {
 	public GatewayFilterSpec stripPrefix(int parts) {
 		return filter(getBean(StripPrefixGatewayFilterFactory.class)
 				.apply(c -> c.setParts(parts)));
+	}
+
+	public GatewayFilterSpec requestHeaderToRequestUri(String headerName) {
+		return filter(getBean(RequestHeaderToRequestUriGatewayFilterFactory.class)
+				.apply(c -> c.setName(headerName)));
+	}
+
+	public GatewayFilterSpec changeRequestUri(
+			Function<ServerWebExchange, Optional<URI>> determineRequestUri) {
+		return filter(
+				new AbstractChangeRequestUriGatewayFilterFactory<Object>(Object.class) {
+					@Override
+					protected Optional<URI> determineRequestUri(
+							ServerWebExchange exchange, Object config) {
+						return determineRequestUri.apply(exchange);
+					}
+				}.apply(c -> {
+				}));
 	}
 
 	private String routeId() {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryIntegrationTests.java
@@ -1,0 +1,81 @@
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.net.URI;
+import java.util.Optional;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Toshiaki Maki
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DirtiesContext
+public class RequestHeaderToRequestUriGatewayFilterFactoryIntegrationTests
+		extends BaseWebClientTests {
+	@LocalServerPort
+	int port;
+
+	@Test
+	public void changeUriWorkWithProperties() {
+		testClient.get().uri("/").header("Host", "www.changeuri.org")
+				.header("X-CF-Forwarded-Url",
+						"http://localhost:" + port + "/actuator/health")
+				.exchange().expectBody(JsonNode.class)
+				.consumeWith(r -> assertThat(r.getResponseBody().has("status")).isTrue());
+	}
+
+	@Test
+	public void changeUriWorkWithDsl() {
+		testClient.get().uri("/").header("Host", "www.changeuri.org")
+				.header("X-Next-Url", "http://localhost:" + port + "/actuator/health")
+				.exchange().expectBody(JsonNode.class)
+				.consumeWith(r -> assertThat(r.getResponseBody().has("status")).isTrue());
+	}
+
+	@Test
+	public void changeUriWorkWithCustomLogic() {
+		testClient.get()
+				.uri(b -> b.path("/")
+						.queryParam("url",
+								"http://localhost:" + port + "/actuator/health")
+						.build())
+				.header("Host", "www.changeuri.org").exchange().expectBody(JsonNode.class)
+				.consumeWith(r -> assertThat(r.getResponseBody().has("status")).isTrue());
+	}
+
+	@EnableAutoConfiguration
+	@SpringBootConfiguration
+	@Import(DefaultTestConfig.class)
+	public static class TestConfig {
+		@Bean
+		public RouteLocator routeLocator(RouteLocatorBuilder builder) {
+			return builder.routes()
+					.route(r -> r.host("**.changeuri.org").and().header("X-Next-Url")
+							.filters(f -> f.requestHeaderToRequestUri("X-Next-Url"))
+							.uri("http://example.com"))
+					.route(r -> r.host("**.changeuri.org").and().query("url")
+							.filters(f -> f.changeRequestUri(e -> Optional.of(URI.create(
+									e.getRequest().getQueryParams().getFirst("url")))))
+							.uri("http://example.com"))
+					.build();
+		}
+	}
+}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryTests.java
@@ -1,0 +1,84 @@
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.net.URI;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Toshiaki Maki
+ */
+public class RequestHeaderToRequestUriGatewayFilterFactoryTests {
+
+	@Test
+	public void filterChangeRequestUri() throws Exception {
+		RequestHeaderToRequestUriGatewayFilterFactory factory = new RequestHeaderToRequestUriGatewayFilterFactory();
+		GatewayFilter filter = factory.apply(c -> c.setName("X-CF-Forwarded-Url"));
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+				.header("X-CF-Forwarded-Url", "http://example.com").build();
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR,
+				URI.create("http://localhost"));
+		GatewayFilterChain filterChain = mock(GatewayFilterChain.class);
+		ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor
+				.forClass(ServerWebExchange.class);
+		when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
+		filter.filter(exchange, filterChain);
+		ServerWebExchange webExchange = captor.getValue();
+		URI uri = (URI) webExchange.getAttributes().get(GATEWAY_REQUEST_URL_ATTR);
+		assertThat(uri).isNotNull();
+		assertThat(uri.toString()).isEqualTo("http://example.com");
+	}
+
+	@Test
+	public void filterDoesNotChangeRequestUriIfHeaderIsAbsent() throws Exception {
+		RequestHeaderToRequestUriGatewayFilterFactory factory = new RequestHeaderToRequestUriGatewayFilterFactory();
+		GatewayFilter filter = factory.apply(c -> c.setName("X-CF-Forwarded-Url"));
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+				.build();
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR,
+				URI.create("http://localhost"));
+		GatewayFilterChain filterChain = mock(GatewayFilterChain.class);
+		ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor
+				.forClass(ServerWebExchange.class);
+		when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
+		filter.filter(exchange, filterChain);
+		ServerWebExchange webExchange = captor.getValue();
+		URI uri = (URI) webExchange.getAttributes().get(GATEWAY_REQUEST_URL_ATTR);
+		assertThat(uri).isNotNull();
+		assertThat(uri.toString()).isEqualTo("http://localhost");
+	}
+
+	@Test
+	public void filterDoesNotChangeRequestUriIfHeaderIsInvalid() throws Exception {
+		RequestHeaderToRequestUriGatewayFilterFactory factory = new RequestHeaderToRequestUriGatewayFilterFactory();
+		GatewayFilter filter = factory.apply(c -> c.setName("X-CF-Forwarded-Url"));
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+				.header("X-CF-Forwarded-Url", "example").build();
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR,
+				URI.create("http://localhost"));
+		GatewayFilterChain filterChain = mock(GatewayFilterChain.class);
+		ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor
+				.forClass(ServerWebExchange.class);
+		when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
+		filter.filter(exchange, filterChain);
+		ServerWebExchange webExchange = captor.getValue();
+		URI uri = (URI) webExchange.getAttributes().get(GATEWAY_REQUEST_URL_ATTR);
+		assertThat(uri).isNotNull();
+		assertThat(uri.toURL().toString()).isEqualTo("http://localhost");
+	}
+}

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -245,6 +245,15 @@ spring:
         - Header=Foo, .*
 
       # =====================================
+      - id: change_uri_test
+        uri: ${test.uri}
+        predicates:
+        - Host=**.changeuri.org
+        - Header=X-CF-Forwarded-Url
+        filters:
+        - RequestHeaderToRequestUri=X-CF-Forwarded-Url
+
+      # =====================================
       - id: default_path_to_httpbin
         uri: ${test.uri}
         order: 10000


### PR DESCRIPTION
This PR adds `AbstractChangeRequestUriGatewayFilterFactory` that enables the gateway to change URL dynamically using `ServerWebExchange`.
As a implementation, `RequestHeaderToRequestUriGatewayFilterFactory` comes with this PR that determine URL by a request header.
This factory will be pretty useful when implementing [Cloud Foundry Route Service](https://docs.cloudfoundry.org/services/route-services.html).

also fixes https://github.com/spring-cloud/spring-cloud-gateway/issues/276

https://twitter.com/Fitzoh/status/985423505947754496