### PR TITLE
Use implicit name for lambdas with single parameter

### DIFF
--- a/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/builder/RouteDslTests.kt
+++ b/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/builder/RouteDslTests.kt
@@ -59,11 +59,11 @@ class RouteDslTests {
 
 		StepVerifier
 				.create(routeLocator.routes)
-				.expectNextMatches({ r ->
-					r.id == "test" && r.filters.size == 1 && r.uri == URI.create("http://httpbin.org:80")
+				.expectNextMatches({
+					it.id == "test" && it.filters.size == 1 && it.uri == URI.create("http://httpbin.org:80")
 				})
-				.expectNextMatches({ r ->
-					r.id == "test2" && r.filters.size == 2 && r.uri == URI.create("https://httpbin.org:443")
+				.expectNextMatches({
+					it.id == "test2" && it.filters.size == 2 && it.uri == URI.create("https://httpbin.org:443")
 				})
 				.expectComplete()
 				.verify()
@@ -71,11 +71,11 @@ class RouteDslTests {
 		val sampleExchange: ServerWebExchange = MockServerWebExchange.from(MockServerHttpRequest.get("/image/webp")
 				.header("Host", "test.abc.org").build())
 
-		val filteredRoutes = routeLocator.routes.filter({ r -> r.predicate.test(sampleExchange) })
+		val filteredRoutes = routeLocator.routes.filter({ it.predicate.test(sampleExchange) })
 
 		StepVerifier.create(filteredRoutes)
-				.expectNextMatches({ r ->
-					r.id == "test2" && r.filters.size == 2 && r.uri == URI.create("https://httpbin.org:443")
+				.expectNextMatches({
+					it.id == "test2" && it.filters.size == 2 && it.uri == URI.create("https://httpbin.org:443")
 				})
 				.expectComplete()
 				.verify()
@@ -94,19 +94,19 @@ class RouteDslTests {
 		}
 
 		StepVerifier.create(routerLocator.routes)
-				.expectNextMatches({ r ->
-					r.id == "test1" &&
-							r.uri == URI.create("http://httpbin.org:80") &&
-							r.order == 10 &&
-							r.predicate.test(MockServerWebExchange
+				.expectNextMatches({
+					it.id == "test1" &&
+							it.uri == URI.create("http://httpbin.org:80") &&
+							it.order == 10 &&
+							it.predicate.test(MockServerWebExchange
 									.from(MockServerHttpRequest
 											.get("/someuri").header("Host", "test.abc.org")))
 				})
-				.expectNextMatches({ r ->
-					r.id == "test2" &&
-							r.uri == URI.create("http://override-url:80") &&
-							r.order == 10 &&
-							r.predicate.test(MockServerWebExchange
+				.expectNextMatches({
+					it.id == "test2" &&
+							it.uri == URI.create("http://override-url:80") &&
+							it.order == 10 &&
+							it.predicate.test(MockServerWebExchange
 									.from(MockServerHttpRequest
 											.get("/someuri").header("Host", "test.abc.org")))
 				})


### PR DESCRIPTION
Just omitted the lambda arrow (->) and replaced the declared parameter with the implicitly declared parameter 'it' in lambdas with single parameter in the Kotlin code.

Reference: https://kotlinlang.org/docs/reference/lambdas.html#it-implicit-name-of-a-single-parameter