### PR TITLE
Validate Hystrix config name

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.Assert;
 import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -69,6 +70,7 @@ public class HystrixGatewayFilterFactory extends AbstractGatewayFilterFactory<Hy
 	public GatewayFilter apply(Config config) {
 		//TODO: if no name is supplied, generate one from command id (useful for default filter)
 		if (config.setter == null) {
+			Assert.notNull(config.name, "A name must be supplied for the Hystrix Command Key");
 			HystrixCommandGroupKey groupKey = HystrixCommandGroupKey.Factory.asKey(getClass().getSimpleName());
 			HystrixCommandKey commandKey = HystrixCommandKey.Factory.asKey(config.name);
 


### PR DESCRIPTION
If a name isn't supplied you get a nasty stack trace.
`f.hystrix(c -> c.setFallbackUri("forward:/whatever")`
```
Caused by: java.lang.NullPointerException
	at java.util.concurrent.ConcurrentHashMap.get(ConcurrentHashMap.java:936)
	at com.netflix.hystrix.util.InternMap.interned(InternMap.java:22)
	at com.netflix.hystrix.HystrixCommandKey$Factory.asKey(HystrixCommandKey.java:48)
	at org.springframework.cloud.gateway.filter.factory.HystrixGatewayFilterFactory.apply(HystrixGatewayFilterFactory.java:73)
	at org.springframework.cloud.gateway.filter.factory.HystrixGatewayFilterFactory.apply(HystrixGatewayFilterFactory.java:52)
	at org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory.apply(GatewayFilterFactory.java:47)
	at org.springframework.cloud.gateway.route.builder.GatewayFilterSpec.hystrix(GatewayFilterSpec.java:110)
```