### PR TITLE
add x-forwarded-prefix header

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.springframework.cloud.gateway.filter.headers;
 
 import java.net.URI;

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -92,7 +92,7 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	private boolean protoAppend = true;
 
 	/** If appending X-Forwarded-Prefix as a list is enabled. */
-	private boolean prefixAppend = true;
+	private boolean prefixAppend = false;
 
 	@Override
 	public int getOrder() {
@@ -219,10 +219,10 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 			String prefix = null;
 
 			if (request.getHeaders().containsKey(X_FORWARDED_PREFIX_HEADER)){
-				prefix = request.getHeaders().get(X_FORWARDED_PREFIX_HEADER).get(0);
+				prefix = request.getHeaders().getFirst(X_FORWARDED_PREFIX_HEADER);
 			}
 			else if(request.getHeaders().containsKey(X_ORIGINAL_URI)){
-				String originalUri = request.getHeaders().get(X_ORIGINAL_URI).get(0);
+				String originalUri = request.getHeaders().getFirst(X_ORIGINAL_URI);
 				prefix = originalUri.replace(request.getURI().getPath(),"");
 			}
 			write(updated,X_FORWARDED_PREFIX_HEADER, prefix, isPrefixAppend());

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -209,8 +209,15 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 
 			if(originalUris != null && requestUri != null) {
 				originalUris.stream().forEach(originalUri -> {
-					String prefix = originalUri.getPath().replace(requestUri.getPath(), "");
-					write(updated, X_FORWARDED_PREFIX_HEADER, prefix, isPrefixAppend());
+					if(originalUri!=null && originalUri.getPath()!=null) {
+						String prefix = originalUri.getPath();
+						if(requestUri.getPath()!=null){
+							prefix = originalUri.getPath().replace(requestUri.getPath(), "");
+						}
+						if (prefix != null && prefix.length() > 0 && prefix.length() < originalUri.getPath().length()) {
+							write(updated, X_FORWARDED_PREFIX_HEADER, prefix, isPrefixAppend());
+						}
+					}
 				});
 			}
 		}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -219,13 +219,18 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 			write(updated, X_FORWARDED_PROTO_HEADER, proto, isProtoAppend());
 		}
 
-		if(isPrefixEnabled()){
+		if(isPrefixEnabled()) {
+			//if the path of the url that the gw is routing to is a subset (and ending part) of the url that it is routing from then the difference is the prefix
+			//e.g. if request original.com/prefix/get/ is routed to routedservice:8090/get then /prefix is the prefix - see XForwardedHeadersFilterTests
+			//so first get uris, then extract paths and remove one from another if it's the ending part
 
 			LinkedHashSet<URI> originalUris = exchange.getAttribute(GATEWAY_ORIGINAL_REQUEST_URL_ATTR);
 			URI requestUri = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
 
 			if(originalUris != null && requestUri != null) {
+
 				originalUris.stream().forEach(originalUri -> {
+
 					if(originalUri!=null && originalUri.getPath()!=null) {
 						String prefix = originalUri.getPath();
 
@@ -233,7 +238,7 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 						String originalUriPath = originalUri.getPath().substring(0, originalUri.getPath().length() - (originalUri.getPath().endsWith("/") ? 1 : 0));
 						String requestUriPath = requestUri.getPath().substring(0, requestUri.getPath().length() - (requestUri.getPath().endsWith("/") ? 1 : 0));
 
-						if(requestUriPath!=null && (originalUriPath.endsWith(requestUriPath)) ){
+						if(requestUriPath!=null && (originalUriPath.endsWith(requestUriPath))) {
 							prefix = originalUriPath.replace(requestUriPath, "");
 						}
 						if (prefix != null && prefix.length() > 0 &&

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -235,8 +235,8 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 						String prefix = originalUri.getPath();
 
 						//strip trailing slashes before checking if request path is end of original path
-						String originalUriPath = originalUri.getPath().substring(0, originalUri.getPath().length() - (originalUri.getPath().endsWith("/") ? 1 : 0));
-						String requestUriPath = requestUri.getPath().substring(0, requestUri.getPath().length() - (requestUri.getPath().endsWith("/") ? 1 : 0));
+						String originalUriPath = stripTrailingSlash(originalUri);
+						String requestUriPath = stripTrailingSlash(requestUri);
 
 						if(requestUriPath!=null && (originalUriPath.endsWith(requestUriPath))) {
 							prefix = originalUriPath.replace(requestUriPath, "");
@@ -299,6 +299,14 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 		}
 		else {
 			return host + ":" + port;
+		}
+	}
+
+	private String stripTrailingSlash(URI uri) {
+		if (uri.getPath().endsWith("/")) {
+			return uri.getPath().substring(0, uri.getPath().length() - 1);
+		} else {
+			return uri.getPath();
 		}
 	}
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -79,7 +79,7 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	private boolean protoEnabled = true;
 
 	/** If X-Forwarded-Prefix is enabled. */
-	private boolean prefixEnabled = false;
+	private boolean prefixEnabled = true;
 
 	/** If appending X-Forwarded-For as a list is enabled. */
 	private boolean forAppend = true;
@@ -228,10 +228,16 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 				originalUris.stream().forEach(originalUri -> {
 					if(originalUri!=null && originalUri.getPath()!=null) {
 						String prefix = originalUri.getPath();
-						if(requestUri.getPath()!=null){
-							prefix = originalUri.getPath().replace(requestUri.getPath(), "");
+
+						//strip trailing slashes before checking if request path is end of original path
+						String originalUriPath = originalUri.getPath().substring(0, originalUri.getPath().length() - (originalUri.getPath().endsWith("/") ? 1 : 0));
+						String requestUriPath = requestUri.getPath().substring(0, requestUri.getPath().length() - (requestUri.getPath().endsWith("/") ? 1 : 0));
+
+						if(requestUriPath!=null && (originalUriPath.endsWith(requestUriPath)) ){
+							prefix = originalUriPath.replace(requestUriPath, "");
 						}
-						if (prefix != null && prefix.length() > 0 && prefix.length() < originalUri.getPath().length()) {
+						if (prefix != null && prefix.length() > 0 &&
+								prefix.length() < originalUri.getPath().length()) {
 							write(updated, X_FORWARDED_PREFIX_HEADER, prefix, isPrefixAppend());
 						}
 					}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -52,6 +52,12 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	/** X-Forwarded-Proto Header */
 	public static final String X_FORWARDED_PROTO_HEADER = "X-Forwarded-Proto";
 
+	/** X-Forwarded-Prefix Header */
+	public static final String X_FORWARDED_PREFIX_HEADER = "X-Forwarded-Prefix";
+
+	/** X-Original-URI Header */
+	public static final String X_ORIGINAL_URI = "X-Original-URI";
+
 	/** The order of the XForwardedHeadersFilter. */
 	private int order = 0;
 
@@ -70,6 +76,9 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	/** If X-Forwarded-Proto is enabled. */
 	private boolean protoEnabled = true;
 
+	/** If X-Forwarded-Prefix is enabled. */
+	private boolean prefixEnabled = true;
+
 	/** If appending X-Forwarded-For as a list is enabled. */
 	private boolean forAppend = true;
 
@@ -81,6 +90,9 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 
 	/** If appending X-Forwarded-Proto as a list is enabled. */
 	private boolean protoAppend = true;
+
+	/** If appending X-Forwarded-Prefix as a list is enabled. */
+	private boolean prefixAppend = true;
 
 	@Override
 	public int getOrder() {
@@ -131,6 +143,14 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 		this.protoEnabled = protoEnabled;
 	}
 
+	public boolean isPrefixEnabled() {
+		return prefixEnabled;
+	}
+
+	public void setPrefixEnabled(boolean prefixEnabled) {
+		this.prefixEnabled = prefixEnabled;
+	}
+
 	public boolean isForAppend() {
 		return forAppend;
 	}
@@ -163,6 +183,14 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 		this.protoAppend = protoAppend;
 	}
 
+	public void setPrefixAppend(boolean prefixAppend) {
+		this.prefixAppend = prefixAppend;
+	}
+
+	public boolean isPrefixAppend() {
+		return prefixAppend;
+	}
+
 	@Override
 	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
@@ -185,6 +213,19 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 		String proto = request.getURI().getScheme();
 		if (isProtoEnabled()) {
 			write(updated, X_FORWARDED_PROTO_HEADER, proto, isProtoAppend());
+		}
+
+		if(isPrefixEnabled()){
+			String prefix = null;
+
+			if (request.getHeaders().containsKey(X_FORWARDED_PREFIX_HEADER)){
+				prefix = request.getHeaders().get(X_FORWARDED_PREFIX_HEADER).get(0);
+			}
+			else if(request.getHeaders().containsKey(X_ORIGINAL_URI)){
+				String originalUri = request.getHeaders().get(X_ORIGINAL_URI).get(0);
+				prefix = originalUri.replace(request.getURI().getPath(),"");
+			}
+			write(updated,X_FORWARDED_PREFIX_HEADER, prefix, isPrefixAppend());
 		}
 
 		if (isPortEnabled()) {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -155,7 +155,7 @@ public class XForwardedHeadersFilterTests {
 
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
-		originalUris.add(UriComponentsBuilder.fromUriString("http://originalhost:8080/prefix/get").build().toUri());
+		originalUris.add(UriComponentsBuilder.fromUriString("http://originalhost:8080/prefix/get/").build().toUri()); //trailing slash
 		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
 		URI requestUri = UriComponentsBuilder.fromUriString("http://routedservice:8090/get").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
@@ -184,9 +184,36 @@ public class XForwardedHeadersFilterTests {
 
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
-		originalUris.add(UriComponentsBuilder.fromUriString("http://originalhost:8080/get").build().toUri());
+		originalUris.add(UriComponentsBuilder.fromUriString("http://originalhost:8080/get/").build().toUri());
 		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
 		URI requestUri = UriComponentsBuilder.fromUriString("http://routedservice:8090/get").build().toUri();
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
+
+		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);
+
+		assertThat(headers).isEmpty();
+	}
+
+	@Test
+	public void routedPathInRequestPathButNotPrefix() throws Exception {
+		MockServerHttpRequest request = MockServerHttpRequest
+				.get("http://originalhost:8080/get")
+				.remoteAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
+				.build();
+
+		XForwardedHeadersFilter filter = new XForwardedHeadersFilter();
+		filter.setPrefixAppend(true);
+		filter.setPrefixEnabled(true);
+		filter.setForEnabled(false);
+		filter.setHostEnabled(false);
+		filter.setPortEnabled(false);
+		filter.setProtoEnabled(false);
+
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
+		originalUris.add(UriComponentsBuilder.fromUriString("http://originalhost:8080/one/two/three").build().toUri());
+		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
+		URI requestUri = UriComponentsBuilder.fromUriString("http://routedservice:8090/two").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.gateway.filter.headers.XForwardedHeadersFilter.X_FORWARDED_FOR_HEADER;
 import static org.springframework.cloud.gateway.filter.headers.XForwardedHeadersFilter.X_FORWARDED_HOST_HEADER;
 import static org.springframework.cloud.gateway.filter.headers.XForwardedHeadersFilter.X_FORWARDED_PORT_HEADER;
+import static org.springframework.cloud.gateway.filter.headers.XForwardedHeadersFilter.X_FORWARDED_PREFIX_HEADER;
 import static org.springframework.cloud.gateway.filter.headers.XForwardedHeadersFilter.X_FORWARDED_PROTO_HEADER;
 
 /**
@@ -112,6 +113,7 @@ public class XForwardedHeadersFilterTests {
 				.header(X_FORWARDED_HOST_HEADER, "example.com")
 				.header(X_FORWARDED_PORT_HEADER, "443")
 				.header(X_FORWARDED_PROTO_HEADER, "https")
+				.header(X_FORWARDED_PREFIX_HEADER,"/prefix")
 				.build();
 
 		XForwardedHeadersFilter filter = new XForwardedHeadersFilter();
@@ -119,16 +121,18 @@ public class XForwardedHeadersFilterTests {
 		filter.setHostAppend(false);
 		filter.setPortAppend(false);
 		filter.setProtoAppend(false);
+		filter.setPrefixAppend(false);
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
 		assertThat(headers).containsKeys(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
-				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER);
+				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER,X_FORWARDED_PREFIX_HEADER);
 
 		assertThat(headers.getFirst(X_FORWARDED_FOR_HEADER)).isEqualTo("10.0.0.1");
 		assertThat(headers.getFirst(X_FORWARDED_HOST_HEADER)).isEqualTo("localhost:8080");
 		assertThat(headers.getFirst(X_FORWARDED_PORT_HEADER)).isEqualTo("8080");
 		assertThat(headers.getFirst(X_FORWARDED_PROTO_HEADER)).isEqualTo("http");
+		assertThat(headers.getFirst(X_FORWARDED_PREFIX_HEADER)).isEqualTo("/prefix");
 	}
 
 	@Test
@@ -143,6 +147,7 @@ public class XForwardedHeadersFilterTests {
 		filter.setHostEnabled(false);
 		filter.setPortEnabled(false);
 		filter.setProtoEnabled(false);
+		filter.setPrefixEnabled(false);
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 


### PR DESCRIPTION
fixes https://github.com/spring-cloud/spring-cloud-gateway/issues/314

New PR after closing https://github.com/spring-cloud/spring-cloud-gateway/pull/377 - this time just using data available in the gw implementation. The idea is that if the path of the url that the gw is routing to is a subset of the url that it is routing from then the difference is the prefix. Also applies if the path of the url being routed to is empty and the routed-from url path is non-empty. 

Included quite a few null checks as it should allow for the various different route definition styles and types of request. I've been [using this](https://github.com/ryandawsonuk/activiti-cloud-gateway/tree/develop/src/main/java/org/springframework/cloud/gateway/filter/headers) in k8s by overriding the class and found the null checks to be necessary.

Was thinking it could be disabled by default as that's how it is for [nginx ingress](https://github.com/kubernetes/ingress-nginx/pull/1805) but I haven't thought of any specific reason not to enable by default.