### PR TITLE
Fix the typo in method 'convertHttpToWs'

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
@@ -118,7 +118,7 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 	}
 
 	private String convertHttpToWs(String scheme) {
-		return "http".equals(scheme) ? "ws" : "https".equals(scheme) ? "wws" : scheme;
+		return "http".equals(scheme) ? "ws" : "https".equals(scheme) ? "wss" : scheme;
 	}
 
 	private static class ProxyWebSocketHandler implements WebSocketHandler {


### PR DESCRIPTION
The secure WebSocket protocol is "wss", not "wws".