### PR TITLE
ForwardedHeadersFilter causes a broken http header (fixes #440) 

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -990,7 +990,7 @@ public class PostGatewayFilterFactory extends AbstractGatewayFilterFactory<PostG
 		// grab configuration from Config object
 		return (exchange, chain) -> {
 			return chain.filter(exchange).then(Mono.fromRunnable(() -> {
-				ServerHttpReponse response = exchange.getResponse();
+				ServerHttpResponse response = exchange.getResponse();
 				//Manipulate the response in some way
 			}));
 		};

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.jetbrains.annotations.Nullable;
-
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -58,7 +57,7 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 		List<Forwarded> forwardeds = parse(original.get(FORWARDED_HEADER));
 
 		for (Forwarded f : forwardeds) {
-			updated.add(FORWARDED_HEADER, f.toString());
+			updated.add(FORWARDED_HEADER, f.toHeaderValue());
 		}
 
 		//TODO: add new forwarded

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
@@ -17,24 +17,20 @@
 
 package org.springframework.cloud.gateway.filter.headers;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.cloud.gateway.filter.headers.ForwardedHeadersFilter.FORWARDED_HEADER;
-
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.junit.Test;
 import org.springframework.cloud.gateway.filter.headers.ForwardedHeadersFilter.Forwarded;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.util.StringUtils;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.gateway.filter.headers.ForwardedHeadersFilter.FORWARDED_HEADER;
 
 /**
  * @author Spencer Gibb
@@ -121,7 +117,7 @@ public class ForwardedHeadersFilterTests {
 
 	@Test
 	public void forwardedParsedCorrectly() {
-		String[] valid = new String[] {
+		String[] valid = new String[]{
 				"for=\"_gazonk\"",
 				"for=192.0.2.60;proto=http;by=203.0.113.43",
 				"for=192.0.2.43, for=198.51.100.17",
@@ -132,15 +128,15 @@ public class ForwardedHeadersFilterTests {
 
 		@SuppressWarnings("unchecked")
 		List<List<Map<String, String>>> expectedFor = new ArrayList<List<Map<String, String>>>() {{
-				add(list(map("for", "\"_gazonk\"")));
-				add(list(map("for", "192.0.2.60", "proto", "http", "by", "203.0.113.43")));
-				add(list(map("for", "192.0.2.43"), map("for", "198.51.100.17")));
-				add(list(map("for", "12.34.56.78", "host", "example.com", "proto", "https"),
-						map("for", "23.45.67.89")));
-				add(list(map("for", "12.34.56.78"),
-						map("for", "23.45.67.89", "secret", "egah2CGj55fSJFs"),
-						map("for", "10.1.2.3")));
-				add(list(map("for", "\"[2001:db8:cafe::17]:4711\"")));
+			add(list(map("for", "\"_gazonk\"")));
+			add(list(map("for", "192.0.2.60", "proto", "http", "by", "203.0.113.43")));
+			add(list(map("for", "192.0.2.43"), map("for", "198.51.100.17")));
+			add(list(map("for", "12.34.56.78", "host", "example.com", "proto", "https"),
+					map("for", "23.45.67.89")));
+			add(list(map("for", "12.34.56.78"),
+					map("for", "23.45.67.89", "secret", "egah2CGj55fSJFs"),
+					map("for", "10.1.2.3")));
+			add(list(map("for", "\"[2001:db8:cafe::17]:4711\"")));
 		}};
 
 		for (int i = 0; i < valid.length; i++) {


### PR DESCRIPTION
Fixes a small bug in the ForwardedHeadersFilter which causes a broken http header, if a Forwarded header has already been set.