### PR TITLE
change LoadBalancerClientFilter to support extended

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayLoadBalancerClientAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayLoadBalancerClientAutoConfiguration.java
@@ -20,6 +20,7 @@ package org.springframework.cloud.gateway.config;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
 import org.springframework.cloud.gateway.filter.LoadBalancerClientFilter;
 import org.springframework.cloud.netflix.ribbon.RibbonAutoConfiguration;
@@ -39,6 +40,7 @@ public class GatewayLoadBalancerClientAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean(LoadBalancerClient.class)
+	@ConditionalOnMissingBean(LoadBalancerClientFilter.class)
 	public LoadBalancerClientFilter loadBalancerClientFilter(LoadBalancerClient client) {
 		return new LoadBalancerClientFilter(client);
 	}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilter.java
@@ -43,7 +43,7 @@ public class LoadBalancerClientFilter implements GlobalFilter, Ordered {
 	private static final Log log = LogFactory.getLog(LoadBalancerClientFilter.class);
 	public static final int LOAD_BALANCER_CLIENT_FILTER_ORDER = 10100;
 
-	private final LoadBalancerClient loadBalancer;
+	protected final LoadBalancerClient loadBalancer;
 
 	public LoadBalancerClientFilter(LoadBalancerClient loadBalancer) {
 		this.loadBalancer = loadBalancer;
@@ -66,7 +66,7 @@ public class LoadBalancerClientFilter implements GlobalFilter, Ordered {
 
 		log.trace("LoadBalancerClientFilter url before: " + url);
 
-		final ServiceInstance instance = loadBalancer.choose(url.getHost());
+		final ServiceInstance instance = choose(exchange);
 
 		if (instance == null) {
 			throw new NotFoundException("Unable to find instance for " + url.getHost());
@@ -86,6 +86,10 @@ public class LoadBalancerClientFilter implements GlobalFilter, Ordered {
 		log.trace("LoadBalancerClientFilter url chosen: " + requestUrl);
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
 		return chain.filter(exchange);
+	}
+
+	protected ServiceInstance choose(ServerWebExchange exchange) {
+		return loadBalancer.choose(((URI) exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR)).getHost());
 	}
 
 	class DelegatingServiceInstance implements ServiceInstance {

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.gateway.handler.AsyncPredicate;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -114,7 +115,11 @@ public class Route implements Ordered {
 
 		public B uri(URI uri) {
 			this.uri = uri;
-			if (this.uri.getPort() < 0 && this.uri.getScheme().startsWith("http")) {
+			String scheme = this.uri.getScheme();
+			if (StringUtils.isEmpty(scheme)) {
+				throw new IllegalArgumentException("The parameter [" + this.uri + "] format is incorrect ");
+			}
+			if (this.uri.getPort() < 0 && scheme.startsWith("http")) {
 				// default known http ports
 				int port = this.uri.getScheme().equals("https") ? 443 : 80;
 				this.uri = UriComponentsBuilder.fromUri(this.uri)

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
@@ -114,9 +114,7 @@ public class Route implements Ordered {
 
 		public B uri(URI uri) {
 			this.uri = uri;
-			String scheme = this.uri.getScheme();
-			Assert.hasText(scheme, "The parameter [" + this.uri + "] format is incorrect, scheme can not be empty");
-			if (this.uri.getPort() < 0 && scheme.startsWith("http")) {
+			if (this.uri.getPort() < 0 && this.uri.getScheme().startsWith("http")) {
 				// default known http ports
 				int port = this.uri.getScheme().equals("https") ? 443 : 80;
 				this.uri = UriComponentsBuilder.fromUri(this.uri)

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
@@ -117,7 +117,7 @@ public class Route implements Ordered {
 			this.uri = uri;
 			String scheme = this.uri.getScheme();
 			if (StringUtils.isEmpty(scheme)) {
-				throw new IllegalArgumentException("The parameter [" + this.uri + "] format is incorrect ");
+				throw new IllegalArgumentException("The parameter [" + this.uri + "] format is incorrect, scheme cannot be empty");
 			}
 			if (this.uri.getPort() < 0 && scheme.startsWith("http")) {
 				// default known http ports

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
@@ -31,7 +31,6 @@ import org.springframework.cloud.gateway.handler.AsyncPredicate;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -116,9 +115,7 @@ public class Route implements Ordered {
 		public B uri(URI uri) {
 			this.uri = uri;
 			String scheme = this.uri.getScheme();
-			if (StringUtils.isEmpty(scheme)) {
-				throw new IllegalArgumentException("The parameter [" + this.uri + "] format is incorrect, scheme cannot be empty");
-			}
+			Assert.hasText(scheme, "The parameter [" + this.uri + "] format is incorrect, scheme can not be empty");
 			if (this.uri.getPort() < 0 && scheme.startsWith("http")) {
 				// default known http ports
 				int port = this.uri.getScheme().equals("https") ? 443 : 80;

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilterTests.java
@@ -1,11 +1,11 @@
 package org.springframework.cloud.gateway.filter;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -225,6 +225,52 @@ public class LoadBalancerClientFilterTests {
 		verify(chain).filter(exchange);
 		verifyNoMoreInteractions(chain);
 		verifyZeroInteractions(loadBalancerClient);
+	}
+
+	@Test
+	public void shouldSelectSpecifiedServer() {
+		URI uri1 = UriComponentsBuilder.fromUriString("lb://myservice").port(11111).build().toUri();
+		URI uri2 = UriComponentsBuilder.fromUriString("lb://myservice").port(22222).build().toUri();
+
+		SpringClientFactory clientFactory = mock(SpringClientFactory.class);
+		ILoadBalancer loadBalancer = mock(ILoadBalancer.class);
+		when(clientFactory.getLoadBalancerContext("myservice")).thenReturn(new RibbonLoadBalancerContext(loadBalancer));
+		when(clientFactory.getLoadBalancer("myservice")).thenReturn(loadBalancer);
+
+		when(loadBalancer.chooseServer("11111")).thenReturn(new Server("myservice-host1", 8081));
+		when(loadBalancer.chooseServer("22222")).thenReturn(new Server("myservice-host2", 8081));
+
+		LoadBalancerClient loadBalancerClient = new RibbonLoadBalancerClient(clientFactory) {
+			private String loadBalancerKey;
+			public ServiceInstance choose(String serviceId) {
+				String[] strings = serviceId.split("<<>>");
+				loadBalancerKey = strings[1];
+				return super.choose(strings[0]);
+			}
+			protected Server getServer(ILoadBalancer loadBalancer) {
+				return loadBalancer == null ? null : loadBalancer.chooseServer(StringUtils.isEmpty(loadBalancerKey) ? "default" : loadBalancerKey);
+			}
+		};
+
+		LoadBalancerClientFilter loadBalancerClientFilter = new LoadBalancerClientFilter(loadBalancerClient) {
+			protected ServiceInstance choose(ServerWebExchange exchange) {
+				URI attribute = (URI) exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
+				return loadBalancer.choose(attribute.getHost() + "<<>>" + attribute.getPort());
+			}
+		};
+
+		MockServerHttpRequest request = MockServerHttpRequest
+				.get("http://localhost/get")
+				.build();
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri1);
+		loadBalancerClientFilter.filter(exchange, chain);
+		assertThat(((URI)exchange.getAttributes().get(GATEWAY_REQUEST_URL_ATTR)).getHost()).isEqualTo("myservice-host1");
+
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri2);
+		loadBalancerClientFilter.filter(exchange, chain);
+		assertThat(((URI)exchange.getAttributes().get(GATEWAY_REQUEST_URL_ATTR)).getHost()).isEqualTo("myservice-host2");
 	}
 
 	private ServerWebExchange testFilter(MockServerHttpRequest request, URI uri) {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilterTests.java
@@ -5,7 +5,6 @@ import java.util.LinkedHashSet;
 
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,6 +22,7 @@ import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
 


### PR DESCRIPTION
change LoadBalancerClientFilter to support extended.
for example:
```
public class CustomLoadBalancerClientFilter extends LoadBalancerClientFilter {
    public CustomLoadBalancerClientFilter(LoadBalancerClient loadBalancer) {
        super(loadBalancer);
    }
    protected ServiceInstance choose(ServerWebExchange exchange) {
        return loadBalancer.choose(((URI) exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR)).getHost() + "<<>>" + exchange.getRequest().getRemoteAddress());
    }
}

public class CustomRibbonLoadBalancerClient extends RibbonLoadBalancerClient {
    public CustomRibbonLoadBalancerClient(SpringClientFactory clientFactory) {
        super(clientFactory);
    }

    protected Server getServer(String serviceId) {
        String[] strings = serviceId.split("<<>>");
        ILoadBalancer loadBalancer = getLoadBalancer(strings[0]);
        if (loadBalancer == null) {
            return null;
        }
        return loadBalancer.chooseServer(strings[1]);
    }
}
```