### PR TITLE
Fix bug where metrics fail if actuator is not added as a project depency

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -886,14 +886,16 @@ spring:
 
 === Gateway Metrics Filter
 
-The Gateway Metrics Filter runs as long as the property `spring.cloud.gateway.metrics.enabled` is not set to `false`. This filter adds a timer metric named "gateway.requests" with the following tags:
+To enable Gateway Metrics add spring-boot-starter-actuator as a project dependency. Then, by default, the Gateway Metrics Filter runs as long as the property `spring.cloud.gateway.metrics.enabled` is not set to `false`. This filter adds a timer metric named "gateway.requests" with the following tags:
 
 * `routeId`: The route id 
 * `routeUri`: The URI that the API will be routed to
-* `outcome` |Outcome as classified by link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpStatus.Series.html[HttpStatus.Series]
+* `outcome`: Outcome as classified by link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpStatus.Series.html[HttpStatus.Series]
 * `status`: Http Status of the request returned to the client
 
 These metrics are then available to be scraped from ``/actuator/metrics/gateway.requests`` and can be easily integated with Prometheus to create a link:images/gateway-grafana-dashboard.jpeg[Grafana] link:gateway-grafana-dashboard.json[dashboard].
+
+NOTE: To enable the pometheus endpoint add micrometer-registry-prometheus as a project dependency.
 
 === Making An Exchange As Routed
 

--- a/spring-cloud-gateway-sample/pom.xml
+++ b/spring-cloud-gateway-sample/pom.xml
@@ -24,6 +24,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
+			<exclusions> <!-- exclude metrics to verify that gateway doesn't fall over when it is not available -->
+				<exclusion>
+					<groupId>io.micrometer</groupId>
+					<artifactId>micrometer-core</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/spring-cloud-gateway-sample/pom.xml
+++ b/spring-cloud-gateway-sample/pom.xml
@@ -24,12 +24,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
-			<exclusions> <!-- exclude metrics to verify that gateway doesn't fall over when it is not available -->
-				<exclusion>
-					<groupId>io.micrometer</groupId>
-					<artifactId>micrometer-core</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -58,6 +52,11 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-test-support</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-gateway-sample/src/main/java/org/springframework/cloud/gateway/sample/GatewaySampleApplication.java
+++ b/spring-cloud-gateway-sample/src/main/java/org/springframework/cloud/gateway/sample/GatewaySampleApplication.java
@@ -45,6 +45,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 @Import(AdditionalRoutes.class)
 public class GatewaySampleApplication {
 
+	public static final String HELLO_FROM_FAKE_ACTUATOR_METRICS_GATEWAY_REQUESTS = "hello from fake /actuator/metrics/gateway.requests";
 	@Value("${test.uri:http://httpbin.org:80}")
 	String uri;
 
@@ -132,6 +133,14 @@ public class GatewaySampleApplication {
 		RouterFunction<ServerResponse> route = RouterFunctions.route(
 				RequestPredicates.path("/testfun"),
 				request -> ServerResponse.ok().body(BodyInserters.fromObject("hello")));
+		return route;
+	}
+
+	@Bean
+	public RouterFunction<ServerResponse> testWhenMetricPathIsNotMeet() {
+		RouterFunction<ServerResponse> route = RouterFunctions.route(
+				RequestPredicates.path("/actuator/metrics/gateway.requests"),
+				request -> ServerResponse.ok().body(BodyInserters.fromObject(HELLO_FROM_FAKE_ACTUATOR_METRICS_GATEWAY_REQUESTS)));
 		return route;
 	}
 

--- a/spring-cloud-gateway-sample/src/test/java/org/springframework/cloud/gateway/sample/GatewaySampleApplicationWithoutMetricsTests.java
+++ b/spring-cloud-gateway-sample/src/test/java/org/springframework/cloud/gateway/sample/GatewaySampleApplicationWithoutMetricsTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.gateway.sample;
+
+import java.time.Duration;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.gateway.sample.GatewaySampleApplicationTests.TestConfig;
+import org.springframework.cloud.test.ClassPathExclusions;
+import org.springframework.cloud.test.ModifiedClassPathRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.util.SocketUtils;
+
+@RunWith(ModifiedClassPathRunner.class)
+@ClassPathExclusions({ "micrometer-*.jar" })
+@DirtiesContext
+public class GatewaySampleApplicationWithoutMetricsTests {
+
+	static protected int port;
+
+	protected WebTestClient webClient;
+	protected String baseUri;
+
+	@BeforeClass
+	public static void beforeClass() {
+		port = SocketUtils.findAvailableTcpPort();
+		System.setProperty("server.port", Integer.toString(port));
+	}
+
+	@AfterClass
+	public static void afterClass() {
+		System.clearProperty("server.port");
+	}
+
+	@Before
+	public void setup() {
+		baseUri = "http://localhost:" + port;
+		this.webClient = WebTestClient.bindToServer()
+				.responseTimeout(Duration.ofSeconds(10)).baseUrl(baseUri).build();
+	}
+
+	protected ConfigurableApplicationContext init(Class<?> config) {
+		return new SpringApplicationBuilder().web(WebApplicationType.REACTIVE)
+				.sources(GatewaySampleApplication.class, config).run();
+	}
+
+	@Test
+	public void actuatorMetrics() {
+		init(TestConfig.class);
+		webClient.get().uri("/get").exchange().expectStatus().isOk();
+		webClient.get()
+				.uri("http://localhost:" + port + "/actuator/metrics/gateway.requests")
+				.exchange().expectStatus().isOk().expectBody(String.class).isEqualTo(
+						GatewaySampleApplication.HELLO_FROM_FAKE_ACTUATOR_METRICS_GATEWAY_REQUESTS);
+	}
+
+}


### PR DESCRIPTION
Code fixed and failing test added.

Before this PR a user who uses spring cloud gateway starter would fail because the exiting code assumes actuator metrics dependencies are always there. But actuator is an optional dependency in the spring gateway core.