### PR TITLE
Add global cors config to simlple URL Handler mapping. Spring webflux…

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1048,7 +1048,7 @@ spring:
 
 In the example above, CORS requests will be allowed from requests that originate from docs.spring.io for all GET requested paths.
 
-To provide the same CORS configuration to requests that are not handled by some gateway route predicate, set the property `spring.cloud.gateway.globalcors.add-to-simple-url-hander-mapping` equal to true. This is useful when trying to support CORS preflight requests and your route predicate doesn't evalute to true because the http method is `options`.
+To provide the same CORS configuration to requests that are not handled by some gateway route predicate, set the property `spring.cloud.gateway.globalcors.add-to-simple-url-handler-mapping` equal to true. This is useful when trying to support CORS preflight requests and your route predicate doesn't evalute to true because the http method is `options`.
 
 == Actuator API
 

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1048,6 +1048,8 @@ spring:
 
 In the example above, CORS requests will be allowed from requests that originate from docs.spring.io for all GET requested paths.
 
+To provide the same CORS configuration to requests that are not handled by some gateway route predicate, set the property `spring.cloud.gateway.globalcors.add-to-simple-url-hander-mapping` equal to true. This is useful when trying to support CORS preflight requests and your route predicate doesn't evalute to true because the http method is `options`.
+
 == Actuator API
 
 TODO: document the `/gateway` actuator endpoint

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
 
 @Configuration
 @ConditionalOnClass(SimpleUrlHandlerMapping.class)
-@ConditionalOnProperty(name = "spring.cloud.gateway.globalcors.addToSimpleUrlHanderMapping", matchIfMissing = true)
+@ConditionalOnProperty(name = "spring.cloud.gateway.globalcors.add-to-simple-url-hander-mapping", matchIfMissing = false)
 public class SimpleUrlHandlerMappingGlobalCorsAutoConfiguration {
 
 	@Autowired

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
@@ -1,0 +1,32 @@
+package org.springframework.cloud.gateway.config;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+
+/**
+ * This is useful for PreFlight CORS requests. We can add a "global" configuration here so
+ * we don't have to modify existing predicates to allow the "options" HTTP method.
+ * 
+ */
+
+@Configuration
+@ConditionalOnProperty(name = "spring.cloud.gateway.globalcors.addToSimpleUrlHanderMapping", matchIfMissing = true)
+public class SimpleUrlHandlerMappingGlobalCorsAutoConfiguration {
+
+	@Autowired
+	private GlobalCorsProperties globalCorsProperties;
+
+	@Autowired
+	private SimpleUrlHandlerMapping simpleUrlHandlerMapping;
+
+	@PostConstruct
+	void config() {
+		simpleUrlHandlerMapping
+				.setCorsConfigurations(globalCorsProperties.getCorsConfigurations());
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
@@ -33,7 +33,7 @@ import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
 
 @Configuration
 @ConditionalOnClass(SimpleUrlHandlerMapping.class)
-@ConditionalOnProperty(name = "spring.cloud.gateway.globalcors.add-to-simple-url-hander-mapping", matchIfMissing = false)
+@ConditionalOnProperty(name = "spring.cloud.gateway.globalcors.add-to-simple-url-handler-mapping", matchIfMissing = false)
 public class SimpleUrlHandlerMappingGlobalCorsAutoConfiguration {
 
 	@Autowired

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
@@ -3,6 +3,7 @@ package org.springframework.cloud.gateway.config;
 import javax.annotation.PostConstruct;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
@@ -14,6 +15,7 @@ import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
  */
 
 @Configuration
+@ConditionalOnClass(SimpleUrlHandlerMapping.class)
 @ConditionalOnProperty(name = "spring.cloud.gateway.globalcors.addToSimpleUrlHanderMapping", matchIfMissing = true)
 public class SimpleUrlHandlerMappingGlobalCorsAutoConfiguration {
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/SimpleUrlHandlerMappingGlobalCorsAutoConfiguration.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package org.springframework.cloud.gateway.config;
 
 import javax.annotation.PostConstruct;

--- a/spring-cloud-gateway-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gateway-core/src/main/resources/META-INF/spring.factories
@@ -5,4 +5,5 @@ org.springframework.cloud.gateway.config.GatewayAutoConfiguration,\
 org.springframework.cloud.gateway.config.GatewayLoadBalancerClientAutoConfiguration,\
 org.springframework.cloud.gateway.config.GatewayMetricsAutoConfiguration,\
 org.springframework.cloud.gateway.config.GatewayRedisAutoConfiguration,\
-org.springframework.cloud.gateway.discovery.GatewayDiscoveryClientAutoConfiguration
+org.springframework.cloud.gateway.discovery.GatewayDiscoveryClientAutoConfiguration,\
+org.springframework.cloud.gateway.config.SimpleUrlHandlerMappingGlobalCorsAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/cors/SimpleUrlHandlerCorsTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/cors/SimpleUrlHandlerCorsTests.java
@@ -44,7 +44,7 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 import reactor.core.publisher.Mono;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT, properties="spring.cloud.gateway.globalcors.add-to-simple-url-hander-mapping=true")
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties="spring.cloud.gateway.globalcors.add-to-simple-url-handler-mapping=true")
 @DirtiesContext
 @ActiveProfiles("request-header-web-filter")
 public class SimpleUrlHandlerCorsTests extends BaseWebClientTests {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/cors/SimpleUrlHandlerCorsTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/cors/SimpleUrlHandlerCorsTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.gateway.cors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.config.GatewayAutoConfiguration;
+import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.client.ClientResponse;
+
+import reactor.core.publisher.Mono;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DirtiesContext
+@ActiveProfiles("request-header-web-filter")
+public class SimpleUrlHandlerCorsTests extends BaseWebClientTests {
+
+	
+	@Test
+	public void testPreFlightCorsRequestNotHandledByGW() {
+		ClientResponse clientResponse = webClient.options().uri("/abc/123/function")
+				.header("Origin", "domain.com")
+				.header("Access-Control-Request-Method", "GET").exchange().block();
+		HttpHeaders asHttpHeaders = clientResponse.headers().asHttpHeaders();
+		Mono<String> bodyToMono = clientResponse.bodyToMono(String.class);
+		// pre-flight request shouldn't return the response body
+		assertNull(bodyToMono.block());
+		assertEquals(
+				"Missing header value in response: "
+						+ HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+				"*", asHttpHeaders.getAccessControlAllowOrigin());
+		assertEquals(
+				"Missing header value in response: "
+						+ HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS,
+				Arrays.asList(new HttpMethod[] { HttpMethod.GET }),
+				asHttpHeaders.getAccessControlAllowMethods());
+		assertEquals("Pre Flight call failed.", HttpStatus.OK,
+				clientResponse.statusCode());
+	}
+
+	@Test
+	public void testCorsRequestNotHandledByGW() {
+		ClientResponse clientResponse = webClient.get().uri("/abc/123/function")
+				.header("Origin", "domain.com").header(HttpHeaders.HOST, "www.path.org")
+				.exchange().block();
+		HttpHeaders asHttpHeaders = clientResponse.headers().asHttpHeaders();
+		Mono<String> bodyToMono = clientResponse.bodyToMono(String.class);
+		assertNotNull(bodyToMono.block());
+		assertEquals(
+				"Missing header value in response: "
+						+ HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN,
+				"*", asHttpHeaders.getAccessControlAllowOrigin());
+		assertEquals("CORS request failed.", HttpStatus.NOT_FOUND,
+				clientResponse.statusCode());
+	}
+
+	@EnableAutoConfiguration
+	@SpringBootConfiguration
+	@AutoConfigureBefore(GatewayAutoConfiguration.class)
+	@Import(DefaultTestConfig.class)
+	public static class TestConfig {
+
+	}
+
+}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/cors/SimpleUrlHandlerCorsTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/cors/SimpleUrlHandlerCorsTests.java
@@ -44,7 +44,7 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 import reactor.core.publisher.Mono;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(webEnvironment = RANDOM_PORT)
+@SpringBootTest(webEnvironment = RANDOM_PORT, properties="spring.cloud.gateway.globalcors.add-to-simple-url-hander-mapping=true")
 @DirtiesContext
 @ActiveProfiles("request-header-web-filter")
 public class SimpleUrlHandlerCorsTests extends BaseWebClientTests {


### PR DESCRIPTION
… adds a static resource handler, WebFluxAutoConfiguration.WebFluxConfig. This adds a SimpleURLHandler which will be the handler that ends returning http 404 for requets that match any spring cloud gateway predicates. An alternative to this is to require that the each route also allow the http options method...but that couldn't be considered global configuration

fixes gh-840