### PR TITLE
Handle case to work with non standard content like "Content-Type: image"

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 import reactor.ipc.netty.NettyPipeline;
 import reactor.ipc.netty.http.client.HttpClient;
@@ -129,8 +130,9 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 			res.responseHeaders().forEach(entry -> headers.add(entry.getKey(), entry.getValue()));
 
-			if (headers.getContentType() != null) {
-				exchange.getAttributes().put(ORIGINAL_RESPONSE_CONTENT_TYPE_ATTR, headers.getContentType());
+			String contentTypeValue = headers.getFirst(HttpHeaders.CONTENT_TYPE);
+			if (StringUtils.hasLength(contentTypeValue)) {
+				exchange.getAttributes().put(ORIGINAL_RESPONSE_CONTENT_TYPE_ATTR, contentTypeValue);
 			}
 
 			HttpHeaders filteredResponseHeaders = HttpHeadersFilter.filter(

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
@@ -75,7 +75,12 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 					.retain() //TODO: needed?
 					.map(factory::wrap);
 
-			MediaType contentType = response.getHeaders().getContentType();
+			MediaType contentType = null;
+			try {
+				contentType = response.getHeaders().getContentType();
+			} catch (Exception e) {
+				log.trace("invalid media type", e);
+			}
 			return (isStreamingMediaType(contentType) ?
 					response.writeAndFlushWith(body.map(Flux::just)) : response.writeWith(body));
 		}));

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
@@ -84,9 +84,11 @@ public class ModifyResponseBodyGatewayFilterFactory
 					Class inClass = config.getInClass();
 					Class outClass = config.getOutClass();
 
-					MediaType originalResponseContentType = exchange.getAttribute(ORIGINAL_RESPONSE_CONTENT_TYPE_ATTR);
+					String originalResponseContentType = exchange.getAttribute(ORIGINAL_RESPONSE_CONTENT_TYPE_ATTR);
 					HttpHeaders httpHeaders = new HttpHeaders();
-					httpHeaders.setContentType(originalResponseContentType);
+					//explicitly add it in this way instead of 'httpHeaders.setContentType(originalResponseContentType)'
+					//this will prevent exception in case of using non-standard media types like "Content-Type: image"
+					httpHeaders.add(HttpHeaders.CONTENT_TYPE, originalResponseContentType);
 					ResponseAdapter responseAdapter = new ResponseAdapter(body, httpHeaders);
 					DefaultClientResponse clientResponse = new DefaultClientResponse(responseAdapter, ExchangeStrategies.withDefaults());
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/NonStandardHeadersInResponseTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/NonStandardHeadersInResponseTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2013-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.gateway.filter.headers;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+		webEnvironment = DEFINED_PORT,
+		properties = {"server.port=62175"}
+)
+@DirtiesContext
+public class NonStandardHeadersInResponseTests extends BaseWebClientTests {
+
+	public static final String CONTENT_TYPE_IMAGE = "image";
+
+	@Test
+	public void nonStandardHeadersInResponse() {
+		URI uri = UriComponentsBuilder
+				.fromUriString(this.baseUri + "/get-image")
+				.build(true)
+				.toUri();
+
+		String contentType = WebClient.builder()
+				.baseUrl(baseUri)
+				.build()
+				.get()
+				.uri(uri)
+				.exchange()
+				.map(clientResponse -> clientResponse.headers().asHttpHeaders().getFirst(HttpHeaders.CONTENT_TYPE))
+				.block();
+
+		assertEquals(CONTENT_TYPE_IMAGE, contentType);
+	}
+
+	@EnableAutoConfiguration
+	@SpringBootConfiguration
+	@Import(DefaultTestConfig.class)
+	public static class TestConfig {
+		private static final Log log = LogFactory.getLog(TestConfig.class);
+		@Value("${test.uri}")
+		String uri;
+		@Value("${server.port}")
+		int port;
+
+		@Bean
+		@Order(5001)
+		public GlobalFilter addNonStandardHeaderFilter() {
+			return (exchange, chain) -> {
+				log.info("addNonStandardHeaderFilter pre phase");
+				return chain.filter(exchange).then(Mono.fromRunnable(() -> {
+					log.info("addNonStandardHeaderFilter post phase");
+					List<String> contentTypes = exchange.getResponse().getHeaders().get(HttpHeaders.CONTENT_TYPE);
+					contentTypes.clear();
+					contentTypes.add(CONTENT_TYPE_IMAGE);
+				}));
+			};
+		}
+
+		@Bean
+		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
+			return builder.routes()
+					.route("non_standard_header_route", r ->
+							r.path("/get-image/**")
+									.filters(f -> f
+											.addRequestHeader(HttpHeaders.HOST, "www.addrequestparameter.org")
+											.stripPrefix(1)
+									)
+									.uri("http://localhost:" + port + "/get"))
+					.route("internal_route", r ->
+							r.path("/get/**")
+									.filters(f -> f.prefixPath("/httpbin"))
+									.uri(uri))
+					.build();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Sometimes the services behind the cloud gateway respond with non standard content type like 'image'. It is fixed here.