### PR TITLE
Use GATEWAY_REQUEST_URL_ATTR value as tag in GatewayMetricsFilter

### DIFF
--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricFilterTests.java
@@ -60,7 +60,7 @@ public class GatewayMetricFilterTests extends BaseWebClientTests {
 		assertMetricsContainsTag("outcome", HttpStatus.Series.SUCCESSFUL.name());
 		assertMetricsContainsTag("status", HttpStatus.OK.name());
 		assertMetricsContainsTag("routeId", "default_path_to_httpbin");
-		assertMetricsContainsTag("routeUri", "http://localhost:5044");
+		assertMetricsContainsTag("routeUri", "http://localhost:" + port);
 	}
 
 	@Test
@@ -71,7 +71,7 @@ public class GatewayMetricFilterTests extends BaseWebClientTests {
 		assertMetricsContainsTag("outcome", HttpStatus.Series.SERVER_ERROR.name());
 		assertMetricsContainsTag("status", HttpStatus.INTERNAL_SERVER_ERROR.name());
 		assertMetricsContainsTag("routeId", "default_path_to_httpbin");
-		assertMetricsContainsTag("routeUri", "http://localhost:5044");
+		assertMetricsContainsTag("routeUri", "http://localhost:" + port);
 	}
 
 	@Test
@@ -86,14 +86,14 @@ public class GatewayMetricFilterTests extends BaseWebClientTests {
 		assertMetricsContainsTag("outcome", "CUSTOM");
 		assertMetricsContainsTag("status", "432");
 		assertMetricsContainsTag("routeId", "test_custom_http_status");
-		assertMetricsContainsTag("routeUri", "http://localhost:5044");
+		assertMetricsContainsTag("routeUri", "http://localhost:" + port);
 	}
 
 	@Test
 	public void gatewayRequestsMeterFilterUsesStaticRouteURI() {
 		testClient.get().uri("/").header("Host", "test.gateway-metrics.org")
 				.header("X-CF-Forwarded-Url",
-						"http://localhost:\" + port + \"/actuator/health?metrics")
+						"http://localhost:" + port + "/actuator/health?metrics")
 				.header("X-CF-Proxy-Signature", "foo")
 				.header("X-CF-Proxy-Metadata", "bar").exchange();
 		assertMetricsContainsTag("routeId", "gateway_metrics_route-url_test");

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -3,6 +3,7 @@ test:
 #  hostport: localhost:5000
 #  uri: http://${test.hostport}
   uri: lb://testservice
+  fixed-port: 5044
 
 spring:
   cloud:
@@ -257,6 +258,15 @@ spring:
         predicates:
         - Host=**.changeuri.org
         - Header=X-CF-Forwarded-Url
+        filters:
+        - RequestHeaderToRequestUri=X-CF-Forwarded-Url
+
+      # =====================================
+      - id: gateway_metrics_route-url_test
+        uri: http://localhost:${test.fixed-port}/actuator
+        predicates:
+        - Host=**.gateway-metrics.org
+        - CloudFoundryRouteService=
         filters:
         - RequestHeaderToRequestUri=X-CF-Forwarded-Url
 


### PR DESCRIPTION
This PR is related to issue #487. 

It was a bit more complicated than I first assumed. Simply replacing the URI of the route definition with the GATEWAY_REQUEST_URL_ATTR creates an issue with variable path elements as each of these elements would lead to a separate tag (... user/1 ... user/2 ...). So I was only able to use the scheme and host part of the request URI but this is a loss of information compared to the current solution as the route URI might well contain some additional (static) path information that we could use for tagging.

So I came up with the following solution:

- If the start of the URI string matches the route URI string then I use the route URI for tagging (same as today)
- Otherweise I use the scheme and host part of the request URI to not include any variable path elements

Hope it makes sense like this. 
