### PR TITLE
Make Gateway return 504 when HttpClient times out

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
+import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.NettyPipeline;
@@ -151,10 +152,9 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 				});
 
 		if (properties.getResponseTimeout() != null) {
-			//TODO: figure out how to make this a 504
 			responseFlux = responseFlux.timeout(properties.getResponseTimeout(),
 					Mono.error(new TimeoutException("Response took longer than timeout: " +
-							properties.getResponseTimeout())));
+							properties.getResponseTimeout()))).onErrorMap(TimeoutException.class, th -> new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, null, th));
 		}
 
 		return responseFlux.then(chain.filter(exchange));

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -44,12 +45,8 @@ public class NettyRoutingFilterIntegrationTests extends BaseWebClientTests {
 		testClient.get()
 				.uri("/delay/5")
 				.exchange()
-				.expectStatus().is5xxServerError()
-				.expectBody(Map.class)
-				.consumeWith(result -> {
-					Map body = result.getResponseBody();
-					assertThat(body).containsEntry("message", "Response took longer than timeout: PT3S");
-				});
+				.expectStatus().isEqualTo(HttpStatus.GATEWAY_TIMEOUT)
+				.expectBody().jsonPath("$.status").isEqualTo(String.valueOf(HttpStatus.GATEWAY_TIMEOUT.value()));
 	}
 
 	@EnableAutoConfiguration


### PR DESCRIPTION
When the underpinning Netty `HttpClient` times out (based, e.g., on the value of `spring.cloud.gateway.httpclient.responseTimeout`), the Gateway returns `500` to its client instead of `504`.

This change wraps the `org.springframework.cloud.gateway.support.TimeoutException` thrown upon the timeout with a `org.springframework.web.server.ResponseStatusException` that sets the status code to `504`.

As an added boon, using `org.springframework.web.server.ResponseStatusException` this way enables the usual error handling mechanisms (error white-page, error attributes) for this type of failure.