### PR TITLE
Modify request_rate_limiter.lua

### DIFF
--- a/spring-cloud-gateway-core/src/main/resources/META-INF/scripts/request_rate_limiter.lua
+++ b/spring-cloud-gateway-core/src/main/resources/META-INF/scripts/request_rate_limiter.lua
@@ -37,6 +37,7 @@ local allowed_num = 0
 if allowed then
   new_tokens = filled_tokens - requested
   allowed_num = 1
+  redis.call("setex", timestamp_key, ttl, now)
 end
 
 --redis.log(redis.LOG_WARNING, "delta " .. delta)
@@ -45,6 +46,5 @@ end
 --redis.log(redis.LOG_WARNING, "new_tokens " .. new_tokens)
 
 redis.call("setex", tokens_key, ttl, new_tokens)
-redis.call("setex", timestamp_key, ttl, now)
 
 return { allowed_num, new_tokens }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -48,7 +48,7 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 				.setReplenishRate(replenishRate));
 
 		// Bursts work
-		for (int i = 0; i < 10; i++) {
+		for (int i = 0; i < 3; i++) {
 			Response response = rateLimiter.isAllowed(routeId, id).block();
 			if ((i & 1) == 0) {
 				assertThat(response.isAllowed()).as("Burst # %s is allowed", i).isTrue();

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -51,15 +51,11 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 		for (int i = 0; i < 3; i++) {
 			Response response = rateLimiter.isAllowed(routeId, id).block();
 			if ((i & 1) == 0) {
+				// it's been past 1200ms when i == 2 and it should replenish once
 				assertThat(response.isAllowed()).as("Burst # %s is allowed", i).isTrue();
 			} else {
 				assertThat(response.isAllowed()).as("Burst # %s is allowed", i).isFalse();
 			}
-			assertThat(response.getHeaders()).containsKey(RedisRateLimiter.REMAINING_HEADER);
-			assertThat(response.getHeaders()).
-					containsEntry(RedisRateLimiter.REPLENISH_RATE_HEADER, String.valueOf(replenishRate));
-			assertThat(response.getHeaders()).
-					containsEntry(RedisRateLimiter.BURST_CAPACITY_HEADER, String.valueOf(burstCapacity));
 			Thread.sleep(600);
 		}
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -31,34 +31,6 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 
 	@Autowired
 	private RedisRateLimiter rateLimiter;
-
-	@Test
-	public void redisRateLimiterInSecond() throws Exception {
-		assumeThat("Ignore on Circle",
-				System.getenv("CIRCLECI"), is(nullValue()));
-
-		String id = UUID.randomUUID().toString();
-
-		int replenishRate = 1;
-		int burstCapacity = replenishRate;
-
-		String routeId = "myroute";
-		rateLimiter.getConfig().put(routeId, new RedisRateLimiter.Config()
-				.setBurstCapacity(burstCapacity)
-				.setReplenishRate(replenishRate));
-
-		// Bursts work
-		for (int i = 0; i < 3; i++) {
-			Response response = rateLimiter.isAllowed(routeId, id).block();
-			if ((i & 1) == 0) {
-				// it's been past 1200ms when i == 2 and it should replenish once
-				assertThat(response.isAllowed()).as("Burst # %s is allowed", i).isTrue();
-			} else {
-				assertThat(response.isAllowed()).as("Burst # %s is allowed", i).isFalse();
-			}
-			Thread.sleep(600);
-		}
-	}
 	
 	@Test
 	public void redisRateLimiterWorks() throws Exception {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -50,7 +50,7 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 		// Bursts work
 		for (int i = 0; i < 10; i++) {
 			Response response = rateLimiter.isAllowed(routeId, id).block();
-			if (i & 1 == 0) {
+			if ((i & 1) == 0) {
 				assertThat(response.isAllowed()).as("Burst # %s is allowed", i).isTrue();
 			} else {
 				assertThat(response.isAllowed()).as("Burst # %s is allowed", i).isFalse();


### PR DESCRIPTION
Update last refresh timestamp only if one request be allowed.

For example. If i set `replenishRate=1` and set `capacity=1`, and i send requests in every 600ms.
Unfortunately, i just got success response in the 1st request, and all failed in others.

If set refresh timestamp with the last allowed request time, i can get one success, one failed, one success, one failed ... ... as i expected.