### PR TITLE
Use EmbeddedRedis to make build self-contained

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 		<java.version>1.8</java.version>
 		<spring-cloud-commons.version>2.0.1.BUILD-SNAPSHOT</spring-cloud-commons.version>
 		<spring-cloud-netflix.version>2.0.1.BUILD-SNAPSHOT</spring-cloud-netflix.version>
+		<embedded-redis.version>0.6</embedded-redis.version>
 	</properties>
 
 	<dependencyManagement>
@@ -110,6 +111,11 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-devtools</artifactId>
 				<version>${spring-boot.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.kstyrc</groupId>
+				<artifactId>embedded-redis</artifactId>
+				<version>${embedded-redis.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/spring-cloud-gateway-core/pom.xml
+++ b/spring-cloud-gateway-core/pom.xml
@@ -116,6 +116,11 @@
 			<artifactId>jackson-module-kotlin</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.github.kstyrc</groupId>
+			<artifactId>embedded-redis</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -2,6 +2,7 @@ package org.springframework.cloud.gateway.filter.ratelimit;
 
 import java.util.UUID;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +11,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.filter.ratelimit.RateLimiter.Response;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.cloud.gateway.test.support.redis.RedisRule;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -28,6 +30,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
 public class RedisRateLimiterTests extends BaseWebClientTests {
+
+	@Rule
+	public final RedisRule redis = RedisRule.bindToPort(6379);
 
 	@Autowired
 	private RedisRateLimiter rateLimiter;

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/support/redis/RedisRule.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/support/redis/RedisRule.java
@@ -1,0 +1,62 @@
+package org.springframework.cloud.gateway.test.support.redis;
+
+import static java.lang.String.format;
+import static java.util.stream.IntStream.range;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import org.junit.rules.ExternalResource;
+import redis.embedded.RedisServer;
+
+public class RedisRule extends ExternalResource {
+
+	public static RedisRule bindToPort(final int port) {
+		return new RedisRule(port);
+	}
+
+	public static RedisRule bindToFirstOpenPort(final int startInclusive, final int endExclusive) {
+		return new RedisRule(findOpenPort(startInclusive, endExclusive));
+	}
+
+	private static int findOpenPort(final int startInclusive, final int endExclusive) {
+		return range(startInclusive, endExclusive)
+				.filter(RedisRule::testPort)
+				.findFirst()
+				.orElseThrow(() ->new IllegalStateException(format(
+						"No open port found in the range [%d, %d]", startInclusive, endExclusive)));
+	}
+
+	private static boolean testPort(int port) {
+		try {
+			new ServerSocket(port).close();
+			return true;
+		} catch (final IOException ex) {
+			return false;
+		}
+	}
+
+	private final int port;
+
+	private RedisServer redisServer;
+
+	private RedisRule(final int port) {
+		this.port = port;
+	}
+
+	@Override
+	protected void before() {
+		try {
+			redisServer = RedisServer.builder().port(port).setting("maxmemory 16MB").build();
+			redisServer.start();
+		} catch (final Exception e) {
+			throw new RuntimeException(format("Error while initializing the Redis server"
+					+ " on port %d", port), e);
+		}
+	}
+
+	@Override
+	protected void after() {
+		redisServer.stop();
+	}
+
+}


### PR DESCRIPTION
This PR introduces a `RedisRule` that is used to bootstrap a local Redis server and make the build self-contained.