### PR TITLE
ObjectProvider.getIfAvailable() is called too frequently, fix this performance problem.

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
@@ -19,10 +19,10 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 
 	private static final Log log = LogFactory.getLog(ForwardRoutingFilter.class);
 
-	private final ObjectProvider<DispatcherHandler> dispatcherHandler;
+	private final DispatcherHandler dispatcherHandler;
 
-	public ForwardRoutingFilter(ObjectProvider<DispatcherHandler> dispatcherHandler) {
-		this.dispatcherHandler = dispatcherHandler;
+	public ForwardRoutingFilter(ObjectProvider<DispatcherHandler> dispatcherHandlerProvider) {
+		this.dispatcherHandler = dispatcherHandlerProvider.getIfAvailable();
 	}
 
 	@Override
@@ -46,6 +46,6 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 			log.trace("Forwarding to URI: "+requestUrl);
 		}
 
-		return this.dispatcherHandler.getIfAvailable().handle(exchange);
+		return this.dispatcherHandler.handle(exchange);
 	}
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -61,14 +61,14 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.s
 public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 	private final HttpClient httpClient;
-	private final ObjectProvider<List<HttpHeadersFilter>> headersFilters;
+	private final List<HttpHeadersFilter> headersFilters;
 	private final HttpClientProperties properties;
 
 	public NettyRoutingFilter(HttpClient httpClient,
-							  ObjectProvider<List<HttpHeadersFilter>> headersFilters,
+							  ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider,
 							  HttpClientProperties properties) {
 		this.httpClient = httpClient;
-		this.headersFilters = headersFilters;
+		this.headersFilters = headersFiltersProvider.getIfAvailable();
 		this.properties = properties;
 	}
 
@@ -92,8 +92,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 		final HttpMethod method = HttpMethod.valueOf(request.getMethod().toString());
 		final String url = requestUrl.toString();
 
-		HttpHeaders filtered = filterRequest(this.headersFilters.getIfAvailable(),
-				exchange);
+		HttpHeaders filtered = filterRequest(this.headersFilters, exchange);
 
 		final DefaultHttpHeaders httpHeaders = new DefaultHttpHeaders();
 		filtered.forEach(httpHeaders::set);
@@ -138,7 +137,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 			}
 
 			HttpHeaders filteredResponseHeaders = HttpHeadersFilter.filter(
-					this.headersFilters.getIfAvailable(), headers, exchange, Type.RESPONSE);
+					this.headersFilters, headers, exchange, Type.RESPONSE);
 			
 			response.getHeaders().putAll(filteredResponseHeaders);
 			HttpStatus status = HttpStatus.resolve(res.status().code());

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
@@ -59,11 +59,11 @@ public class HystrixGatewayFilterFactory extends AbstractGatewayFilterFactory<Hy
 
 	public static final String FALLBACK_URI = "fallbackUri";
 
-	private final ObjectProvider<DispatcherHandler> dispatcherHandler;
+	private final DispatcherHandler dispatcherHandler;
 
-	public HystrixGatewayFilterFactory(ObjectProvider<DispatcherHandler> dispatcherHandler) {
+	public HystrixGatewayFilterFactory(ObjectProvider<DispatcherHandler> dispatcherHandlerProvider) {
 		super(Config.class);
-		this.dispatcherHandler = dispatcherHandler;
+		this.dispatcherHandler = dispatcherHandlerProvider.getIfAvailable();
 	}
 
 	@Override
@@ -167,7 +167,7 @@ public class HystrixGatewayFilterFactory extends AbstractGatewayFilterFactory<Hy
 
 			ServerHttpRequest request = this.exchange.getRequest().mutate().uri(requestUrl).build();
 			ServerWebExchange mutated = exchange.mutate().request(request).build();
-			DispatcherHandler dispatcherHandler = HystrixGatewayFilterFactory.this.dispatcherHandler.getIfAvailable();
+			DispatcherHandler dispatcherHandler = HystrixGatewayFilterFactory.this.dispatcherHandler;
 			return RxReactiveStreams.toObservable(dispatcherHandler.handle(mutated));
 		}
 	}


### PR DESCRIPTION
I used a flame graph tool to watch the performance of spring-cloud-gateway(version 2.0.2.RELEASE), and I found that the following stack trace costs too much cpu: 

```
Total: 744882425 (1.58%)  samples: 743
  [ 0] JVM_GetStackAccessControlContext
  [ 1] java.security.AccessController.getStackAccessControlContext
  [ 2] java.security.AccessController.getContext
  [ 3] org.springframework.beans.factory.support.AbstractBeanFactory.getAccessControlContext
  [ 4] org.springframework.beans.factory.support.AbstractBeanFactory.resolveBeanClass
  [ 5] org.springframework.beans.factory.support.DefaultListableBeanFactory.isAutowireCandidate
  [ 6] org.springframework.beans.factory.support.DefaultListableBeanFactory.isAutowireCandidate
  [ 7] org.springframework.beans.factory.support.DefaultListableBeanFactory.isAutowireCandidate
  [ 8] org.springframework.beans.factory.support.DefaultListableBeanFactory.findAutowireCandidates
  [ 9] org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveMultipleBeans
  [10] org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency
  [11] org.springframework.beans.factory.support.DefaultListableBeanFactory$DependencyObjectProvider.getIfAvailable
  [12] org.springframework.cloud.gateway.filter.NettyRoutingFilter.filter
  [13] org.springframework.cloud.gateway.handler.FilteringWebHandler$GatewayFilterAdapter.filter
  [14] org.springframework.cloud.gateway.filter.OrderedGatewayFilter.filter
  [15] org.springframework.cloud.gateway.handler.FilteringWebHandler$DefaultGatewayFilterChain.lambda$filter$0
  [16] org.springframework.cloud.gateway.handler.FilteringWebHandler$DefaultGatewayFilterChain$$Lambda$784.506293773.get
  [17] reactor.core.publisher.MonoDefer.subscribe
.............
```

the key is that `ObjectProvider.getIfAvailable()` is called every time when a http request come in.
I have tested `ObjectProvider.getIfAvailable()`, at my MacBookPro, it can only run about 10000 times per second, and in the above stack trace, `java.security.AccessController.getStackAccessControlContext` is a native method, this will also switch to kernal state.

So I submit this pull request to fix this performance problem.