### PR TITLE
refactor null safety http method resolving for non standard method

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -88,7 +88,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 		ServerHttpRequest request = exchange.getRequest();
 
-		final HttpMethod method = getMethod(request);
+		final HttpMethod method = HttpMethod.valueOf(request.getMethodValue());
 		final String url = requestUrl.toString();
 
 		HttpHeaders filtered = filterRequest(this.headersFilters.getIfAvailable(),
@@ -164,15 +164,6 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 		}
 
 		return responseFlux.then(chain.filter(exchange));
-	}
-
-	private HttpMethod getMethod(ServerHttpRequest request){
-		org.springframework.http.HttpMethod httpMethod = request.getMethod();
-		if(httpMethod != null){
-			return HttpMethod.valueOf(httpMethod.toString());
-		}else {
-			return HttpMethod.valueOf(request.getMethodValue());
-		}
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -88,7 +88,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 		ServerHttpRequest request = exchange.getRequest();
 
-		final HttpMethod method = HttpMethod.valueOf(request.getMethod().toString());
+		final HttpMethod method = getMethod(request);
 		final String url = requestUrl.toString();
 
 		HttpHeaders filtered = filterRequest(this.headersFilters.getIfAvailable(),
@@ -165,4 +165,14 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 		return responseFlux.then(chain.filter(exchange));
 	}
+
+	private HttpMethod getMethod(ServerHttpRequest request){
+		org.springframework.http.HttpMethod httpMethod = request.getMethod();
+		if(httpMethod != null){
+			return HttpMethod.valueOf(httpMethod.toString());
+		}else {
+			return HttpMethod.valueOf(request.getMethodValue());
+		}
+	}
+
 }


### PR DESCRIPTION
There was a null unsafely execution in process of mapping `org.springframework.http.HttpMethod` to `io.netty.handler.codec.http.HttpMethod`. The case is to proxy non standard methods (like PROPFIND or custom).  Execution of `request.getMethod().toString()` for http method which is not value of org.springframework.http.HttpMethod enum produces NullPointerException in cause of `request.getMethod()` returns `null`. 
This fix should help to prevent such cases.  