### PR TITLE
create HandlerStrategies only one in ModifyRequestBodyGatewayFilterFactory

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
@@ -17,10 +17,13 @@
 
 package org.springframework.cloud.gateway.filter.factory.rewrite;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.cloud.gateway.support.BodyInserterContext;
 import org.springframework.cloud.gateway.support.CachedBodyOutputMessage;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.web.reactive.function.server.HandlerStrategies;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -41,8 +44,11 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 public class ModifyRequestBodyGatewayFilterFactory
 		extends AbstractGatewayFilterFactory<ModifyRequestBodyGatewayFilterFactory.Config> {
 
+	private final List<HttpMessageReader<?>> messageReaders;
+
 	public ModifyRequestBodyGatewayFilterFactory() {
 		super(Config.class);
+		this.messageReaders = HandlerStrategies.withDefaults().messageReaders();
 	}
 
 	@Deprecated
@@ -56,7 +62,7 @@ public class ModifyRequestBodyGatewayFilterFactory
 		return (exchange, chain) -> {
 			Class inClass = config.getInClass();
 
-			ServerRequest serverRequest = new DefaultServerRequest(exchange);
+			ServerRequest serverRequest = new DefaultServerRequest(exchange, messageReaders);
 			//TODO: flux or mono
 			Mono<?> modifiedBody = serverRequest.bodyToMono(inClass)
 					// .log("modify_request_mono", Level.INFO)

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
@@ -61,8 +61,8 @@ public class ModifyRequestBodyGatewayFilterFactory
 	public GatewayFilter apply(Config config) {
 		return (exchange, chain) -> {
 			Class inClass = config.getInClass();
+			ServerRequest serverRequest = new DefaultServerRequest(exchange, this.messageReaders);
 
-			ServerRequest serverRequest = new DefaultServerRequest(exchange, messageReaders);
 			//TODO: flux or mono
 			Mono<?> modifiedBody = serverRequest.bodyToMono(inClass)
 					// .log("modify_request_mono", Level.INFO)


### PR DESCRIPTION
Create `HandlerStrategies` occurs blocking point in `ModifyRequestBodyGatewayFilterFactory`. Issue link is https://github.com/spring-cloud/spring-cloud-gateway/issues/760.
Solution is create once and reuse `HandlerStrategies`, using the constructor. I think this fix should help to prevent performance degradation.