### PR TITLE
Validate that we actually have a hostname when using a load balanced URI

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
@@ -68,6 +68,12 @@ public class RouteToRequestUrlFilter implements GlobalFilter, Ordered {
 			routeUri = URI.create(routeUri.getSchemeSpecificPart());
 		}
 
+		if("lb".equalsIgnoreCase(routeUri.getScheme()) && routeUri.getHost() == null) {
+			//Load balanced URIs should always have a host.  If the host is null it is most
+			//likely because the host name was invalid (for example included an underscore)
+			throw new IllegalStateException("Invalid host: " + routeUri.toString());
+		}
+
 		URI mergedUrl = UriComponentsBuilder.fromUri(uri)
 				// .uri(routeUri)
 				.scheme(routeUri.getScheme())

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
@@ -66,6 +66,14 @@ public class RouteToRequestUrlFilterTests {
 		assertThat(uri).hasScheme("lb").hasHost("myhost");
 	}
 
+	@Test(expected = IllegalStateException.class)
+	public void invalidHost() {
+		MockServerHttpRequest request = MockServerHttpRequest
+				.get("http://localhost/getb")
+				.build();
+		testFilter(request, "lb://my_host");
+	}
+
 	@Test
 	public void happyPathLbPlusScheme() {
 		MockServerHttpRequest request = MockServerHttpRequest


### PR DESCRIPTION
Fixes #779

I thought about putting some logic in the load balanced filter but at that point we dont have the original URI (that I could see anyways).  I can do some validation there in order to keep anything specific out of the `RouteToRequestUrlFilter`.