### PR TITLE
Fix documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1418,7 +1418,7 @@ public GlobalFilter customGlobalPostFilter() {
         })
         .then();
 }
----
+----
 
 === Writing Custom Route Locators and Writers
 


### PR DESCRIPTION
Currently documentation on [site](https://cloud.spring.io/spring-cloud-gateway/single/spring-cloud-gateway.html) looks the following way:
![screen shot 2019-02-14 at 11 26 57 am](https://user-images.githubusercontent.com/1207414/52776968-74b1ca80-304b-11e9-9e5a-5b3418be7b34.png)

This PR fixes an issue.
