### PR TITLE
Allow Security HTTP headers to be disabled

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -19,6 +19,8 @@ package org.springframework.cloud.gateway.filter.factory;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.http.HttpHeaders;
 
+import java.util.List;
+
 /**
  * https://blog.appcanary.com/2017/http-security-headers.html.
  *
@@ -78,20 +80,43 @@ public class SecureHeadersGatewayFilterFactory extends AbstractGatewayFilterFact
 
 		return (exchange, chain) -> {
 			HttpHeaders headers = exchange.getResponse().getHeaders();
+			List<String> disabledHeaders = properties.getDisable();
 
-			// TODO: allow header to be disabled
-			headers.add(X_XSS_PROTECTION_HEADER, properties.getXssProtectionHeader());
-			headers.add(STRICT_TRANSPORT_SECURITY_HEADER,
-					properties.getStrictTransportSecurity());
-			headers.add(X_FRAME_OPTIONS_HEADER, properties.getFrameOptions());
-			headers.add(X_CONTENT_TYPE_OPTIONS_HEADER,
-					properties.getContentTypeOptions());
-			headers.add(REFERRER_POLICY_HEADER, properties.getReferrerPolicy());
-			headers.add(CONTENT_SECURITY_POLICY_HEADER,
-					properties.getContentSecurityPolicy());
-			headers.add(X_DOWNLOAD_OPTIONS_HEADER, properties.getDownloadOptions());
-			headers.add(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
-					properties.getPermittedCrossDomainPolicies());
+			if (!disabledHeaders.contains(X_XSS_PROTECTION_HEADER)) {
+				headers.add(X_XSS_PROTECTION_HEADER, properties.getXssProtectionHeader());
+			}
+
+			if (!disabledHeaders.contains(STRICT_TRANSPORT_SECURITY_HEADER)) {
+				headers.add(STRICT_TRANSPORT_SECURITY_HEADER,
+						properties.getStrictTransportSecurity());
+			}
+
+			if (!disabledHeaders.contains(X_FRAME_OPTIONS_HEADER)) {
+				headers.add(X_FRAME_OPTIONS_HEADER, properties.getFrameOptions());
+			}
+
+			if (!disabledHeaders.contains(X_CONTENT_TYPE_OPTIONS_HEADER)) {
+				headers.add(X_CONTENT_TYPE_OPTIONS_HEADER,
+						properties.getContentTypeOptions());
+			}
+
+			if (!disabledHeaders.contains(REFERRER_POLICY_HEADER)) {
+				headers.add(REFERRER_POLICY_HEADER, properties.getReferrerPolicy());
+			}
+
+			if (!disabledHeaders.contains(CONTENT_SECURITY_POLICY_HEADER)) {
+				headers.add(CONTENT_SECURITY_POLICY_HEADER,
+						properties.getContentSecurityPolicy());
+			}
+
+			if (!disabledHeaders.contains(X_DOWNLOAD_OPTIONS_HEADER)) {
+				headers.add(X_DOWNLOAD_OPTIONS_HEADER, properties.getDownloadOptions());
+			}
+
+			if (!disabledHeaders.contains(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
+				headers.add(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
+						properties.getPermittedCrossDomainPolicies());
+			}
 
 			return chain.filter(exchange);
 		};

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersProperties.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersProperties.java
@@ -18,6 +18,9 @@ package org.springframework.cloud.gateway.filter.factory;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Spencer Gibb
  */
@@ -95,6 +98,8 @@ public class SecureHeadersProperties {
 
 	private String permittedCrossDomainPolicies = X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER_DEFAULT;
 
+	private List<String> disable = new ArrayList<>();
+
 	public String getXssProtectionHeader() {
 		return xssProtectionHeader;
 	}
@@ -159,6 +164,14 @@ public class SecureHeadersProperties {
 		this.permittedCrossDomainPolicies = permittedCrossDomainPolicies;
 	}
 
+	public List<String> getDisable() {
+		return disable;
+	}
+
+	public void setDisable(List<String> disable) {
+		this.disable = disable;
+	}
+
 	@Override
 	public String toString() {
 		final StringBuffer sb = new StringBuffer("SecureHeadersProperties{");
@@ -172,6 +185,7 @@ public class SecureHeadersProperties {
 		sb.append(", downloadOptions='").append(downloadOptions).append('\'');
 		sb.append(", permittedCrossDomainPolicies='").append(permittedCrossDomainPolicies)
 				.append('\'');
+		sb.append(", disable=").append(disable).append(']');
 		sb.append('}');
 		return sb.toString();
 	}


### PR DESCRIPTION
Add property spring.cloud.gateway.filter.secure-headers.disable, which accepts a list of following values.

  - X-Xss-Protection
  - Strict-Transport-Security
  - X-Frame-Options
  - X-Content-Type-Options
  - Referrer-Policy
  - Content-Security-Policy
  - X-Download-Options
  - X-Permitted-Cross-Domain-Policies

The SecureHeaders GatewayFilter Factory won't add specified headers into response.