### PR TITLE
URL Cleanup

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -27,7 +27,7 @@ added after the original pull request but before a merge.
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
   [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
-  [Eclipse Code Formatter Plugin](http://plugins.jetbrains.com/plugin/6546) to import the same file.
+  [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546) to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
@@ -39,6 +39,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow [these conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
+* When writing a commit message please follow [these conventions](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/README.adoc
+++ b/README.adoc
@@ -62,7 +62,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -84,13 +84,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -149,7 +149,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -162,7 +162,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 
@@ -233,7 +233,7 @@ If you need to suppress some rules (e.g. line length needs to be longer), then i
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/>

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -16,7 +16,7 @@ include::intro.adoc[]
 == How to Include Spring Cloud Gateway
 
 To include Spring Cloud Gateway in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-gateway`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-gateway`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 If you include the starter, but, for some reason, you do not want the gateway to be enabled, set `spring.cloud.gateway.enabled=false`.
@@ -34,8 +34,8 @@ IMPORTANT: Spring Cloud Gateway requires the Netty runtime provided by Spring Bo
 == Glossary
 
 * *Route*: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.
-* *Predicate*: This is a http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html[Java 8 Function Predicate]. The input type is a http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html[Spring Framework `ServerWebExchange`]. This allows developers to match on anything from the HTTP request, such as headers or parameters.
-* *Filter*: These are instances http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html[Spring Framework `GatewayFilter`] constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.
+* *Predicate*: This is a https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html[Java 8 Function Predicate]. The input type is a https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html[Spring Framework `ServerWebExchange`]. This allows developers to match on anything from the HTTP request, such as headers or parameters.
+* *Filter*: These are instances https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html[Spring Framework `GatewayFilter`] constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.
 
 [[gateway-how-it-works]]
 == How It Works
@@ -62,7 +62,7 @@ spring:
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]
 ----
@@ -80,7 +80,7 @@ spring:
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]
 ----
@@ -98,7 +98,7 @@ spring:
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]
 ----
@@ -116,7 +116,7 @@ spring:
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p
 ----
@@ -134,7 +134,7 @@ spring:
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+
 ----
@@ -152,7 +152,7 @@ spring:
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org
 ----
@@ -175,7 +175,7 @@ spring:
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET
 ----
@@ -193,7 +193,7 @@ spring:
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}
 ----
@@ -222,7 +222,7 @@ spring:
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz
 ----
@@ -237,7 +237,7 @@ spring:
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.
 ----
@@ -256,7 +256,7 @@ spring:
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24
 ----
@@ -334,7 +334,7 @@ spring:
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar
 ----
@@ -352,7 +352,7 @@ spring:
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar
 ----
@@ -370,7 +370,7 @@ spring:
     gateway:
       routes:
       - id: add_response_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar
 ----
@@ -388,7 +388,7 @@ spring:
     gateway:
       routes:
       - id: dedupe_response_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin
 ----
@@ -402,7 +402,7 @@ The DedupeResponseHeader filter also accepts an optional `strategy` parameter. T
 https://github.com/Netflix/Hystrix[Hystrix] is a library from Netflix that implements the https://martinfowler.com/bliki/CircuitBreaker.html[circuit breaker pattern].
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.
 
-To enable Hystrix GatewayFilters in your project, add a dependency on `spring-cloud-starter-netflix-hystrix` from http://cloud.spring.io/spring-cloud-netflix/[Spring Cloud Netflix].
+To enable Hystrix GatewayFilters in your project, add a dependency on `spring-cloud-starter-netflix-hystrix` from https://cloud.spring.io/spring-cloud-netflix/[Spring Cloud Netflix].
 
 The Hystrix GatewayFilter Factory requires a single `name` parameter, which is the name of the `HystrixCommand`.
 
@@ -414,7 +414,7 @@ spring:
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName
 ----
@@ -545,7 +545,7 @@ spring:
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath
 ----
@@ -563,7 +563,7 @@ spring:
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader
 ----
@@ -618,7 +618,7 @@ spring:
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -648,7 +648,7 @@ spring:
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -668,12 +668,12 @@ spring:
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org
+        - RedirectTo=302, https://acme.org
 ----
 
-This will send a status 302 with a `Location:http://acme.org` header to perform a redirect.
+This will send a status 302 with a `Location:https://acme.org` header to perform a redirect.
 
 === RemoveHopByHopHeadersFilter GatewayFilter Factory
 The RemoveHopByHopHeadersFilter GatewayFilter Factory removes headers from forwarded requests. The default list of headers that is removed comes from the https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3[IETF].
@@ -701,7 +701,7 @@ spring:
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo
 ----
@@ -719,7 +719,7 @@ spring:
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo
 ----
@@ -741,7 +741,7 @@ spring:
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -761,7 +761,7 @@ spring:
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&]+, password=***
 ----
@@ -770,7 +770,7 @@ For a header value of `/42?user=ford&password=omg!what&flag=true`, it will be se
 
 === SaveSession GatewayFilter Factory
 The SaveSession GatewayFilter Factory forces a `WebSession::save` operation _before_ forwarding the call downstream. This is of particular use when
-using something like http://projects.spring.io/spring-session/[Spring Session] with a lazy data store and need to ensure the session state has been saved before making the forwarded call.
+using something like https://projects.spring.io/spring-session/[Spring Session] with a lazy data store and need to ensure the session state has been saved before making the forwarded call.
 
 .application.yml
 [source,yaml]
@@ -780,14 +780,14 @@ spring:
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession
 ----
 
-If you are integrating http://projects.spring.io/spring-security/[Spring Security] with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.
+If you are integrating https://projects.spring.io/spring-security/[Spring Security] with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.
 
 === SecureHeaders GatewayFilter Factory
 The SecureHeaders GatewayFilter Factory adds a number of headers to the response at the reccomendation from https://blog.appcanary.com/2017/http-security-headers.html[this blog post].
@@ -826,7 +826,7 @@ spring:
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -846,7 +846,7 @@ spring:
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar
 ----
@@ -864,11 +864,11 @@ spring:
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401
 ----
@@ -886,14 +886,14 @@ spring:
     gateway:
       routes:
       - id: nameRoot
-        uri: http://nameservice
+        uri: https://nameservice
         predicates:
         - Path=/name/**
         filters:
         - StripPrefix=2
 ----
 
-When a request is made through the gateway to `/name/bar/foo` the request made to `nameservice` will look like `http://nameservice/foo`.
+When a request is made through the gateway to `/name/bar/foo` the request made to `nameservice` will look like `https://nameservice/foo`.
 
 === Retry GatewayFilter Factory
 The Retry GatewayFilter Factory takes `retries`, `statuses`, `methods`, and `series` as parameters.
@@ -1256,13 +1256,13 @@ spring:
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401
 ----
@@ -1376,7 +1376,7 @@ spring:
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET
 ----
@@ -1488,7 +1488,7 @@ To retrieve information about a single route, make a `GET` request to `/actuator
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]
 ----

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
@@ -53,7 +53,7 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.c
 
 /**
  * Depends on `spring-cloud-starter-netflix-hystrix`,
- * {@see http://cloud.spring.io/spring-cloud-netflix/}.
+ * {@see https://cloud.spring.io/spring-cloud-netflix/}.
  *
  * @author Spencer Gibb
  * @author Michele Mancioppi

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -194,7 +194,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * Wraps the route in a Hystrix command. Depends on @{code
 	 * org.springframework.cloud::spring-cloud-starter-netflix-hystrix} being on the
-	 * classpath, {@see http://cloud.spring.io/spring-cloud-netflix/}
+	 * classpath, {@see https://cloud.spring.io/spring-cloud-netflix/}
 	 * @param configConsumer a {@link Consumer} which provides configuration for the
 	 * Hystrix command
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
@@ -550,10 +550,10 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter which forces a {@code WebSession::save} operation before forwarding the
 	 * call downstream. This is of particular use when using something like
-	 * <a href="http://projects.spring.io/spring-session/">Spring Session</a> with a lazy
+	 * <a href="https://projects.spring.io/spring-session/">Spring Session</a> with a lazy
 	 * data store and need to ensure the session state has been saved before making the
 	 * forwarded call. If you are integrating
-	 * <a href="http://projects.spring.io/spring-security/">Spring Security</a> with
+	 * <a href="https://projects.spring.io/spring-security/">Spring Security</a> with
 	 * Spring Session, and want to ensure security details have been forwarded to the
 	 * remote process, this is critical.
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
@@ -617,7 +617,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * Adds hystrix execution exception headers to fallback request. Depends on @{code
 	 * org.springframework.cloud::spring-cloud-starter-netflix-hystrix} being on the
-	 * classpath, {@see http://cloud.spring.io/spring-cloud-netflix/}
+	 * classpath, {@see https://cloud.spring.io/spring-cloud-netflix/}
 	 * @param config a {@link FallbackHeadersGatewayFilterFactory.Config} which provides
 	 * the header names. If header names arguments are not provided, default values are
 	 * used.
@@ -632,7 +632,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * Adds hystrix execution exception headers to fallback request. Depends on @{code
 	 * org.springframework.cloud::spring-cloud-starter-netflix-hystrix} being on the
-	 * classpath, {@see http://cloud.spring.io/spring-cloud-netflix/}
+	 * classpath, {@see https://cloud.spring.io/spring-cloud-netflix/}
 	 * @param configConsumer a {@link Consumer} which can be used to set up the names of
 	 * the headers in the config. If header names arguments are not provided, default
 	 * values are used.

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
@@ -72,7 +72,7 @@ public class ForwardRoutingFilterTests {
 
 	@Test
 	public void shouldNotFilterWhenGatewayRequestUrlSchemeIsNotForward() {
-		URI uri = UriComponentsBuilder.fromUriString("http://endpoint").build().toUri();
+		URI uri = UriComponentsBuilder.fromUriString("https://endpoint").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri);
 		forwardRoutingFilter.filter(exchange, chain);
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/LoadBalancerClientFilterTests.java
@@ -95,7 +95,7 @@ public class LoadBalancerClientFilterTests {
 
 	@Test
 	public void shouldNotFilterWhenGatewayRequestUrlSchemeIsNotLb() {
-		URI uri = UriComponentsBuilder.fromUriString("http://myservice").build().toUri();
+		URI uri = UriComponentsBuilder.fromUriString("https://myservice").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri);
 
 		loadBalancerClientFilter.filter(exchange, chain);
@@ -202,7 +202,7 @@ public class LoadBalancerClientFilterTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("https://localhost")
 				.build();
 
-		URI lbUri = URI.create("http://service1");
+		URI lbUri = URI.create("https://service1");
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		exchange.getAttributes().put(GATEWAY_SCHEME_PREFIX_ATTR, "lb");
 		ServerWebExchange webExchange = testFilter(exchange, lbUri, 443);
@@ -309,7 +309,7 @@ public class LoadBalancerClientFilterTests {
 
 	@Test
 	public void shouldNotFilterWhenGatewaySchemePrefixAttrIsNotLb() {
-		URI uri = UriComponentsBuilder.fromUriString("http://myservice").build().toUri();
+		URI uri = UriComponentsBuilder.fromUriString("https://myservice").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri);
 		exchange.getAttributes().put(GATEWAY_SCHEME_PREFIX_ATTR, "xx");
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
@@ -46,7 +46,7 @@ public class RouteToRequestUrlFilterTests {
 		MockServerHttpRequest request = MockServerHttpRequest
 				.get("http://localhost/get?a=b").build();
 
-		ServerWebExchange webExchange = testFilter(request, "http://myhost/mypath");
+		ServerWebExchange webExchange = testFilter(request, "https://myhost/mypath");
 		URI uri = webExchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).hasScheme("http").hasHost("myhost").hasPath("/get")
 				.hasParameter("a", "b");
@@ -74,7 +74,7 @@ public class RouteToRequestUrlFilterTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost/getb")
 				.build();
 
-		ServerWebExchange webExchange = testFilter(request, "lb:http://myhost");
+		ServerWebExchange webExchange = testFilter(request, "lb:https://myhost");
 		URI uri = webExchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).hasScheme("http").hasHost("myhost");
 		String schemePrefix = webExchange
@@ -87,7 +87,7 @@ public class RouteToRequestUrlFilterTests {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost/get")
 				.build();
 
-		ServerWebExchange webExchange = testFilter(request, "http://myhost");
+		ServerWebExchange webExchange = testFilter(request, "https://myhost");
 		URI uri = webExchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).hasScheme("http").hasHost("myhost");
 	}
@@ -105,7 +105,7 @@ public class RouteToRequestUrlFilterTests {
 		MockServerHttpRequest request = MockServerHttpRequest.method(HttpMethod.GET, url)
 				.build();
 
-		ServerWebExchange webExchange = testFilter(request, "http://myhost");
+		ServerWebExchange webExchange = testFilter(request, "https://myhost");
 		URI uri = webExchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).hasScheme("http").hasHost("myhost").hasParameter("a", "b")
 				.hasParameter("c", "d[]");
@@ -129,7 +129,7 @@ public class RouteToRequestUrlFilterTests {
 		MockServerHttpRequest request = MockServerHttpRequest.method(HttpMethod.GET, url)
 				.build();
 
-		ServerWebExchange webExchange = testFilter(request, "http://myhost");
+		ServerWebExchange webExchange = testFilter(request, "https://myhost");
 		URI uri = webExchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).hasScheme("http").hasHost("myhost")
 				.hasParameter("key[]", "test= key").hasParameter("start", "1533108081");
@@ -153,7 +153,7 @@ public class RouteToRequestUrlFilterTests {
 				.build();
 
 		ServerWebExchange webExchange = testFilter(request,
-				"http://myhost/abc%20def/get");
+				"https://myhost/abc%20def/get");
 		URI uri = webExchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).hasScheme("http").hasHost("myhost").hasPath("/abc def/get");
 
@@ -171,7 +171,7 @@ public class RouteToRequestUrlFilterTests {
 		MockServerHttpRequest request = MockServerHttpRequest.method(HttpMethod.GET, url)
 				.build();
 
-		ServerWebExchange webExchange = testFilter(request, "http://myhost");
+		ServerWebExchange webExchange = testFilter(request, "https://myhost");
 
 		URI uri = webExchange.getRequiredAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).hasScheme("http").hasHost("myhost").hasParameter("a", "b")

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToGatewayFilterFactoryTests.java
@@ -43,7 +43,7 @@ public class RedirectToGatewayFilterFactoryTests extends BaseWebClientTests {
 	public void redirectToFilterWorks() {
 		testClient.get().uri("/").header("Host", "www.redirectto.org").exchange()
 				.expectStatus().isEqualTo(HttpStatus.FOUND).expectHeader()
-				.valueEquals(HttpHeaders.LOCATION, "http://example.org");
+				.valueEquals(HttpHeaders.LOCATION, "https://example.org");
 	}
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryIntegrationTests.java
@@ -91,11 +91,11 @@ public class RequestHeaderToRequestUriGatewayFilterFactoryIntegrationTests
 			return builder.routes()
 					.route(r -> r.host("**.changeuri.org").and().header("X-Next-Url")
 							.filters(f -> f.requestHeaderToRequestUri("X-Next-Url"))
-							.uri("http://example.com"))
+							.uri("https://example.com"))
 					.route(r -> r.host("**.changeuri.org").and().query("url")
 							.filters(f -> f.changeRequestUri(e -> Optional.of(URI.create(
 									e.getRequest().getQueryParams().getFirst("url")))))
-							.uri("http://example.com"))
+							.uri("https://example.com"))
 					.build();
 		}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryTests.java
@@ -43,7 +43,7 @@ public class RequestHeaderToRequestUriGatewayFilterFactoryTests {
 		RequestHeaderToRequestUriGatewayFilterFactory factory = new RequestHeaderToRequestUriGatewayFilterFactory();
 		GatewayFilter filter = factory.apply(c -> c.setName("X-CF-Forwarded-Url"));
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
-				.header("X-CF-Forwarded-Url", "http://example.com").build();
+				.header("X-CF-Forwarded-Url", "https://example.com").build();
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR,
 				URI.create("http://localhost"));
@@ -55,7 +55,7 @@ public class RequestHeaderToRequestUriGatewayFilterFactoryTests {
 		ServerWebExchange webExchange = captor.getValue();
 		URI uri = (URI) webExchange.getAttributes().get(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).isNotNull();
-		assertThat(uri.toString()).isEqualTo("http://example.com");
+		assertThat(uri.toString()).isEqualTo("https://example.com");
 	}
 
 	@Test

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -168,7 +168,7 @@ public class XForwardedHeadersFilterTests {
 	@Test
 	public void prefixToInfer() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest
-				.get("http://originalhost:8080/prefix/get")
+				.get("https://originalhost:8080/prefix/get")
 				.remoteAddress(
 						new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
 				.build();
@@ -180,11 +180,11 @@ public class XForwardedHeadersFilterTests {
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
 		originalUris.add(UriComponentsBuilder
-				.fromUriString("http://originalhost:8080/prefix/get/").build().toUri()); // trailing
+				.fromUriString("https://originalhost:8080/prefix/get/").build().toUri()); // trailing
 																							// slash
 		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
 		URI requestUri = UriComponentsBuilder
-				.fromUriString("http://routedservice:8090/get").build().toUri();
+				.fromUriString("https://routedservice:8090/get").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);
@@ -197,7 +197,7 @@ public class XForwardedHeadersFilterTests {
 	@Test
 	public void prefixAddedWithoutTrailingSlash() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest
-				.get("http://originalhost:8080/foo/bar")
+				.get("https://originalhost:8080/foo/bar")
 				.remoteAddress(
 						new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
 				.build();
@@ -209,9 +209,9 @@ public class XForwardedHeadersFilterTests {
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
 		originalUris.add(UriComponentsBuilder
-				.fromUriString("http://originalhost:8080/foo/bar").build().toUri());
+				.fromUriString("https://originalhost:8080/foo/bar").build().toUri());
 		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
-		URI requestUri = UriComponentsBuilder.fromUriString("http://routedservice:8090/")
+		URI requestUri = UriComponentsBuilder.fromUriString("https://routedservice:8090/")
 				.build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
 
@@ -223,7 +223,7 @@ public class XForwardedHeadersFilterTests {
 	@Test
 	public void noPrefixToInfer() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest
-				.get("http://originalhost:8080/get")
+				.get("https://originalhost:8080/get")
 				.remoteAddress(
 						new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
 				.build();
@@ -239,10 +239,10 @@ public class XForwardedHeadersFilterTests {
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
 		originalUris.add(UriComponentsBuilder
-				.fromUriString("http://originalhost:8080/get/").build().toUri());
+				.fromUriString("https://originalhost:8080/get/").build().toUri());
 		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
 		URI requestUri = UriComponentsBuilder
-				.fromUriString("http://routedservice:8090/get").build().toUri();
+				.fromUriString("https://routedservice:8090/get").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);
@@ -253,7 +253,7 @@ public class XForwardedHeadersFilterTests {
 	@Test
 	public void routedPathInRequestPathButNotPrefix() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest
-				.get("http://originalhost:8080/get")
+				.get("https://originalhost:8080/get")
 				.remoteAddress(
 						new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
 				.build();
@@ -269,10 +269,10 @@ public class XForwardedHeadersFilterTests {
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
 		originalUris.add(UriComponentsBuilder
-				.fromUriString("http://originalhost:8080/one/two/three").build().toUri());
+				.fromUriString("https://originalhost:8080/one/two/three").build().toUri());
 		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
 		URI requestUri = UriComponentsBuilder
-				.fromUriString("http://routedservice:8090/two").build().toUri();
+				.fromUriString("https://routedservice:8090/two").build().toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactoryTests.java
@@ -70,7 +70,7 @@ public class BetweenRoutePredicateFactoryTests {
 	}
 
 	static ServerWebExchange getExchange() {
-		MockServerHttpRequest request = MockServerHttpRequest.get("http://example.com")
+		MockServerHttpRequest request = MockServerHttpRequest.get("https://example.com")
 				.build();
 		return MockServerWebExchange.from(request);
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CloudFoundryRouteServiceRoutePredicateFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CloudFoundryRouteServiceRoutePredicateFactoryIntegrationTests.java
@@ -88,7 +88,7 @@ public class CloudFoundryRouteServiceRoutePredicateFactoryIntegrationTests
 			return builder.routes().route(r -> r.cloudFoundryRouteService().and()
 					.header("Host", "dsl.routeservice.example.com")
 					.filters(f -> f.requestHeaderToRequestUri("X-CF-Forwarded-Url"))
-					.uri("http://example.com")).build();
+					.uri("https://example.com")).build();
 		}
 
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactoryTests.java
@@ -33,7 +33,7 @@ public class CookieRoutePredicateFactoryTests extends BaseWebClientTests {
 
 	@Test
 	public void noCookiesForYou() {
-		MockServerHttpRequest request = MockServerHttpRequest.get("http://example.com")
+		MockServerHttpRequest request = MockServerHttpRequest.get("https://example.com")
 				.build();
 		MockServerWebExchange exchange = MockServerWebExchange.from(request);
 
@@ -45,7 +45,7 @@ public class CookieRoutePredicateFactoryTests extends BaseWebClientTests {
 
 	@Test
 	public void okOneCookieForYou() {
-		MockServerHttpRequest request = MockServerHttpRequest.get("http://example.com")
+		MockServerHttpRequest request = MockServerHttpRequest.get("https://example.com")
 				.cookie(new HttpCookie("yourcookie", "sugar"),
 						new HttpCookie("mycookie", "chip"))
 				.build();

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocatorTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocatorTests.java
@@ -55,7 +55,7 @@ public class RouteDefinitionRouteLocatorTests {
 		gatewayProperties.setRoutes(Arrays.asList(new RouteDefinition() {
 			{
 				setId("foo");
-				setUri(URI.create("http://foo.example.com"));
+				setUri(URI.create("https://foo.example.com"));
 				setPredicates(
 						Arrays.asList(new PredicateDefinition("Host=*.example.com")));
 				setFilters(Arrays.asList(

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/RouteTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/RouteTests.java
@@ -30,7 +30,7 @@ public class RouteTests {
 	@Test
 	public void defeaultHttpPort() {
 		Route route = Route.async().id("1").predicate(exchange -> true)
-				.uri("http://acme.com").build();
+				.uri("https://acme.com").build();
 
 		assertThat(route.getUri()).hasHost("acme.com").hasScheme("http").hasPort(80);
 	}
@@ -46,7 +46,7 @@ public class RouteTests {
 	@Test
 	public void fullUri() {
 		Route route = Route.async().id("1").predicate(exchange -> true)
-				.uri("http://acme.com:8080").build();
+				.uri("https://acme.com:8080").build();
 
 		assertThat(route.getUri()).hasHost("acme.com").hasScheme("http").hasPort(8080);
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/builder/RouteBuilderTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/builder/RouteBuilderTests.java
@@ -45,7 +45,7 @@ public class RouteBuilderTests {
 		RouteLocator routeLocator = this.routeLocatorBuilder.routes()
 				.route("test1", r -> r.host("*.somehost.org").and().path("/somepath")
 						.filters(f -> f.addRequestHeader("header1", "header-value-1"))
-						.uri("http://someuri"))
+						.uri("https://someuri"))
 				.route("test2", r -> r.host("*.somehost2.org")
 						.filters(f -> f.addResponseHeader("header-response-1",
 								"header-response-1"))
@@ -55,7 +55,7 @@ public class RouteBuilderTests {
 		StepVerifier.create(routeLocator.getRoutes())
 				.expectNextMatches(
 						r -> r.getId().equals("test1") && r.getFilters().size() == 1
-								&& r.getUri().equals(URI.create("http://someuri:80")))
+								&& r.getUri().equals(URI.create("https://someuri:80")))
 				.expectNextMatches(
 						r -> r.getId().equals("test2") && r.getFilters().size() == 1
 								&& r.getUri()

--- a/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/builder/RouteDslTests.kt
+++ b/spring-cloud-gateway-core/src/test/kotlin/org/springframework/cloud/gateway/route/builder/RouteDslTests.kt
@@ -85,12 +85,12 @@ class RouteDslTests {
     @Test
     fun dslWithFunctionParameters() {
         val routerLocator = builder.routes {
-            route(id = "test1", order = 10, uri = "http://httpbin.org") {
+            route(id = "test1", order = 10, uri = "https://httpbin.org") {
                 host("**.abc.org")
             }
-            route(id = "test2", order = 10, uri = "http://someurl") {
+            route(id = "test2", order = 10, uri = "https://someurl") {
                 host("**.abc.org")
-                uri("http://override-url")
+                uri("https://override-url")
             }
         }
 
@@ -106,7 +106,7 @@ class RouteDslTests {
                 })
                 .expectNextMatches({
                     it.id == "test2" &&
-                            it.uri == URI.create("http://override-url:80") &&
+                            it.uri == URI.create("https://override-url:80") &&
                             it.order == 10 &&
                             it.predicate.apply(MockServerWebExchange
                                     .from(MockServerHttpRequest

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -222,7 +222,7 @@ spring:
         predicates:
         - Host=**.redirectto.org
         filters:
-        - RedirectTo=302, http://example.org
+        - RedirectTo=302, https://example.org
 
       # =====================================
       - id: remove_request_header_test


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://httpbin.org:80 (200) with 11 occurrences could not be migrated:  
   ([https](https://httpbin.org:80) result NotSslRecordException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://acme.com:8080 (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://acme.com:8080 ([https](https://acme.com:8080) result ConnectTimeoutException).
* [ ] http://acme.org (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://acme.org ([https](https://acme.org) result ConnectTimeoutException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://endpoint (UnknownHostException) with 1 occurrences migrated to:  
  https://endpoint ([https](https://endpoint) result UnknownHostException).
* [ ] http://foo.example.com (UnknownHostException) with 1 occurrences migrated to:  
  https://foo.example.com ([https](https://foo.example.com) result UnknownHostException).
* [ ] http://myhost (UnknownHostException) with 5 occurrences migrated to:  
  https://myhost ([https](https://myhost) result UnknownHostException).
* [ ] http://myhost/abc%20def/get (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost/abc%20def/get ([https](https://myhost/abc%20def/get) result UnknownHostException).
* [ ] http://myhost/mypath (UnknownHostException) with 1 occurrences migrated to:  
  https://myhost/mypath ([https](https://myhost/mypath) result UnknownHostException).
* [ ] http://myservice (UnknownHostException) with 2 occurrences migrated to:  
  https://myservice ([https](https://myservice) result UnknownHostException).
* [ ] http://nameservice (UnknownHostException) with 1 occurrences migrated to:  
  https://nameservice ([https](https://nameservice) result UnknownHostException).
* [ ] http://nameservice/foo (UnknownHostException) with 1 occurrences migrated to:  
  https://nameservice/foo ([https](https://nameservice/foo) result UnknownHostException).
* [ ] http://originalhost:8080/foo/bar (UnknownHostException) with 2 occurrences migrated to:  
  https://originalhost:8080/foo/bar ([https](https://originalhost:8080/foo/bar) result UnknownHostException).
* [ ] http://originalhost:8080/get (UnknownHostException) with 2 occurrences migrated to:  
  https://originalhost:8080/get ([https](https://originalhost:8080/get) result UnknownHostException).
* [ ] http://originalhost:8080/get/ (UnknownHostException) with 1 occurrences migrated to:  
  https://originalhost:8080/get/ ([https](https://originalhost:8080/get/) result UnknownHostException).
* [ ] http://originalhost:8080/one/two/three (UnknownHostException) with 1 occurrences migrated to:  
  https://originalhost:8080/one/two/three ([https](https://originalhost:8080/one/two/three) result UnknownHostException).
* [ ] http://originalhost:8080/prefix/get (UnknownHostException) with 1 occurrences migrated to:  
  https://originalhost:8080/prefix/get ([https](https://originalhost:8080/prefix/get) result UnknownHostException).
* [ ] http://originalhost:8080/prefix/get/ (UnknownHostException) with 1 occurrences migrated to:  
  https://originalhost:8080/prefix/get/ ([https](https://originalhost:8080/prefix/get/) result UnknownHostException).
* [ ] http://override-url (UnknownHostException) with 1 occurrences migrated to:  
  https://override-url ([https](https://override-url) result UnknownHostException).
* [ ] http://override-url:80 (UnknownHostException) with 1 occurrences migrated to:  
  https://override-url:80 ([https](https://override-url:80) result UnknownHostException).
* [ ] http://routedservice:8090/ (UnknownHostException) with 1 occurrences migrated to:  
  https://routedservice:8090/ ([https](https://routedservice:8090/) result UnknownHostException).
* [ ] http://routedservice:8090/get (UnknownHostException) with 2 occurrences migrated to:  
  https://routedservice:8090/get ([https](https://routedservice:8090/get) result UnknownHostException).
* [ ] http://routedservice:8090/two (UnknownHostException) with 1 occurrences migrated to:  
  https://routedservice:8090/two ([https](https://routedservice:8090/two) result UnknownHostException).
* [ ] http://service1 (UnknownHostException) with 1 occurrences migrated to:  
  https://service1 ([https](https://service1) result UnknownHostException).
* [ ] http://someuri (UnknownHostException) with 1 occurrences migrated to:  
  https://someuri ([https](https://someuri) result UnknownHostException).
* [ ] http://someuri:80 (UnknownHostException) with 1 occurrences migrated to:  
  https://someuri:80 ([https](https://someuri:80) result UnknownHostException).
* [ ] http://someurl (UnknownHostException) with 1 occurrences migrated to:  
  https://someurl ([https](https://someurl) result UnknownHostException).
* [ ] http://www.uri-destination.org (UnknownHostException) with 1 occurrences migrated to:  
  https://www.uri-destination.org ([https](https://www.uri-destination.org) result UnknownHostException).
* [ ] http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html ([https](https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html) result 404).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://acme.com with 1 occurrences migrated to:  
  https://acme.com ([https](https://acme.com) result 200).
* [ ] http://cloud.spring.io/spring-cloud-netflix/ with 5 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-netflix/ ([https](https://cloud.spring.io/spring-cloud-netflix/) result 200).
* [ ] http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html with 1 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html ([https](https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html) result 200).
* [ ] http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html ([https](https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html) result 200).
* [ ] http://example.com with 8 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://example.org with 34 occurrences migrated to:  
  https://example.org ([https](https://example.org) result 200).
* [ ] http://httpbin.org with 1 occurrences migrated to:  
  https://httpbin.org ([https](https://httpbin.org) result 200).
* [ ] http://projects.spring.io/spring-cloud/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-cloud/ ([https](https://projects.spring.io/spring-cloud/) result 200).
* [ ] http://projects.spring.io/spring-security/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-security/ ([https](https://projects.spring.io/spring-security/) result 200).
* [ ] http://projects.spring.io/spring-session/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-session/ ([https](https://projects.spring.io/spring-session/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 2 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://docs.spring.io with 1 occurrences migrated to:  
  https://docs.spring.io ([https](https://docs.spring.io) result 301).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 51 occurrences
* http://localhost/ with 2 occurrences
* http://localhost/abc with 1 occurrences
* http://localhost/get with 10 occurrences
* http://localhost/get?a=b with 2 occurrences
* http://localhost/get?a=b&c=d with 4 occurrences
* http://localhost/get?key with 1 occurrences
* http://localhost/getb with 3 occurrences
* http://localhost:3001 with 1 occurrences
* http://localhost:8008/configserver/foo/default with 1 occurrences
* http://localhost:8080/flakey with 1 occurrences
* http://localhost:8080/get with 6 occurrences
* http://localhost:8080/upload with 1 occurrences
* http://localhost:9000/foos/ with 4 occurrences
* http://localhost:9080 with 1 occurrences
* http://localhost:9994 with 3 occurrences