### PR TITLE
URL Cleanup

### DIFF
--- a/1.0.x/spring-cloud-gateway.xml
+++ b/1.0.x/spring-cloud-gateway.xml
@@ -13,7 +13,7 @@
 </preface>
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
-<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
+<simpara>To include Spring Cloud Gateway in your project add a dependency with group <literal>org.springframework.cloud</literal> and artifact id <literal>spring-cloud-gateway-mvc</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link> for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 </chapter>
 <chapter xml:id="_building_a_gateway_using_spring_mvc">
 <title>Building a Gateway Using Spring MVC</title>

--- a/2.0.x/spring-cloud-gateway.xml
+++ b/2.0.x/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 </chapter>
@@ -25,10 +25,10 @@ for details on setting up your build system with the current Spring Cloud Releas
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -59,7 +59,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -78,7 +78,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -97,7 +97,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Betweeen=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -116,7 +116,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -135,7 +135,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -154,7 +154,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org</programlisting>
 </para>
@@ -173,7 +173,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -192,7 +192,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}</programlisting>
 </para>
@@ -212,7 +212,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -227,7 +227,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -246,7 +246,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -269,7 +269,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -288,7 +288,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -307,7 +307,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -326,7 +326,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: hytstrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -345,7 +345,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -377,7 +377,7 @@ for details on setting up your build system with the current Spring Cloud Releas
       routes:
       # =====================================
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RequestRateLimiter=10, 20, #{@userKeyResolver}</programlisting>
 </para>
@@ -405,12 +405,12 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removenonproxyheaders_gatewayfilter_factory">
 <title>RemoveNonProxyHeaders GatewayFilter Factory</title>
@@ -456,7 +456,7 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -475,7 +475,7 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -494,7 +494,7 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -574,7 +574,7 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -595,7 +595,7 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -614,11 +614,11 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -680,13 +680,13 @@ KeyResolver userKeyResolver() {
       routes:
       # =====================================
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>

--- a/2.1.x/spring-cloud-gateway.xml
+++ b/2.1.x/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -37,10 +37,10 @@ working with Spring Cloud Gateway.</simpara>
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -73,7 +73,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -91,7 +91,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -109,7 +109,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -127,7 +127,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -145,7 +145,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -163,7 +163,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -183,7 +183,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -201,7 +201,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -224,7 +224,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -238,7 +238,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -256,7 +256,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -343,7 +343,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -361,7 +361,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -379,7 +379,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_response_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -397,7 +397,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: dedupe_response_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - DedupeResponseHeader=Access-Control-Allow-Credentials Access-Control-Allow-Origin</programlisting>
 </para>
@@ -409,7 +409,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -419,7 +419,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -549,7 +549,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -567,7 +567,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -614,7 +614,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -641,7 +641,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -662,12 +662,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removehopbyhopheadersfilter_gatewayfilter_factory">
 <title>RemoveHopByHopHeadersFilter GatewayFilter Factory</title>
@@ -712,7 +712,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -730,7 +730,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -751,7 +751,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -771,7 +771,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -781,7 +781,7 @@ and have it applied to all routes.</simpara>
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -790,14 +790,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -869,7 +869,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -889,7 +889,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -907,11 +907,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1312,13 +1312,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1426,7 +1426,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1544,7 +1544,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>

--- a/font-awesome/font/fontawesome-webfont.svg
+++ b/font-awesome/font/fontawesome-webfont.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" >
 <svg xmlns="http://www.w3.org/2000/svg">
 <metadata></metadata>
 <defs>

--- a/spring-cloud-gateway.xml
+++ b/spring-cloud-gateway.xml
@@ -14,7 +14,7 @@
 <chapter xml:id="gateway-starter">
 <title>How to Include Spring Cloud Gateway</title>
 <simpara>To include Spring Cloud Gateway in your project use the starter with group <literal>org.springframework.cloud</literal>
-and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="http://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
+and artifact id <literal>spring-cloud-starter-gateway</literal>. See the <link xl:href="https://projects.spring.io/spring-cloud/">Spring Cloud Project page</link>
 for details on setting up your build system with the current Spring Cloud Release Train.</simpara>
 <simpara>If you include the starter, but, for some reason, you do not want the gateway to be enabled, set <literal>spring.cloud.gateway.enabled=false</literal>.</simpara>
 <important>
@@ -37,10 +37,10 @@ working with Spring Cloud Gateway.</simpara>
 <simpara><emphasis role="strong">Route</emphasis>: Route the basic building block of the gateway. It is defined by an ID, a destination URI, a collection of predicates and a collection of filters. A route is matched if aggregate predicate is true.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
+<simpara><emphasis role="strong">Predicate</emphasis>: This is a <link xl:href="https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html">Java 8 Function Predicate</link>. The input type is a <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html">Spring Framework <literal>ServerWebExchange</literal></link>. This allows developers to match on anything from the HTTP request, such as headers or parameters.</simpara>
 </listitem>
 <listitem>
-<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
+<simpara><emphasis role="strong">Filter</emphasis>: These are instances <link xl:href="https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html">Spring Framework <literal>GatewayFilter</literal></link> constructed in with a specific factory. Here, requests and responses can be modified before or after sending the downstream request.</simpara>
 </listitem>
 </itemizedlist>
 </chapter>
@@ -73,7 +73,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: after_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - After=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -91,7 +91,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: before_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Before=2017-01-20T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -109,7 +109,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: between_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]</programlisting>
 </para>
@@ -127,7 +127,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: cookie_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Cookie=chocolate, ch.p</programlisting>
 </para>
@@ -145,7 +145,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: header_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Header=X-Request-Id, \d+</programlisting>
 </para>
@@ -163,7 +163,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Host=**.somehost.org,**.anotherhost.org</programlisting>
 </para>
@@ -183,7 +183,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: method_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Method=GET</programlisting>
 </para>
@@ -201,7 +201,7 @@ working with Spring Cloud Gateway.</simpara>
     gateway:
       routes:
       - id: host_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment},/bar/{segment}</programlisting>
 </para>
@@ -224,7 +224,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=baz</programlisting>
 </para>
@@ -238,7 +238,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: query_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Query=foo, ba.</programlisting>
 </para>
@@ -256,7 +256,7 @@ String segment = uriVariables.get("segment");</programlisting>
     gateway:
       routes:
       - id: remoteaddr_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - RemoteAddr=192.168.1.1/24</programlisting>
 </para>
@@ -343,7 +343,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestHeader=X-Request-Foo, Bar</programlisting>
 </para>
@@ -361,7 +361,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_parameter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddRequestParameter=foo, bar</programlisting>
 </para>
@@ -379,7 +379,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
     gateway:
       routes:
       - id: add_request_header_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - AddResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -390,7 +390,7 @@ If two hops of trusted infrastructure are required before Spring Cloud Gateway i
 <title>Hystrix GatewayFilter Factory</title>
 <simpara><link xl:href="https://github.com/Netflix/Hystrix">Hystrix</link> is a library from Netflix that implements the <link xl:href="https://martinfowler.com/bliki/CircuitBreaker.html">circuit breaker pattern</link>.
 The Hystrix GatewayFilter allows you to introduce circuit breakers to your gateway routes, protecting your services from cascading failures and allowing you to provide fallback responses in the event of downstream failures.</simpara>
-<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="http://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
+<simpara>To enable Hystrix GatewayFilters in your project, add a dependency on <literal>spring-cloud-starter-netflix-hystrix</literal> from <link xl:href="https://cloud.spring.io/spring-cloud-netflix/">Spring Cloud Netflix</link>.</simpara>
 <simpara>The Hystrix GatewayFilter Factory requires a single <literal>name</literal> parameter, which is the name of the <literal>HystrixCommand</literal>.</simpara>
 <formalpara>
 <title>application.yml</title>
@@ -400,7 +400,7 @@ The Hystrix GatewayFilter allows you to introduce circuit breakers to your gatew
     gateway:
       routes:
       - id: hystrix_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - Hystrix=myCommandName</programlisting>
 </para>
@@ -530,7 +530,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PrefixPath=/mypath</programlisting>
 </para>
@@ -548,7 +548,7 @@ their default values:</simpara>
     gateway:
       routes:
       - id: preserve_host_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - PreserveHostHeader</programlisting>
 </para>
@@ -595,7 +595,7 @@ spring.cloud.gateway.routes[0].filters[0]=RequestRateLimiter=2, 2, #{@userkeyres
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -622,7 +622,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: requestratelimiter_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: RequestRateLimiter
           args:
@@ -643,12 +643,12 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: prefixpath_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
-        - RedirectTo=302, http://acme.org</programlisting>
+        - RedirectTo=302, https://acme.org</programlisting>
 </para>
 </formalpara>
-<simpara>This will send a status 302 with a <literal>Location:http://acme.org</literal> header to perform a redirect.</simpara>
+<simpara>This will send a status 302 with a <literal>Location:https://acme.org</literal> header to perform a redirect.</simpara>
 </section>
 <section xml:id="_removehopbyhopheadersfilter_gatewayfilter_factory">
 <title>RemoveHopByHopHeadersFilter GatewayFilter Factory</title>
@@ -693,7 +693,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removerequestheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveRequestHeader=X-Request-Foo</programlisting>
 </para>
@@ -711,7 +711,7 @@ KeyResolver userKeyResolver() {
     gateway:
       routes:
       - id: removeresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RemoveResponseHeader=X-Response-Foo</programlisting>
 </para>
@@ -732,7 +732,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewritepath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
@@ -752,7 +752,7 @@ and have it applied to all routes.</simpara>
     gateway:
       routes:
       - id: rewriteresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - RewriteResponseHeader=X-Response-Foo, , password=[^&amp;]+, password=***</programlisting>
 </para>
@@ -762,7 +762,7 @@ and have it applied to all routes.</simpara>
 <section xml:id="_savesession_gatewayfilter_factory">
 <title>SaveSession GatewayFilter Factory</title>
 <simpara>The SaveSession GatewayFilter Factory forces a <literal>WebSession::save</literal> operation <emphasis>before</emphasis> forwarding the call downstream. This is of particular use when
-using something like <link xl:href="http://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
+using something like <link xl:href="https://projects.spring.io/spring-session/">Spring Session</link> with a lazy data store and need to ensure the session state has been saved before making the forwarded call.</simpara>
 <formalpara>
 <title>application.yml</title>
 <para>
@@ -771,14 +771,14 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: save_session
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/**
         filters:
         - SaveSession</programlisting>
 </para>
 </formalpara>
-<simpara>If you are integrating <link xl:href="http://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
+<simpara>If you are integrating <link xl:href="https://projects.spring.io/spring-security/">Spring Security</link> with Spring Session, and want to ensure security details have been forwarded to the remote process, this is critical.</simpara>
 </section>
 <section xml:id="_secureheaders_gatewayfilter_factory">
 <title>SecureHeaders GatewayFilter Factory</title>
@@ -850,7 +850,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setpath_route
-        uri: http://example.org
+        uri: https://example.org
         predicates:
         - Path=/foo/{segment}
         filters:
@@ -870,7 +870,7 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setresponseheader_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetResponseHeader=X-Response-Foo, Bar</programlisting>
 </para>
@@ -888,11 +888,11 @@ using something like <link xl:href="http://projects.spring.io/spring-session/">S
     gateway:
       routes:
       - id: setstatusstring_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=BAD_REQUEST
       - id: setstatusint_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1293,13 +1293,13 @@ or check if an exchange has already been routed.</simpara>
     gateway:
       routes:
       - id: setstatus_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - name: SetStatus
           args:
             status: 401
       - id: setstatusshortcut_route
-        uri: http://example.org
+        uri: https://example.org
         filters:
         - SetStatus=401</programlisting>
 </para>
@@ -1407,7 +1407,7 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]: "'/${remain
       globalcors:
         corsConfigurations:
           '[/**]':
-            allowedOrigins: "http://docs.spring.io"
+            allowedOrigins: "https://docs.spring.io"
             allowedMethods:
             - GET</programlisting>
 </para>
@@ -1525,7 +1525,7 @@ management.endpoints.web.exposure.include=gateway</programlisting>
     "args": {"_genkey_0":"/first"}
   }],
   "filters": [],
-  "uri": "http://www.uri-destination.org",
+  "uri": "https://www.uri-destination.org",
   "order": 0
 }]</screen>
 <simpara>The following table describes the structure of the response.</simpara>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://httpbin.org:80 (200) with 9 occurrences could not be migrated:  
   ([https](https://httpbin.org:80) result NotSslRecordException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://acme.org (ConnectTimeoutException) with 6 occurrences migrated to:  
  https://acme.org ([https](https://acme.org) result ConnectTimeoutException).
* [ ] http://www.uri-destination.org (UnknownHostException) with 2 occurrences migrated to:  
  https://www.uri-destination.org ([https](https://www.uri-destination.org) result UnknownHostException).
* [ ] http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html (301) with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html ([https](https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/GatewayFilter.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://cloud.spring.io/spring-cloud-netflix/ with 2 occurrences migrated to:  
  https://cloud.spring.io/spring-cloud-netflix/ ([https](https://cloud.spring.io/spring-cloud-netflix/) result 200).
* [ ] http://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html with 3 occurrences migrated to:  
  https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html ([https](https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html) result 200).
* [ ] http://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html with 3 occurrences migrated to:  
  https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html ([https](https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html) result 200).
* [ ] http://example.org with 90 occurrences migrated to:  
  https://example.org ([https](https://example.org) result 200).
* [ ] http://projects.spring.io/spring-cloud/ with 4 occurrences migrated to:  
  https://projects.spring.io/spring-cloud/ ([https](https://projects.spring.io/spring-cloud/) result 200).
* [ ] http://projects.spring.io/spring-security/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-security/ ([https](https://projects.spring.io/spring-security/) result 200).
* [ ] http://projects.spring.io/spring-session/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-session/ ([https](https://projects.spring.io/spring-session/) result 200).
* [ ] http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd with 1 occurrences migrated to:  
  https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd ([https](https://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd) result 200).
* [ ] http://docs.spring.io with 2 occurrences migrated to:  
  https://docs.spring.io ([https](https://docs.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 4 occurrences
* http://localhost:3001 with 2 occurrences
* http://localhost:8080/flakey with 2 occurrences
* http://localhost:8080/upload with 2 occurrences
* http://localhost:9994 with 8 occurrences
* http://nameservice with 2 occurrences
* http://nameservice/foo with 4 occurrences
* http://www.w3.org/1999/xlink with 4 occurrences
* http://www.w3.org/2000/svg with 1 occurrences