### PR TITLE
Add methods using custom spec to GatewayFilterSpec::modifyResponseBody() and GatewayFilterSpec::modifyRequestBody()

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -222,7 +222,6 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <R> the new request body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
-	// TODO: setup custom spec
 	public <T, R> GatewayFilterSpec modifyRequestBody(Class<T> inClass, Class<R> outClass,
 			RewriteFunction<T, R> rewriteFunction) {
 		return filter(getBean(ModifyRequestBodyGatewayFilterFactory.class)
@@ -248,9 +247,33 @@ public class GatewayFilterSpec extends UriSpec {
 	}
 
 	/**
+	 * A filter that can be used to modify the request body. This filter is BETA and may
+	 * be subject to change in a future release.
+	 * @param configConsumer request spec for response modification
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 * <pre>
+	 * {@code
+	 * ...
+	 * .modifyRequestBody(c -> c
+	 *		.setInClass(Some.class)
+	 *		.setOutClass(SomeOther.class)
+ 	 *		.setInHints(hintsIn)
+	 *		.setOutHints(hintsOut)
+	 *		.setRewriteFunction(rewriteFunction))
+	 * }
+	 * </pre>
+
+	 */
+	public <T, R> GatewayFilterSpec modifyRequestBody(
+			Consumer<ModifyRequestBodyGatewayFilterFactory.Config> configConsumer) {
+		return filter(getBean(ModifyRequestBodyGatewayFilterFactory.class)
+				.apply(configConsumer));
+	}
+
+	/**
 	 * A filter that can be used to modify the response body This filter is BETA and may
 	 * be subject to change in a future release.
-	 * @param inClass the class to conver the response body to
+	 * @param inClass the class to convert the response body to
 	 * @param outClass the class the Gateway will add to the response before it is
 	 * returned to the client
 	 * @param rewriteFunction the {@link RewriteFunction} that transforms the response
@@ -268,7 +291,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter that can be used to modify the response body This filter is BETA and may
 	 * be subject to change in a future release.
-	 * @param inClass the class to conver the response body to
+	 * @param inClass the class to convert the response body to
 	 * @param outClass the class the Gateway will add to the response before it is
 	 * returned to the client
 	 * @param newContentType the new Content-Type header to be returned
@@ -285,6 +308,28 @@ public class GatewayFilterSpec extends UriSpec {
 		return filter(getBean(ModifyResponseBodyGatewayFilterFactory.class)
 				.apply(c -> c.setRewriteFunction(inClass, outClass, rewriteFunction)
 						.setNewContentType(newContentType)));
+	}
+
+	/**
+	 * A filter that can be used to modify the response body using custom spec.
+	 * This filter is BETA and may be subject to change in a future release.
+	 * @param configConsumer response spec for response modification
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 * <pre>
+	 * {@code
+	 * ...
+	 * .modifyResponseBody(c -> c
+	 *		.setInClass(Some.class)
+	 *		.setOutClass(SomeOther.class)
+	 *		.setOutHints(hintsOut)
+	 *		.setRewriteFunction(rewriteFunction))
+	 * }
+	 * </pre>
+	 */
+	public <T, R> GatewayFilterSpec modifyResponseBody(
+			Consumer<ModifyResponseBodyGatewayFilterFactory.Config> configConsumer) {
+		return filter(getBean(ModifyResponseBodyGatewayFilterFactory.class)
+				.apply(configConsumer));
 	}
 
 	/**

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -70,6 +70,8 @@ import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ServerWebExchange;
 
+import com.re6exp.svetlitsa.filters.Token;
+
 /**
  * Applies specific filters to routes.
  */

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -70,8 +70,6 @@ import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ServerWebExchange;
 
-import com.re6exp.svetlitsa.filters.Token;
-
 /**
  * Applies specific filters to routes.
  */
@@ -303,7 +301,6 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
-	// TODO: setup custom spec
 	public <T, R> GatewayFilterSpec modifyResponseBody(Class<T> inClass,
 			Class<R> outClass, String newContentType,
 			RewriteFunction<T, R> rewriteFunction) {


### PR DESCRIPTION
Hey there,

I added a custom specification used to modify the request / response body. In those places where I expected to be these methods, there were TODOs. Please add this PR to the code base.

Great job guys! This code now works exactly as I expected! Thanks!

P.S. Please do not remove using hints from the request and response. They add extra flexibility to us.
