### PR TITLE
fix problem:when redis is cluster,the limit redis script is not work …

### DIFF
--- a/spring-cloud-gateway-core/src/main/resources/META-INF/scripts/request_rate_limiter.lua
+++ b/spring-cloud-gateway-core/src/main/resources/META-INF/scripts/request_rate_limiter.lua
@@ -1,6 +1,4 @@
-local tokens_key = KEYS[1]
-local timestamp_key = KEYS[2]
---redis.log(redis.LOG_WARNING, "tokens_key " .. tokens_key)
+--redis.log(redis.LOG_WARNING, "tokens_key " .. KEYS[1])
 
 local rate = tonumber(ARGV[1])
 local capacity = tonumber(ARGV[2])
@@ -17,13 +15,13 @@ local ttl = math.floor(fill_time*2)
 --redis.log(redis.LOG_WARNING, "filltime " .. fill_time)
 --redis.log(redis.LOG_WARNING, "ttl " .. ttl)
 
-local last_tokens = tonumber(redis.call("get", tokens_key))
+local last_tokens = tonumber(redis.call("get", KEYS[1]))
 if last_tokens == nil then
   last_tokens = capacity
 end
 --redis.log(redis.LOG_WARNING, "last_tokens " .. last_tokens)
 
-local last_refreshed = tonumber(redis.call("get", timestamp_key))
+local last_refreshed = tonumber(redis.call("get", KEYS[2]))
 if last_refreshed == nil then
   last_refreshed = 0
 end
@@ -44,7 +42,7 @@ end
 --redis.log(redis.LOG_WARNING, "allowed_num " .. allowed_num)
 --redis.log(redis.LOG_WARNING, "new_tokens " .. new_tokens)
 
-redis.call("setex", tokens_key, ttl, new_tokens)
-redis.call("setex", timestamp_key, ttl, now)
+redis.call("setex", KEYS[1], ttl, new_tokens)
+redis.call("setex", KEYS[2], ttl, now)
 
 return { allowed_num, new_tokens }


### PR DESCRIPTION
when redis is cluster,the limit redis script is not work，in redis,All keys must be on one slot ,so,all the keys that the script uses should be passed using the KEYS array