### PR TITLE
Override the uri method with URI as its parameter

### DIFF
--- a/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
+++ b/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
@@ -222,6 +222,16 @@ public class ProxyExchange<T> {
 		}
 		return this;
 	}
+	
+	/**
+	 * Sets the uri for the backend call when triggered by the HTTP methods.
+	 * @param uri the backend uri to send the request to
+	 * @return this for convenience
+	 */
+	public ProxyExchange<T> uri(URI uri) {
+		this.uri = uri;
+		return this;
+	}
 
 	/**
 	 * Sets the uri for the backend call when triggered by the HTTP methods.
@@ -230,12 +240,11 @@ public class ProxyExchange<T> {
 	 */
 	public ProxyExchange<T> uri(String uri) {
 		try {
-			this.uri = new URI(uri);
+			return this.uri(new URI(uri));
 		}
 		catch (URISyntaxException e) {
 			throw new IllegalStateException("Cannot create URI", e);
 		}
-		return this;
 	}
 
 	public String path() {


### PR DESCRIPTION
Normally we'll use URIComponentBuilder to build a URI, then we have to use its .toUriString() method, it may not be necessary but directly pass URI type would be convenient