### PR TITLE
Do not pass `forward` URI scheme along.

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
@@ -227,7 +227,7 @@ public class HystrixGatewayFilterFactory
 			// TODO: assume always?
 			boolean encoded = containsEncodedParts(uri);
 			URI requestUrl = UriComponentsBuilder.fromUri(uri).host(null).port(null)
-					.uri(this.fallbackUri).build(encoded).toUri();
+					.uri(this.fallbackUri).scheme(null).build(encoded).toUri();
 			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
 			addExceptionDetails();
 


### PR DESCRIPTION
We require the `forward:` scheme for the `fallbackUri`, but it's never used, as the request will either go to an internal endpoint via `DispatcherHandler` or if the endpoint is not there, it can be redirected via a different filter to an external app, via the service URI or via `lb:`. In both cases, `forward:` scheme will never be used (the forward filter that might catch it will not verify the `scheme` from this URI, but from the one passed explicitly in the gateway filter). Moreover, it causes https://github.com/spring-cloud/spring-cloud-gateway/issues/646 if used with an external load-balanced endpoint. By setting it null, it will still work fine internally via `DispatcherHandler`, while proper schemes, either from external service URI or evaluated by the LoadBalancer will be used.