### PR TITLE
Suppprt remapping headers in request

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -342,7 +342,7 @@ spring:
 This will add `X-Request-Foo:Bar` header to the downstream request's headers for all matching requests.
 
 === MapRequestHeader GatewayFilter Factory
-The MapRequestHeader GatewayFilter Factory takes a name and value parameter. It creates a new named header (config name) and the value is extracted out of some existing named header (config value) in the input. If the input header does not exist then the filter has no impact.
+The MapRequestHeader GatewayFilter Factory takes a name and value parameter. It creates a new named header (config name) and the value is extracted out of an existing named header (config value) from the incoming http request. If the input header does not exist then the filter has no impact. If the new named header already exists then it's values will be augmented with the new values.
 
 .application.yml
 [source,yaml]
@@ -357,7 +357,7 @@ spring:
         - MapRequestHeader=X-Request-Foo, Bar
 ----
 
-This will add `X-Request-Foo:Bar` header to the downstream request's with the same value that the `Bar` header had.
+This will add `X-Request-Foo:<values>` header to the downstream request's with updated values from the incoming http request `Bar` header.
 
 === AddRequestParameter GatewayFilter Factory
 The AddRequestParameter GatewayFilter Factory takes a name and value parameter.

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -341,6 +341,24 @@ spring:
 
 This will add `X-Request-Foo:Bar` header to the downstream request's headers for all matching requests.
 
+=== MapRequestHeader GatewayFilter Factory
+The MapRequestHeader GatewayFilter Factory takes a name and value parameter. It creates a new named header (config name) and the value is extracted out of some existing named header (config value) in the input. If the input header does not exist then the filter has no impact.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: add_request_header_route
+        uri: https://example.org
+        filters:
+        - AddRequestHeader=X-Request-Foo, Bar
+----
+
+This will add `X-Request-Foo:Bar` header to the downstream request's with the same value that the `Bar` header had.
+
 === AddRequestParameter GatewayFilter Factory
 The AddRequestParameter GatewayFilter Factory takes a name and value parameter.
 

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -354,7 +354,7 @@ spring:
       - id: add_request_header_route
         uri: https://example.org
         filters:
-        - AddRequestHeader=X-Request-Foo, Bar
+        - MapRequestHeader=X-Request-Foo, Bar
 ----
 
 This will add `X-Request-Foo:Bar` header to the downstream request's with the same value that the `Bar` header had.

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -62,6 +62,7 @@ import org.springframework.cloud.gateway.filter.factory.DedupeResponseHeaderGate
 import org.springframework.cloud.gateway.filter.factory.FallbackHeadersGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.HystrixGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.MapRequestHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.PrefixPathGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.PreserveHostHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RedirectToGatewayFilterFactory;
@@ -390,6 +391,11 @@ public class GatewayAutoConfiguration {
 	@Bean
 	public AddRequestHeaderGatewayFilterFactory addRequestHeaderGatewayFilterFactory() {
 		return new AddRequestHeaderGatewayFilterFactory();
+	}
+	
+	@Bean
+	public MapRequestHeaderGatewayFilterFactory mapRequestHeaderGatewayFilterFactory() {
+		return new MapRequestHeaderGatewayFilterFactory();
 	}
 
 	@Bean

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+
+/**
+ * @author Tony Clarke
+ */
+public class MapRequestHeaderGatewayFilterFactory
+		extends AbstractNameValueGatewayFilterFactory {
+
+	@Override
+	public GatewayFilter apply(NameValueConfig config) {
+		return (exchange, chain) -> {
+			if (!exchange.getRequest().getHeaders().containsKey(config.getValue())) {
+				return chain.filter(exchange);
+			}
+			List<String> headerValues = exchange.getRequest().getHeaders().get(config.getValue());
+			String value = toCommaDelimitedString(headerValues);
+			ServerHttpRequest request = exchange.getRequest().mutate()
+					.header(config.getName(), value).build();
+
+			return chain.filter(exchange.mutate().request(request).build());
+		};
+	}
+	
+	private String toCommaDelimitedString(List<String> headerValues) {
+		StringBuilder builder = new StringBuilder();
+		for (Iterator<String> it = headerValues.iterator(); it.hasNext(); ) {
+			String val = it.next();
+			builder.append(val);
+			if (it.hasNext()) {
+				builder.append(", ");
+			}
+		}
+		return builder.toString();
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactory.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import java.util.Iterator;
 import java.util.List;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -25,8 +24,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 /**
  * @author Tony Clarke
  */
-public class MapRequestHeaderGatewayFilterFactory
-		extends AbstractNameValueGatewayFilterFactory {
+public class MapRequestHeaderGatewayFilterFactory extends AbstractNameValueGatewayFilterFactory {
 
 	@Override
 	public GatewayFilter apply(NameValueConfig config) {
@@ -35,24 +33,12 @@ public class MapRequestHeaderGatewayFilterFactory
 				return chain.filter(exchange);
 			}
 			List<String> headerValues = exchange.getRequest().getHeaders().get(config.getValue());
-			String value = toCommaDelimitedString(headerValues);
+
 			ServerHttpRequest request = exchange.getRequest().mutate()
-					.header(config.getName(), value).build();
+					.headers(i -> i.addAll(config.getName(), headerValues)).build();
 
 			return chain.filter(exchange.mutate().request(request).build());
 		};
-	}
-	
-	private String toCommaDelimitedString(List<String> headerValues) {
-		StringBuilder builder = new StringBuilder();
-		for (Iterator<String> it = headerValues.iterator(); it.hasNext(); ) {
-			String val = it.next();
-			builder.append(val);
-			if (it.hasNext()) {
-				builder.append(", ");
-			}
-		}
-		return builder.toString();
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactoryTests.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.assertj.core.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactoryTests.java
@@ -16,8 +16,11 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.assertj.core.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -37,6 +40,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.cloud.gateway.test.TestUtils.getMap;
+import static org.springframework.cloud.gateway.test.TestUtils.getMultiValuedHeader;
 
 /**
  * @author Tony Clarke
@@ -57,13 +61,13 @@ public class MapRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTest
 				});
 	}
 	
+	@SuppressWarnings("unchecked")
 	@Test
 	public void mapRequestHeaderWithMultiValueFilterWorks() {
-		testClient.get().uri("/headers").header("Host", "www.addrequestheader.org").header("a", "tome", "toyou")
-				.exchange().expectBody(Map.class).consumeWith(result -> {
-					Map<String, Object> headers = getMap(result.getResponseBody(),
-							"headers");
-					assertThat(headers).containsEntry("X-Request-Example", "tome, toyou");
+		testClient.get().uri("/multivalueheaders").header("Host", "www.addrequestheader.org").header("a", "tome", "toyou")
+				.exchange().expectBody(Set.class).consumeWith(result -> {
+					List<String> multiValuedHeader = getMultiValuedHeader(result.getResponseBody(), "X-Request-Example");
+					assertThat(multiValuedHeader).contains("tome", "toyou");
 				});
 	}
 	

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/MapRequestHeaderGatewayFilterFactoryTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.cloud.gateway.test.TestUtils.getMap;
+
+/**
+ * @author Tony Clarke
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DirtiesContext
+@ActiveProfiles(profiles = "request-map-header-web-filter")
+public class MapRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTests {
+
+	@Test
+	public void mapRequestHeaderFilterWorks() {
+		testClient.get().uri("/headers").header("Host", "www.addrequestheader.org").header("a", "tome")
+				.exchange().expectBody(Map.class).consumeWith(result -> {
+					Map<String, Object> headers = getMap(result.getResponseBody(),
+							"headers");
+					assertThat(headers).containsEntry("X-Request-Example", "tome");
+				});
+	}
+	
+	@Test
+	public void mapRequestHeaderWithMultiValueFilterWorks() {
+		testClient.get().uri("/headers").header("Host", "www.addrequestheader.org").header("a", "tome", "toyou")
+				.exchange().expectBody(Map.class).consumeWith(result -> {
+					Map<String, Object> headers = getMap(result.getResponseBody(),
+							"headers");
+					assertThat(headers).containsEntry("X-Request-Example", "tome, toyou");
+				});
+	}
+	
+	@Test
+	public void mapRequestHeaderWithNullValueFilterWorks() {
+		testClient.get().uri("/headers").header("Host", "www.addrequestheader.org").header("a", (String)null)
+				.exchange().expectBody(Map.class).consumeWith(result -> {
+					Map<String, Object> headers = getMap(result.getResponseBody(),
+							"headers");
+					assertThat(headers).doesNotContainKey("X-Request-Example");
+				});
+	}
+	
+	@Test
+	public void mapRequestHeaderWhenInputHeaderDoesNotExist() {
+		testClient.get().uri("/headers").header("Host", "www.addrequestheader.org")
+				.exchange().expectBody(Map.class).consumeWith(result -> {
+					Map<String, Object> headers = getMap(result.getResponseBody(),
+							"headers");
+					assertThat(headers).doesNotContainKey("X-Request-Example");
+				});
+	}
+
+
+	@EnableAutoConfiguration
+	@SpringBootConfiguration
+	@Import(DefaultTestConfig.class)
+	public static class TestConfig {
+
+		@Value("${test.uri}")
+		String uri;
+
+		@Bean
+		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
+			return builder.routes().route("add_request_header_java_test",
+					r -> r.path("/headers").and().host("**.addrequestheaderjava.org")
+							.filters(f -> f.prefixPath("/httpbin")
+									.addRequestHeader("X-Request-Acme", "ValueB"))
+							.uri(uri))
+					.build();
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
@@ -73,8 +73,8 @@ public class BaseWebClientTests {
 		this.baseUri = baseUri;
 		this.webClient = WebClient.builder().clientConnector(httpConnector)
 				.baseUrl(this.baseUri).build();
-		this.testClient = WebTestClient.bindToServer(httpConnector).baseUrl(this.baseUri).responseTimeout(Duration.ofHours(1))
-				.build();
+		this.testClient = WebTestClient.bindToServer(httpConnector)
+				.baseUrl(this.baseUri).build();
 	}
 
 	@Configuration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
@@ -73,7 +74,7 @@ public class BaseWebClientTests {
 		this.baseUri = baseUri;
 		this.webClient = WebClient.builder().clientConnector(httpConnector)
 				.baseUrl(this.baseUri).build();
-		this.testClient = WebTestClient.bindToServer(httpConnector).baseUrl(this.baseUri)
+		this.testClient = WebTestClient.bindToServer(httpConnector).baseUrl(this.baseUri).responseTimeout(Duration.ofHours(1))
 				.build();
 	}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
@@ -20,7 +20,6 @@ import java.time.Duration;
 
 import com.netflix.loadbalancer.Server;
 import com.netflix.loadbalancer.ServerList;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -57,6 +59,12 @@ public class HttpBinCompatibleController {
 		Map<String, Object> result = new HashMap<>();
 		result.put("headers", getHeaders(exchange));
 		return result;
+	}
+
+	@RequestMapping(path = "/multivalueheaders", method = { RequestMethod.GET,
+			RequestMethod.POST }, produces = MediaType.APPLICATION_JSON_VALUE)
+	public Set<Entry<String, List<String>>> multiValueHeaders(ServerWebExchange exchange) {
+		return getMutliValuedHeaders(exchange);
 	}
 
 	@RequestMapping(path = "/delay/{sec}", produces = MediaType.APPLICATION_JSON_VALUE)
@@ -133,6 +141,10 @@ public class HttpBinCompatibleController {
 	@RequestMapping("/status/{status}")
 	public ResponseEntity<String> status(@PathVariable int status) {
 		return ResponseEntity.status(status).body("Failed with " + status);
+	}
+
+	public Set<Entry<String, List<String>>> getMutliValuedHeaders(ServerWebExchange exchange) {
+		return exchange.getRequest().getHeaders().entrySet();
 	}
 
 	public Map<String, String> getHeaders(ServerWebExchange exchange) {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/TestUtils.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/TestUtils.java
@@ -16,12 +16,16 @@
 
 package org.springframework.cloud.gateway.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.ClientResponse;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb
@@ -32,6 +36,15 @@ public class TestUtils {
 	public static Map<String, Object> getMap(Map response, String key) {
 		assertThat(response).containsKey(key).isInstanceOf(Map.class);
 		return (Map<String, Object>) response.get(key);
+	}
+
+	public static List<String> getMultiValuedHeader(Set<Map<String, List<String>>> response, String key) {
+		Optional<Map<String, List<String>>> findFirst = response.stream().filter(i -> i.containsKey(key)).findFirst();
+		if(!findFirst.isPresent()) {
+			return Collections.emptyList();
+		} else {
+			return findFirst.get().get(key);
+		}
 	}
 
 	public static void assertStatus(ClientResponse response, HttpStatus status) {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/TestUtils.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/TestUtils.java
@@ -16,8 +16,6 @@
 
 package org.springframework.cloud.gateway.test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +24,8 @@ import java.util.Set;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.client.ClientResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb

--- a/spring-cloud-gateway-core/src/test/resources/application-request-map-header-web-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-request-map-header-web-filter.yml
@@ -2,9 +2,15 @@ spring:
   cloud:
     gateway:
       routes:
-      - id: add_request_header_test
+      - id: add_request_header_test_singleresponse
         uri: ${test.uri}
         predicates:
         - Path=/headers
+        filters:
+        - MapRequestHeader=X-Request-Example, a
+      - id: add_request_header_test_multiresponse
+        uri: ${test.uri}
+        predicates:
+        - Path=/multivalueheaders
         filters:
         - MapRequestHeader=X-Request-Example, a

--- a/spring-cloud-gateway-core/src/test/resources/application-request-map-header-web-filter.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-request-map-header-web-filter.yml
@@ -1,0 +1,10 @@
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: add_request_header_test
+        uri: ${test.uri}
+        predicates:
+        - Path=/headers
+        filters:
+        - MapRequestHeader=X-Request-Example, a

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -14,7 +14,7 @@ spring:
         corsConfigurations:
           '[/**]':
             maxAge: 10
-            allowedOrigins: "*"
+            allowedOrigins: "www.path.org"
             allowedMethods:
             - GET
       default-filters:

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -14,7 +14,7 @@ spring:
         corsConfigurations:
           '[/**]':
             maxAge: 10
-            allowedOrigins: "www.path.org"
+            allowedOrigins: "*"
             allowedMethods:
             - GET
       default-filters:


### PR DESCRIPTION
The MapRequestHeader GatewayFilter Factory takes a name and value parameter. It creates a new named header (config name) and the value is extracted out of some existing named header (config value) in the input. If the input header does not exist then the filter has no impact.