### PR TITLE
Fixes gh-1137 | request param can be removed before routing the request

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -730,6 +730,24 @@ To remove any kind of sensitive header you should configure this filter for any 
 want to do so.  In addition you can configure this filter once using `spring.cloud.gateway.default-filters`
 and have it applied to all routes.
 
+=== RemoveRequestParameter GatewayFilter Factory
+The RemoveRequestParameter GatewayFilter Factory takes a `name` parameter. It is the name of the query parameter to be removed.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: removerequestparameter_route
+        uri: https://example.org
+        filters:
+        - RemoveRequestParameter=foo
+----
+
+This will remove the `foo` parameter before it is sent downstream.
+
 === RewritePath GatewayFilter Factory
 The RewritePath GatewayFilter Factory takes a path `regexp` parameter and a `replacement` parameter. This uses Java regular expressions for a flexible way to rewrite the request path.
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.springframework.util.CollectionUtils.unmodifiableMultiValueMap;
+
+/**
+ * @author Thirunavukkarasu Ravichandran
+ */
+public class RemoveRequestParameterGatewayFilterFactory
+		extends AbstractGatewayFilterFactory<AbstractGatewayFilterFactory.NameConfig> {
+
+	public RemoveRequestParameterGatewayFilterFactory() {
+		super(NameConfig.class);
+	}
+
+	@Override
+	public List<String> shortcutFieldOrder() {
+		return Arrays.asList(NAME_KEY);
+	}
+
+	@Override
+	public GatewayFilter apply(NameConfig config) {
+		return (exchange, chain) -> {
+			ServerHttpRequest request = exchange.getRequest();
+			MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>(
+					request.getQueryParams());
+			queryParams.remove(config.getName());
+
+			URI newUri = UriComponentsBuilder.fromUri(request.getURI())
+					.replaceQueryParams(unmodifiableMultiValueMap(queryParams))
+					.build(true).toUri();
+
+			ServerHttpRequest updatedRequest = exchange.getRequest().mutate().uri(newUri)
+					.build();
+
+			return chain.filter(exchange.mutate().request(updatedRequest).build());
+		};
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -47,6 +47,7 @@ import org.springframework.cloud.gateway.filter.factory.PrefixPathGatewayFilterF
 import org.springframework.cloud.gateway.filter.factory.PreserveHostHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RedirectToGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RemoveRequestHeaderGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.RemoveRequestParameterGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RemoveResponseHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RequestHeaderToRequestUriGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.RequestRateLimiterGatewayFilterFactory;
@@ -422,6 +423,17 @@ public class GatewayFilterSpec extends UriSpec {
 	public GatewayFilterSpec removeRequestHeader(String headerName) {
 		return filter(getBean(RemoveRequestHeaderGatewayFilterFactory.class)
 				.apply(c -> c.setName(headerName)));
+	}
+
+	/**
+	 * A filter that will remove a request param before the request is routed by the
+	 * Gateway.
+	 * @param paramName the name of the header to remove
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec removeRequestParameter(String paramName) {
+		return filter(getBean(RemoveRequestParameterGatewayFilterFactory.class)
+				.apply(c -> c.setName(paramName)));
 	}
 
 	/**

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory.NameConfig;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Thirunavukkarasu Ravichandran
+ */
+public class RemoveRequestParameterGatewayFilterFactoryTests {
+
+	private ServerWebExchange exchange;
+
+	private GatewayFilterChain filterChain;
+
+	private ArgumentCaptor<ServerWebExchange> captor;
+
+	@Before
+	public void setUp() {
+		filterChain = mock(GatewayFilterChain.class);
+		captor = ArgumentCaptor.forClass(ServerWebExchange.class);
+		when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
+
+	}
+
+	@Test
+	public void removeRequestParameterFilterWorks() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+				.queryParam("foo", singletonList("bar")).build();
+		exchange = MockServerWebExchange.from(request);
+		NameConfig config = new NameConfig();
+		config.setName("foo");
+		GatewayFilter filter = new RemoveRequestParameterGatewayFilterFactory()
+				.apply(config);
+
+		filter.filter(exchange, filterChain);
+
+		ServerHttpRequest actualRequest = captor.getValue().getRequest();
+		assertThat(actualRequest.getQueryParams()).doesNotContainKey("foo");
+	}
+
+	@Test
+	public void removeRequestParameterFilterWorksWhenParamIsNotPresentInRequest() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+				.build();
+		exchange = MockServerWebExchange.from(request);
+		NameConfig config = new NameConfig();
+		config.setName("foo");
+		GatewayFilter filter = new RemoveRequestParameterGatewayFilterFactory()
+				.apply(config);
+
+		filter.filter(exchange, filterChain);
+
+		ServerHttpRequest actualRequest = captor.getValue().getRequest();
+		assertThat(actualRequest.getQueryParams()).doesNotContainKey("foo");
+	}
+
+	@Test
+	public void removeRequestParameterFilterShouldOnlyRemoveSpecifiedParam() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+				.queryParam("foo", "bar").queryParam("abc", "xyz").build();
+		exchange = MockServerWebExchange.from(request);
+		NameConfig config = new NameConfig();
+		config.setName("foo");
+		GatewayFilter filter = new RemoveRequestParameterGatewayFilterFactory()
+				.apply(config);
+
+		filter.filter(exchange, filterChain);
+
+		ServerHttpRequest actualRequest = captor.getValue().getRequest();
+		assertThat(actualRequest.getQueryParams()).doesNotContainKey("foo");
+		assertThat(actualRequest.getQueryParams()).containsEntry("abc",
+				singletonList("xyz"));
+	}
+
+}


### PR DESCRIPTION
RemoveRequestParameter GatewayFilter Factory
The RemoveRequestParameter GatewayFilter Factory takes a `name` parameter. It is the name of the query parameter to be removed. Fixes #1137
