### PR TITLE
Fixes gh-1167 Spring Cloud Gateway RouteLocator Java Code Can not get…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -252,6 +252,7 @@ $ touch .springformat
 ==== Intellij IDEA
 
 In order to setup Intellij you should import our coding conventions, inspection profiles and set up the checkstyle plugin.
+The following files can be found in the https://github.com/spring-cloud/spring-cloud-build/tree/master/spring-cloud-build-tools[Spring Cloud Build] project.
 
 .spring-cloud-build-tools/
 ----

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -21,7 +21,7 @@ for details on setting up your build system with the current Spring Cloud Releas
 
 If you include the starter, but, for some reason, you do not want the gateway to be enabled, set `spring.cloud.gateway.enabled=false`.
 
-IMPORTANT: Spring Cloud Gateway is built upon https://spring.io/projects/spring-boot#learn[Spring Boot 2.0],
+IMPORTANT: Spring Cloud Gateway is built upon https://spring.io/projects/spring-boot#learn[Spring Boot 2.x],
 https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html[Spring WebFlux],
 and https://projectreactor.io/docs[Project Reactor].  As a consequence
 many of the familiar synchronous libraries (Spring Data and Spring Security, for example) and patterns you may
@@ -1725,6 +1725,29 @@ The table below summarises the Spring Cloud Gateway actuator endpoints. Note tha
 | Remove an existing route from the gateway.
 
 |===
+
+[[troubleshooting]]
+== Troubleshooting
+
+=== Log Levels
+
+Below are some useful loggers that contain valuable trouble shooting infomration at the `DEBUG` and `TRACE` levels.
+
+- `org.springframework.cloud.gateway`
+- `org.springframework.http.server.reactive`
+- `org.springframework.web.reactive`
+- `org.springframework.boot.autoconfigure.web`
+- `reactor.netty`
+- `redisratelimiter`
+
+=== Wiretap
+
+The Reactor Netty `HttpClient` and `HttpServer` can have wiretap enabled. When combined
+with setting the `reactor.netty` log level to `DEBUG` or `TRACE` will enable logging of
+information such as headers and bodies sent and received across the wire. To enable this,
+set `spring.cloud.gateway.httpserver.wiretap=true` and/or
+`spring.cloud.gateway.httpclient.wiretap=true` for the `HttpServer` and `HttpClient`
+respectively.
 
 == Developer Guide
 

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1444,12 +1444,12 @@ A new, more verbose format has been added to Gateway. This adds more detail to e
 ]
 ----
 
-To enable this feature, set the following property:
+This feature is enabled by default. To disable it, set the following property:
 
 .application.properties
 [source,properties]
 ----
-spring.cloud.gateway.actuator.verbose.enabled=true
+spring.cloud.gateway.actuator.verbose.enabled=false
 ----
 
 This will default to true in a future release.

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -263,6 +263,28 @@ spring:
 
 This route would match if the remote address of the request was, for example, `192.168.1.10`.
 
+=== Weight Route Predicate Factory
+The Weight Route Predicate Factory takes two argument group and weight. The weights are calculated per group.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: weight_high
+        uri: https://weighthigh.org
+        predicates:
+        - Weight=group1, 8
+      - id: weight_low
+        uri: https://weightlow.org
+        predicates:
+        - Weight=group1, 2
+----
+
+This route would forward ~80% of traffic to https://weighthigh.org and ~20% of traffic to https://weighlow.org
+
 ==== Modifying the way remote addresses are resolved
 By default the RemoteAddr Route Predicate Factory uses the remote address from the incoming request.
 This may not match the actual client IP address if Spring Cloud Gateway sits behind a proxy layer.
@@ -1155,7 +1177,7 @@ spring:
 
 To enable Gateway Metrics add spring-boot-starter-actuator as a project dependency. Then, by default, the Gateway Metrics Filter runs as long as the property `spring.cloud.gateway.metrics.enabled` is not set to `false`. This filter adds a timer metric named "gateway.requests" with the following tags:
 
-* `routeId`: The route id 
+* `routeId`: The route id
 * `routeUri`: The URI that the API will be routed to
 * `outcome`: Outcome as classified by link:https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpStatus.Series.html[HttpStatus.Series]
 * `status`: Http Status of the request returned to the client
@@ -1371,7 +1393,7 @@ The logging system can be configured to have a separate access log file. Below i
 
 == CORS Configuration
 
-The gateway can be configured to control CORS behavior. The "global" CORS configuration is a map of URL patterns to https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/cors/CorsConfiguration.html[Spring Framework `CorsConfiguration`]. 
+The gateway can be configured to control CORS behavior. The "global" CORS configuration is a map of URL patterns to https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/cors/CorsConfiguration.html[Spring Framework `CorsConfiguration`].
 
 .application.yml
 [source,yaml]

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -363,6 +363,23 @@ spring:
 
 This will add `X-Request-Foo:Bar` header to the downstream request's headers for all matching requests.
 
+AddRequestHeader is aware of URI variables used to match a path or host. URI variables may be used in the value and will be expanded at runtime.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: add_request_header_route
+        uri: https://example.org
+        predicates:
+        - Path=/foo/{segment}
+        filters:
+        - AddRequestHeader=X-Request-Foo, Bar-{segment}
+----
+
 === AddRequestParameter GatewayFilter Factory
 The AddRequestParameter GatewayFilter Factory takes a name and value parameter.
 
@@ -381,6 +398,23 @@ spring:
 
 This will add `foo=bar` to the downstream request's query string for all matching requests.
 
+AddRequestParameter is aware of URI variables used to match a path or host. URI variables may be used in the value and will be expanded at runtime.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: add_request_parameter_route
+        uri: https://example.org
+        predicates:
+        - Host: {segment}.myhost.org
+        filters:
+        - AddRequestParameter=foo, bar-{segment}
+----
+
 === AddResponseHeader GatewayFilter Factory
 The AddResponseHeader GatewayFilter Factory takes a name and value parameter.
 
@@ -398,6 +432,23 @@ spring:
 ----
 
 This will add `X-Response-Foo:Bar` header to the downstream response's headers for all matching requests.
+
+AddResponseHeader is aware of URI variables used to match a path or host. URI variables may be used in the value and will be expanded at runtime.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: add_response_header_route
+        uri: https://example.org
+        predicates:
+        - Host: {segment}.myhost.org
+        filters:
+        - AddResponseHeader=foo, bar-{segment}
+----
 
 === DedupeResponseHeader GatewayFilter Factory
 The DedupeResponseHeader GatewayFilter Factory takes a `name` parameter and an optional `strategy` parameter. `name` can contain a list of header names, space separated.
@@ -861,6 +912,41 @@ spring:
 
 For a request path of `/foo/bar`, this will set the path to `/bar` before making the downstream request.
 
+=== SetRequestHeader GatewayFilter Factory
+The SetRequestHeader GatewayFilter Factory takes `name` and `value` parameters.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: setrequestheader_route
+        uri: https://example.org
+        filters:
+        - SetRequestHeader=X-Request-Foo, Bar
+----
+
+This GatewayFilter replaces all headers with the given name, rather than adding. So if the downstream server responded with a `X-Request-Foo:1234`, this would be replaced with `X-Request-Foo:Bar`, which is what the downstream service would receive.
+
+SetRequestHeader is aware of URI variables used to match a path or host. URI variables may be used in the value and will be expanded at runtime.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: setrequestheader_route
+        uri: https://example.org
+        predicates:
+        - Host: {segment}.myhost.org
+        filters:
+        - SetRequestHeader=foo, bar-{segment}
+----
+
 === SetResponseHeader GatewayFilter Factory
 The SetResponseHeader GatewayFilter Factory takes `name` and `value` parameters.
 
@@ -878,6 +964,23 @@ spring:
 ----
 
 This GatewayFilter replaces all headers with the given name, rather than adding. So if the downstream server responded with a `X-Response-Foo:1234`, this would be replaced with `X-Response-Foo:Bar`, which is what the gateway client would receive.
+
+SetResponseHeader is aware of URI variables used to match a path or host. URI variables may be used in the value and will be expanded at runtime.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: setresponseheader_route
+        uri: https://example.org
+        predicates:
+        - Host: {segment}.myhost.org
+        filters:
+        - SetResponseHeader=foo, bar-{segment}
+----
 
 === SetStatus GatewayFilter Factory
 The SetStatus GatewayFilter Factory takes a single `status` parameter. It must be a valid Spring `HttpStatus`. It may be the integer value `404` or the string representation of the enumeration `NOT_FOUND`.

--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1422,6 +1422,38 @@ management.endpoint.gateway.enabled=true # default value
 management.endpoints.web.exposure.include=gateway
 ----
 
+=== Verbose Actuator Format
+
+A new, more verbose format has been added to Gateway. This adds more detail to each route allowing to view the predicates and filters associated to each route along with any configuration that is available.
+
+`/actuator/gateway/routes`
+[source,json]
+----
+[
+  {
+    "predicate": "(Hosts: [**.addrequestheader.org] && Paths: [/headers], match trailing slash: true)",
+    "route_id": "add_request_header_test",
+    "filters": [
+      "[[AddResponseHeader X-Response-Default-Foo = 'Default-Bar'], order = 1]",
+      "[[AddRequestHeader X-Request-Foo = 'Bar'], order = 1]",
+      "[[PrefixPath prefix = '/httpbin'], order = 2]"
+    ],
+    "uri": "lb://testservice",
+    "order": 0
+  }
+]
+----
+
+To enable this feature, set the following property:
+
+.application.properties
+[source,properties]
+----
+spring.cloud.gateway.actuator.verbose.enabled=true
+----
+
+This will default to true in a future release.
+
 === Retrieving route filters
 ==== Global Filters
 To retrieve the <<global-filters,global filters>> applied to all routes, make a `GET` request to `/actuator/gateway/globalfilters`. The resulting response is similar to the following:

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.actuate;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.cloud.gateway.route.RouteDefinitionLocator;
+import org.springframework.cloud.gateway.route.RouteDefinitionWriter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.support.NotFoundException;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.core.Ordered;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * @author Spencer Gibb
+ */
+public class AbstractGatewayControllerEndpoint implements ApplicationEventPublisherAware {
+
+	private static final Log log = LogFactory.getLog(GatewayControllerEndpoint.class);
+
+	protected RouteDefinitionLocator routeDefinitionLocator;
+
+	protected List<GlobalFilter> globalFilters;
+
+	protected List<GatewayFilterFactory> GatewayFilters;
+
+	protected RouteDefinitionWriter routeDefinitionWriter;
+
+	protected RouteLocator routeLocator;
+
+	protected ApplicationEventPublisher publisher;
+
+	public AbstractGatewayControllerEndpoint(
+			RouteDefinitionLocator routeDefinitionLocator,
+			List<GlobalFilter> globalFilters, List<GatewayFilterFactory> GatewayFilters,
+			RouteDefinitionWriter routeDefinitionWriter, RouteLocator routeLocator) {
+		this.routeDefinitionLocator = routeDefinitionLocator;
+		this.globalFilters = globalFilters;
+		this.GatewayFilters = GatewayFilters;
+		this.routeDefinitionWriter = routeDefinitionWriter;
+		this.routeLocator = routeLocator;
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	// TODO: Add uncommited or new but not active routes endpoint
+
+	@PostMapping("/refresh")
+	public Mono<Void> refresh() {
+		this.publisher.publishEvent(new RefreshRoutesEvent(this));
+		return Mono.empty();
+	}
+
+	@GetMapping("/globalfilters")
+	public Mono<HashMap<String, Object>> globalfilters() {
+		return getNamesToOrders(this.globalFilters);
+	}
+
+	@GetMapping("/routefilters")
+	public Mono<HashMap<String, Object>> routefilers() {
+		return getNamesToOrders(this.GatewayFilters);
+	}
+
+	private <T> Mono<HashMap<String, Object>> getNamesToOrders(List<T> list) {
+		return Flux.fromIterable(list).reduce(new HashMap<>(), this::putItem);
+	}
+
+	private HashMap<String, Object> putItem(HashMap<String, Object> map, Object o) {
+		Integer order = null;
+		if (o instanceof Ordered) {
+			order = ((Ordered) o).getOrder();
+		}
+		// filters.put(o.getClass().getName(), order);
+		map.put(o.toString(), order);
+		return map;
+	}
+
+	/*
+	 * http POST :8080/admin/gateway/routes/apiaddreqhead uri=http://httpbin.org:80
+	 * predicates:='["Host=**.apiaddrequestheader.org", "Path=/headers"]'
+	 * filters:='["AddRequestHeader=X-Request-ApiFoo, ApiBar"]'
+	 */
+	@PostMapping("/routes/{id}")
+	@SuppressWarnings("unchecked")
+	public Mono<ResponseEntity<Void>> save(@PathVariable String id,
+			@RequestBody Mono<RouteDefinition> route) {
+		return this.routeDefinitionWriter.save(route.map(r -> {
+			r.setId(id);
+			log.debug("Saving route: " + route);
+			return r;
+		})).then(Mono.defer(() -> Mono
+				.just(ResponseEntity.created(URI.create("/routes/" + id)).build())));
+	}
+
+	@DeleteMapping("/routes/{id}")
+	public Mono<ResponseEntity<Object>> delete(@PathVariable String id) {
+		return this.routeDefinitionWriter.delete(Mono.just(id))
+				.then(Mono.defer(() -> Mono.just(ResponseEntity.ok().build())))
+				.onErrorResume(t -> t instanceof NotFoundException,
+						t -> Mono.just(ResponseEntity.notFound().build()));
+	}
+
+	@GetMapping("/routes/{id}/combinedfilters")
+	public Mono<HashMap<String, Object>> combinedfilters(@PathVariable String id) {
+		// TODO: missing global filters
+		return this.routeLocator.getRoutes().filter(route -> route.getId().equals(id))
+				.reduce(new HashMap<>(), this::putItem);
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpoint.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpoint.java
@@ -16,188 +16,71 @@
 
 package org.springframework.cloud.gateway.actuate;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
-import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
 import org.springframework.cloud.gateway.route.Route;
-import org.springframework.cloud.gateway.route.RouteDefinition;
-import org.springframework.cloud.gateway.route.RouteDefinitionLocator;
 import org.springframework.cloud.gateway.route.RouteDefinitionWriter;
 import org.springframework.cloud.gateway.route.RouteLocator;
-import org.springframework.cloud.gateway.support.NotFoundException;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.core.Ordered;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 
 /**
  * @author Spencer Gibb
  */
 @RestControllerEndpoint(id = "gateway")
-public class GatewayControllerEndpoint implements ApplicationEventPublisherAware {
+public class GatewayControllerEndpoint extends AbstractGatewayControllerEndpoint {
 
-	private static final Log log = LogFactory.getLog(GatewayControllerEndpoint.class);
-
-	private RouteDefinitionLocator routeDefinitionLocator;
-
-	private List<GlobalFilter> globalFilters;
-
-	private List<GatewayFilterFactory> GatewayFilters;
-
-	private RouteDefinitionWriter routeDefinitionWriter;
-
-	private RouteLocator routeLocator;
-
-	private ApplicationEventPublisher publisher;
-
-	public GatewayControllerEndpoint(RouteDefinitionLocator routeDefinitionLocator,
-			List<GlobalFilter> globalFilters, List<GatewayFilterFactory> GatewayFilters,
+	public GatewayControllerEndpoint(List<GlobalFilter> globalFilters,
+			List<GatewayFilterFactory> gatewayFilters,
 			RouteDefinitionWriter routeDefinitionWriter, RouteLocator routeLocator) {
-		this.routeDefinitionLocator = routeDefinitionLocator;
-		this.globalFilters = globalFilters;
-		this.GatewayFilters = GatewayFilters;
-		this.routeDefinitionWriter = routeDefinitionWriter;
-		this.routeLocator = routeLocator;
-	}
-
-	@Override
-	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
-		this.publisher = publisher;
-	}
-
-	// TODO: Add uncommited or new but not active routes endpoint
-
-	@PostMapping("/refresh")
-	public Mono<Void> refresh() {
-		this.publisher.publishEvent(new RefreshRoutesEvent(this));
-		return Mono.empty();
-	}
-
-	@GetMapping("/globalfilters")
-	public Mono<HashMap<String, Object>> globalfilters() {
-		return getNamesToOrders(this.globalFilters);
-	}
-
-	@GetMapping("/routefilters")
-	public Mono<HashMap<String, Object>> routefilers() {
-		return getNamesToOrders(this.GatewayFilters);
-	}
-
-	private <T> Mono<HashMap<String, Object>> getNamesToOrders(List<T> list) {
-		return Flux.fromIterable(list).reduce(new HashMap<>(), this::putItem);
-	}
-
-	private HashMap<String, Object> putItem(HashMap<String, Object> map, Object o) {
-		Integer order = null;
-		if (o instanceof Ordered) {
-			order = ((Ordered) o).getOrder();
-		}
-		// filters.put(o.getClass().getName(), order);
-		map.put(o.toString(), order);
-		return map;
+		super(null, globalFilters, gatewayFilters, routeDefinitionWriter, routeLocator);
 	}
 
 	// TODO: Flush out routes without a definition
 	@GetMapping("/routes")
-	public Mono<List<Map<String, Object>>> routes() {
-		Mono<Map<String, RouteDefinition>> routeDefs = this.routeDefinitionLocator
-				.getRouteDefinitions().collectMap(RouteDefinition::getId);
-		Mono<List<Route>> routes = this.routeLocator.getRoutes().collectList();
-		return Mono.zip(routeDefs, routes).map(tuple -> {
-			Map<String, RouteDefinition> defs = tuple.getT1();
-			List<Route> routeList = tuple.getT2();
-			List<Map<String, Object>> allRoutes = new ArrayList<>();
-
-			routeList.forEach(route -> {
-				HashMap<String, Object> r = new HashMap<>();
-				r.put("route_id", route.getId());
-				r.put("order", route.getOrder());
-
-				if (defs.containsKey(route.getId())) {
-					r.put("route_definition", defs.get(route.getId()));
-				}
-				else {
-					HashMap<String, Object> obj = new HashMap<>();
-
-					obj.put("predicate", route.getPredicate().toString());
-
-					if (!route.getFilters().isEmpty()) {
-						ArrayList<String> filters = new ArrayList<>();
-						for (GatewayFilter filter : route.getFilters()) {
-							filters.add(filter.toString());
-						}
-
-						obj.put("filters", filters);
-					}
-
-					if (!obj.isEmpty()) {
-						r.put("route_object", obj);
-					}
-				}
-				allRoutes.add(r);
-			});
-
-			return allRoutes;
-		});
+	public Flux<Map<String, Object>> routes() {
+		return this.routeLocator.getRoutes().map(this::serialize);
 	}
 
-	/*
-	 * http POST :8080/admin/gateway/routes/apiaddreqhead uri=http://httpbin.org:80
-	 * predicates:='["Host=**.apiaddrequestheader.org", "Path=/headers"]'
-	 * filters:='["AddRequestHeader=X-Request-ApiFoo, ApiBar"]'
-	 */
-	@PostMapping("/routes/{id}")
-	@SuppressWarnings("unchecked")
-	public Mono<ResponseEntity<Void>> save(@PathVariable String id,
-			@RequestBody Mono<RouteDefinition> route) {
-		return this.routeDefinitionWriter.save(route.map(r -> {
-			r.setId(id);
-			log.debug("Saving route: " + route);
-			return r;
-		})).then(Mono.defer(() -> Mono
-				.just(ResponseEntity.created(URI.create("/routes/" + id)).build())));
-	}
+	Map<String, Object> serialize(Route route) {
+		HashMap<String, Object> r = new HashMap<>();
+		r.put("route_id", route.getId());
+		r.put("uri", route.getUri().toString());
+		r.put("order", route.getOrder());
+		r.put("predicate", route.getPredicate().toString());
 
-	@DeleteMapping("/routes/{id}")
-	public Mono<ResponseEntity<Object>> delete(@PathVariable String id) {
-		return this.routeDefinitionWriter.delete(Mono.just(id))
-				.then(Mono.defer(() -> Mono.just(ResponseEntity.ok().build())))
-				.onErrorResume(t -> t instanceof NotFoundException,
-						t -> Mono.just(ResponseEntity.notFound().build()));
+		ArrayList<String> filters = new ArrayList<>();
+
+		for (int i = 0; i < route.getFilters().size(); i++) {
+			GatewayFilter gatewayFilter = route.getFilters().get(i);
+			filters.add(gatewayFilter.toString());
+		}
+
+		r.put("filters", filters);
+		return r;
 	}
 
 	@GetMapping("/routes/{id}")
-	public Mono<ResponseEntity<RouteDefinition>> route(@PathVariable String id) {
-		// TODO: missing RouteLocator
-		return this.routeDefinitionLocator.getRouteDefinitions()
-				.filter(route -> route.getId().equals(id)).singleOrEmpty()
+	public Mono<ResponseEntity<Map<String, Object>>> route(@PathVariable String id) {
+		// @formatter:off
+		return this.routeLocator.getRoutes()
+				.filter(route -> route.getId().equals(id))
+				.singleOrEmpty()
+				.map(this::serialize)
 				.map(ResponseEntity::ok)
 				.switchIfEmpty(Mono.just(ResponseEntity.notFound().build()));
-	}
-
-	@GetMapping("/routes/{id}/combinedfilters")
-	public Mono<HashMap<String, Object>> combinedfilters(@PathVariable String id) {
-		// TODO: missing global filters
-		return this.routeLocator.getRoutes().filter(route -> route.getId().equals(id))
-				.reduce(new HashMap<>(), this::putItem);
+		// @formatter:on
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpoint.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpoint.java
@@ -16,71 +16,189 @@
 
 package org.springframework.cloud.gateway.actuate;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
 import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.cloud.gateway.route.RouteDefinitionLocator;
 import org.springframework.cloud.gateway.route.RouteDefinitionWriter;
 import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.support.NotFoundException;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.core.Ordered;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 /**
  * @author Spencer Gibb
  */
 @RestControllerEndpoint(id = "gateway")
-public class GatewayControllerEndpoint extends AbstractGatewayControllerEndpoint {
+public class GatewayControllerEndpoint implements ApplicationEventPublisherAware {
 
-	public GatewayControllerEndpoint(List<GlobalFilter> globalFilters,
-			List<GatewayFilterFactory> gatewayFilters,
+	private static final Log log = LogFactory.getLog(GatewayControllerEndpoint.class);
+
+	private RouteDefinitionLocator routeDefinitionLocator;
+
+	private List<GlobalFilter> globalFilters;
+
+	private List<GatewayFilterFactory> GatewayFilters;
+
+	private RouteDefinitionWriter routeDefinitionWriter;
+
+	private RouteLocator routeLocator;
+
+	private ApplicationEventPublisher publisher;
+
+	public GatewayControllerEndpoint(RouteDefinitionLocator routeDefinitionLocator,
+			List<GlobalFilter> globalFilters, List<GatewayFilterFactory> GatewayFilters,
 			RouteDefinitionWriter routeDefinitionWriter, RouteLocator routeLocator) {
-		super(null, globalFilters, gatewayFilters, routeDefinitionWriter, routeLocator);
+		this.routeDefinitionLocator = routeDefinitionLocator;
+		this.globalFilters = globalFilters;
+		this.GatewayFilters = GatewayFilters;
+		this.routeDefinitionWriter = routeDefinitionWriter;
+		this.routeLocator = routeLocator;
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+		this.publisher = publisher;
+	}
+
+	// TODO: Add uncommited or new but not active routes endpoint
+
+	@PostMapping("/refresh")
+	public Mono<Void> refresh() {
+		this.publisher.publishEvent(new RefreshRoutesEvent(this));
+		return Mono.empty();
+	}
+
+	@GetMapping("/globalfilters")
+	public Mono<HashMap<String, Object>> globalfilters() {
+		return getNamesToOrders(this.globalFilters);
+	}
+
+	@GetMapping("/routefilters")
+	public Mono<HashMap<String, Object>> routefilers() {
+		return getNamesToOrders(this.GatewayFilters);
+	}
+
+	private <T> Mono<HashMap<String, Object>> getNamesToOrders(List<T> list) {
+		return Flux.fromIterable(list).reduce(new HashMap<>(), this::putItem);
+	}
+
+	private HashMap<String, Object> putItem(HashMap<String, Object> map, Object o) {
+		Integer order = null;
+		if (o instanceof Ordered) {
+			order = ((Ordered) o).getOrder();
+		}
+		// filters.put(o.getClass().getName(), order);
+		map.put(o.toString(), order);
+		return map;
 	}
 
 	// TODO: Flush out routes without a definition
 	@GetMapping("/routes")
-	public Flux<Map<String, Object>> routes() {
-		return this.routeLocator.getRoutes().map(this::serialize);
+	public Mono<List<Map<String, Object>>> routes() {
+		Mono<Map<String, RouteDefinition>> routeDefs = this.routeDefinitionLocator
+				.getRouteDefinitions().collectMap(RouteDefinition::getId);
+		Mono<List<Route>> routes = this.routeLocator.getRoutes().collectList();
+		return Mono.zip(routeDefs, routes).map(tuple -> {
+			Map<String, RouteDefinition> defs = tuple.getT1();
+			List<Route> routeList = tuple.getT2();
+			List<Map<String, Object>> allRoutes = new ArrayList<>();
+
+			routeList.forEach(route -> {
+				HashMap<String, Object> r = new HashMap<>();
+				r.put("route_id", route.getId());
+				r.put("order", route.getOrder());
+
+				if (defs.containsKey(route.getId())) {
+					r.put("route_definition", defs.get(route.getId()));
+				}
+				else {
+					HashMap<String, Object> obj = new HashMap<>();
+
+					obj.put("predicate", route.getPredicate().toString());
+
+					if (!route.getFilters().isEmpty()) {
+						ArrayList<String> filters = new ArrayList<>();
+						for (GatewayFilter filter : route.getFilters()) {
+							filters.add(filter.toString());
+						}
+
+						obj.put("filters", filters);
+					}
+
+					if (!obj.isEmpty()) {
+						r.put("route_object", obj);
+					}
+				}
+				allRoutes.add(r);
+			});
+
+			return allRoutes;
+		});
 	}
 
-	Map<String, Object> serialize(Route route) {
-		HashMap<String, Object> r = new HashMap<>();
-		r.put("route_id", route.getId());
-		r.put("uri", route.getUri().toString());
-		r.put("order", route.getOrder());
-		r.put("predicate", route.getPredicate().toString());
+	/*
+	 * http POST :8080/admin/gateway/routes/apiaddreqhead uri=http://httpbin.org:80
+	 * predicates:='["Host=**.apiaddrequestheader.org", "Path=/headers"]'
+	 * filters:='["AddRequestHeader=X-Request-ApiFoo, ApiBar"]'
+	 */
+	@PostMapping("/routes/{id}")
+	@SuppressWarnings("unchecked")
+	public Mono<ResponseEntity<Void>> save(@PathVariable String id,
+			@RequestBody Mono<RouteDefinition> route) {
+		return this.routeDefinitionWriter.save(route.map(r -> {
+			r.setId(id);
+			log.debug("Saving route: " + route);
+			return r;
+		})).then(Mono.defer(() -> Mono
+				.just(ResponseEntity.created(URI.create("/routes/" + id)).build())));
+	}
 
-		ArrayList<String> filters = new ArrayList<>();
-
-		for (int i = 0; i < route.getFilters().size(); i++) {
-			GatewayFilter gatewayFilter = route.getFilters().get(i);
-			filters.add(gatewayFilter.toString());
-		}
-
-		r.put("filters", filters);
-		return r;
+	@DeleteMapping("/routes/{id}")
+	public Mono<ResponseEntity<Object>> delete(@PathVariable String id) {
+		return this.routeDefinitionWriter.delete(Mono.just(id))
+				.then(Mono.defer(() -> Mono.just(ResponseEntity.ok().build())))
+				.onErrorResume(t -> t instanceof NotFoundException,
+						t -> Mono.just(ResponseEntity.notFound().build()));
 	}
 
 	@GetMapping("/routes/{id}")
 	public Mono<ResponseEntity<Map<String, Object>>> route(@PathVariable String id) {
-		// @formatter:off
-		return this.routeLocator.getRoutes()
-				.filter(route -> route.getId().equals(id))
+		return routes().flatMap(allRoutes -> Flux.fromStream(allRoutes.stream())
+				.filter(route -> route.containsKey("route_id") && route.get("route_id")
+						.equals(id))
 				.singleOrEmpty()
-				.map(this::serialize)
-				.map(ResponseEntity::ok)
+				.map(ResponseEntity::ok))
 				.switchIfEmpty(Mono.just(ResponseEntity.notFound().build()));
-		// @formatter:on
+	}
+
+	@GetMapping("/routes/{id}/combinedfilters")
+	public Mono<HashMap<String, Object>> combinedfilters(@PathVariable String id) {
+		// TODO: missing global filters
+		return this.routeLocator.getRoutes().filter(route -> route.getId().equals(id))
+				.reduce(new HashMap<>(), this::putItem);
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/GatewayLegacyControllerEndpoint.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/actuate/GatewayLegacyControllerEndpoint.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.actuate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.cloud.gateway.route.RouteDefinitionLocator;
+import org.springframework.cloud.gateway.route.RouteDefinitionWriter;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+/**
+ * @author Spencer Gibb
+ */
+@RestControllerEndpoint(id = "gateway")
+public class GatewayLegacyControllerEndpoint extends AbstractGatewayControllerEndpoint {
+
+	public GatewayLegacyControllerEndpoint(RouteDefinitionLocator routeDefinitionLocator,
+			List<GlobalFilter> globalFilters, List<GatewayFilterFactory> GatewayFilters,
+			RouteDefinitionWriter routeDefinitionWriter, RouteLocator routeLocator) {
+		super(routeDefinitionLocator, globalFilters, GatewayFilters,
+				routeDefinitionWriter, routeLocator);
+	}
+
+	@GetMapping("/routes")
+	public Mono<List<Map<String, Object>>> routes() {
+		Mono<Map<String, RouteDefinition>> routeDefs = this.routeDefinitionLocator
+				.getRouteDefinitions().collectMap(RouteDefinition::getId);
+		Mono<List<Route>> routes = this.routeLocator.getRoutes().collectList();
+		return Mono.zip(routeDefs, routes).map(tuple -> {
+			Map<String, RouteDefinition> defs = tuple.getT1();
+			List<Route> routeList = tuple.getT2();
+			List<Map<String, Object>> allRoutes = new ArrayList<>();
+
+			routeList.forEach(route -> {
+				HashMap<String, Object> r = new HashMap<>();
+				r.put("route_id", route.getId());
+				r.put("order", route.getOrder());
+
+				if (defs.containsKey(route.getId())) {
+					r.put("route_definition", defs.get(route.getId()));
+				}
+				else {
+					HashMap<String, Object> obj = new HashMap<>();
+
+					obj.put("predicate", route.getPredicate().toString());
+
+					if (!route.getFilters().isEmpty()) {
+						ArrayList<String> filters = new ArrayList<>();
+						for (GatewayFilter filter : route.getFilters()) {
+							filters.add(filter.toString());
+						}
+
+						obj.put("filters", filters);
+					}
+
+					if (!obj.isEmpty()) {
+						r.put("route_object", obj);
+					}
+				}
+				allRoutes.add(r);
+			});
+
+			return allRoutes;
+		});
+	}
+
+	@GetMapping("/routes/{id}")
+	public Mono<ResponseEntity<RouteDefinition>> route(@PathVariable String id) {
+		// TODO: missing RouteLocator
+		return this.routeDefinitionLocator.getRouteDefinitions()
+				.filter(route -> route.getId().equals(id)).singleOrEmpty()
+				.map(ResponseEntity::ok)
+				.switchIfEmpty(Mono.just(ResponseEntity.notFound().build()));
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -39,11 +39,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
 import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.cloud.gateway.actuate.GatewayControllerEndpoint;
+import org.springframework.cloud.gateway.actuate.GatewayLegacyControllerEndpoint;
 import org.springframework.cloud.gateway.filter.AdaptCachedBodyGlobalFilter;
 import org.springframework.cloud.gateway.filter.ForwardPathFilter;
 import org.springframework.cloud.gateway.filter.ForwardRoutingFilter;
@@ -120,6 +122,7 @@ import org.springframework.cloud.gateway.support.StringToZonedDateTimeConverter;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
@@ -653,14 +656,39 @@ public class GatewayAutoConfiguration {
 	protected static class GatewayActuatorConfiguration {
 
 		@Bean
+		@ConditionalOnProperty("spring.cloud.gateway.actuator.verbose.enabled")
 		@ConditionalOnEnabledEndpoint
 		public GatewayControllerEndpoint gatewayControllerEndpoint(
+				List<GlobalFilter> globalFilters,
+				List<GatewayFilterFactory> gatewayFilters,
+				RouteDefinitionWriter routeDefinitionWriter, RouteLocator routeLocator) {
+			return new GatewayControllerEndpoint(globalFilters, gatewayFilters,
+					routeDefinitionWriter, routeLocator);
+		}
+
+		@Bean
+		@Conditional(OnVerboseDisabledCondition.class)
+		@ConditionalOnEnabledEndpoint
+		public GatewayLegacyControllerEndpoint gatewayLegacyControllerEndpoint(
 				RouteDefinitionLocator routeDefinitionLocator,
 				List<GlobalFilter> globalFilters,
-				List<GatewayFilterFactory> GatewayFilters,
+				List<GatewayFilterFactory> gatewayFilters,
 				RouteDefinitionWriter routeDefinitionWriter, RouteLocator routeLocator) {
-			return new GatewayControllerEndpoint(routeDefinitionLocator, globalFilters,
-					GatewayFilters, routeDefinitionWriter, routeLocator);
+			return new GatewayLegacyControllerEndpoint(routeDefinitionLocator,
+					globalFilters, gatewayFilters, routeDefinitionWriter, routeLocator);
+		}
+
+	}
+
+	private static class OnVerboseDisabledCondition extends NoneNestedConditions {
+
+		OnVerboseDisabledCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnProperty("spring.cloud.gateway.actuator.verbose.enabled")
+		static class VerboseDisabled {
+
 		}
 
 	}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -31,7 +31,7 @@ import rx.RxReactiveStreams;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -656,8 +656,9 @@ public class GatewayAutoConfiguration {
 	protected static class GatewayActuatorConfiguration {
 
 		@Bean
-		@ConditionalOnProperty("spring.cloud.gateway.actuator.verbose.enabled")
-		@ConditionalOnEnabledEndpoint
+		@ConditionalOnProperty(name = "spring.cloud.gateway.actuator.verbose.enabled",
+				matchIfMissing = true)
+		@ConditionalOnAvailableEndpoint
 		public GatewayControllerEndpoint gatewayControllerEndpoint(
 				List<GlobalFilter> globalFilters,
 				List<GatewayFilterFactory> gatewayFilters,
@@ -668,7 +669,7 @@ public class GatewayAutoConfiguration {
 
 		@Bean
 		@Conditional(OnVerboseDisabledCondition.class)
-		@ConditionalOnEnabledEndpoint
+		@ConditionalOnAvailableEndpoint
 		public GatewayLegacyControllerEndpoint gatewayLegacyControllerEndpoint(
 				RouteDefinitionLocator routeDefinitionLocator,
 				List<GlobalFilter> globalFilters,
@@ -686,7 +687,8 @@ public class GatewayAutoConfiguration {
 			super(ConfigurationPhase.REGISTER_BEAN);
 		}
 
-		@ConditionalOnProperty("spring.cloud.gateway.actuator.verbose.enabled")
+		@ConditionalOnProperty(name = "spring.cloud.gateway.actuator.verbose.enabled",
+				matchIfMissing = true)
 		static class VerboseDisabled {
 
 		}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -40,10 +40,13 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.condition.NoneNestedConditions;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.autoconfigure.web.embedded.NettyWebServerFactoryCustomizer;
 import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.web.embedded.netty.NettyReactiveWebServerFactory;
 import org.springframework.cloud.gateway.actuate.GatewayControllerEndpoint;
 import org.springframework.cloud.gateway.actuate.GatewayLegacyControllerEndpoint;
 import org.springframework.cloud.gateway.filter.AdaptCachedBodyGlobalFilter;
@@ -520,6 +523,19 @@ public class GatewayAutoConfiguration {
 	protected static class NettyConfiguration {
 
 		@Bean
+		@ConditionalOnProperty(name = "spring.cloud.gateway.httpserver.wiretap")
+		public NettyWebServerFactoryCustomizer nettyServerWiretapCustomizer(
+				Environment environment, ServerProperties serverProperties) {
+			return new NettyWebServerFactoryCustomizer(environment, serverProperties) {
+				@Override
+				public void customize(NettyReactiveWebServerFactory factory) {
+					factory.addServerCustomizers(httpServer -> httpServer.wiretap(true));
+					super.customize(factory);
+				}
+			};
+		}
+
+		@Bean
 		@ConditionalOnMissingBean
 		public HttpClient gatewayHttpClient(HttpClientProperties properties) {
 
@@ -596,8 +612,9 @@ public class GatewayAutoConfiguration {
 				});
 			}
 
-			// TODO: add configuration to turn on wiretap
-			// httpClient = httpClient.wiretap(true);
+			if (properties.isWiretap()) {
+				httpClient = httpClient.wiretap(true);
+			}
 
 			return httpClient;
 		}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
@@ -60,6 +60,9 @@ public class HttpClientProperties {
 	/** Websocket configuration for Netty HttpClient. */
 	private Websocket websocket = new Websocket();
 
+	/** Enables wiretap debugging for Netty HttpClient. */
+	private boolean wiretap;
+
 	public Integer getConnectTimeout() {
 		return connectTimeout;
 	}
@@ -108,6 +111,14 @@ public class HttpClientProperties {
 		this.websocket = websocket;
 	}
 
+	public boolean isWiretap() {
+		return this.wiretap;
+	}
+
+	public void setWiretap(boolean wiretap) {
+		this.wiretap = wiretap;
+	}
+
 	@Override
 	public String toString() {
 		// @formatter:off
@@ -118,6 +129,7 @@ public class HttpClientProperties {
 				.append("proxy", proxy)
 				.append("ssl", ssl)
 				.append("websocket", websocket)
+				.append("wiretap", wiretap)
 				.toString();
 		// @formatter:on
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/OrderedGatewayFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/OrderedGatewayFilter.java
@@ -51,11 +51,8 @@ public class OrderedGatewayFilter implements GatewayFilter, Ordered {
 
 	@Override
 	public String toString() {
-		final StringBuilder sb = new StringBuilder("OrderedGatewayFilter{");
-		sb.append("delegate=").append(delegate);
-		sb.append(", order=").append(order);
-		sb.append('}');
-		return sb.toString();
+		return new StringBuilder("[").append(delegate).append(", order = ").append(order)
+				.append("]").toString();
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactory.java
@@ -20,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -37,8 +38,9 @@ public class AddRequestHeaderGatewayFilterFactory
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange,
 					GatewayFilterChain chain) {
+				String value = ServerWebExchangeUtils.expand(exchange, config.getValue());
 				ServerHttpRequest request = exchange.getRequest().mutate()
-						.header(config.getName(), config.getValue()).build();
+						.header(config.getName(), value).build();
 
 				return chain.filter(exchange.mutate().request(request).build());
 			}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactory.java
@@ -16,8 +16,14 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * @author Spencer Gibb
@@ -27,11 +33,21 @@ public class AddRequestHeaderGatewayFilterFactory
 
 	@Override
 	public GatewayFilter apply(NameValueConfig config) {
-		return (exchange, chain) -> {
-			ServerHttpRequest request = exchange.getRequest().mutate()
-					.header(config.getName(), config.getValue()).build();
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				ServerHttpRequest request = exchange.getRequest().mutate()
+						.header(config.getName(), config.getValue()).build();
 
-			return chain.filter(exchange.mutate().request(request).build());
+				return chain.filter(exchange.mutate().request(request).build());
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(AddRequestHeaderGatewayFilterFactory.this)
+						.append(config.getName(), config.getValue()).toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactory.java
@@ -22,6 +22,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
@@ -52,10 +53,11 @@ public class AddRequestParameterGatewayFilterFactory
 					}
 				}
 
+				String value = ServerWebExchangeUtils.expand(exchange, config.getValue());
 				// TODO urlencode?
 				query.append(config.getName());
 				query.append('=');
-				query.append(config.getValue());
+				query.append(value);
 
 				try {
 					URI newUri = UriComponentsBuilder.fromUri(uri)

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactory.java
@@ -18,10 +18,16 @@ package org.springframework.cloud.gateway.filter.factory;
 
 import java.net.URI;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * @author Spencer Gibb
@@ -31,35 +37,45 @@ public class AddRequestParameterGatewayFilterFactory
 
 	@Override
 	public GatewayFilter apply(NameValueConfig config) {
-		return (exchange, chain) -> {
-			URI uri = exchange.getRequest().getURI();
-			StringBuilder query = new StringBuilder();
-			String originalQuery = uri.getRawQuery();
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				URI uri = exchange.getRequest().getURI();
+				StringBuilder query = new StringBuilder();
+				String originalQuery = uri.getRawQuery();
 
-			if (StringUtils.hasText(originalQuery)) {
-				query.append(originalQuery);
-				if (originalQuery.charAt(originalQuery.length() - 1) != '&') {
-					query.append('&');
+				if (StringUtils.hasText(originalQuery)) {
+					query.append(originalQuery);
+					if (originalQuery.charAt(originalQuery.length() - 1) != '&') {
+						query.append('&');
+					}
+				}
+
+				// TODO urlencode?
+				query.append(config.getName());
+				query.append('=');
+				query.append(config.getValue());
+
+				try {
+					URI newUri = UriComponentsBuilder.fromUri(uri)
+							.replaceQuery(query.toString()).build(true).toUri();
+
+					ServerHttpRequest request = exchange.getRequest().mutate().uri(newUri)
+							.build();
+
+					return chain.filter(exchange.mutate().request(request).build());
+				}
+				catch (RuntimeException ex) {
+					throw new IllegalStateException(
+							"Invalid URI query: \"" + query.toString() + "\"");
 				}
 			}
 
-			// TODO urlencode?
-			query.append(config.getName());
-			query.append('=');
-			query.append(config.getValue());
-
-			try {
-				URI newUri = UriComponentsBuilder.fromUri(uri)
-						.replaceQuery(query.toString()).build(true).toUri();
-
-				ServerHttpRequest request = exchange.getRequest().mutate().uri(newUri)
-						.build();
-
-				return chain.filter(exchange.mutate().request(request).build());
-			}
-			catch (RuntimeException ex) {
-				throw new IllegalStateException(
-						"Invalid URI query: \"" + query.toString() + "\"");
+			@Override
+			public String toString() {
+				return filterToStringCreator(AddRequestParameterGatewayFilterFactory.this)
+						.append(config.getName(), config.getValue()).toString();
 			}
 		};
 	}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddResponseHeaderGatewayFilterFactory.java
@@ -20,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
@@ -36,8 +37,8 @@ public class AddResponseHeaderGatewayFilterFactory
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange,
 					GatewayFilterChain chain) {
-				exchange.getResponse().getHeaders().add(config.getName(),
-						config.getValue());
+				String value = ServerWebExchangeUtils.expand(exchange, config.getValue());
+				exchange.getResponse().getHeaders().add(config.getName(), value);
 
 				return chain.filter(exchange);
 			}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/AddResponseHeaderGatewayFilterFactory.java
@@ -16,7 +16,13 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * @author Spencer Gibb
@@ -26,10 +32,21 @@ public class AddResponseHeaderGatewayFilterFactory
 
 	@Override
 	public GatewayFilter apply(NameValueConfig config) {
-		return (exchange, chain) -> {
-			exchange.getResponse().getHeaders().add(config.getName(), config.getValue());
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				exchange.getResponse().getHeaders().add(config.getName(),
+						config.getValue());
 
-			return chain.filter(exchange);
+				return chain.filter(exchange);
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(AddResponseHeaderGatewayFilterFactory.this)
+						.append(config.getName(), config.getValue()).toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
@@ -47,6 +47,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import static java.util.Collections.singletonList;
 import static java.util.Optional.ofNullable;
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.HYSTRIX_EXECUTION_EXCEPTION_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.containsEncodedParts;
@@ -124,43 +125,56 @@ public class HystrixGatewayFilterFactory
 			config.setter = Setter.withGroupKey(groupKey).andCommandKey(commandKey);
 		}
 
-		return (exchange, chain) -> {
-			RouteHystrixCommand command = new RouteHystrixCommand(
-					createCommandSetter(config, exchange), config.fallbackUri, exchange,
-					chain);
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				RouteHystrixCommand command = new RouteHystrixCommand(
+						createCommandSetter(config, exchange),
+						config.fallbackUri, exchange, chain);
 
-			return Mono.create(s -> {
-				Subscription sub = command.toObservable().subscribe(s::success, s::error,
-						s::success);
-				s.onCancel(sub::unsubscribe);
-			}).onErrorResume((Function<Throwable, Mono<Void>>) throwable -> {
-				if (throwable instanceof HystrixRuntimeException) {
-					HystrixRuntimeException e = (HystrixRuntimeException) throwable;
-					HystrixRuntimeException.FailureType failureType = e.getFailureType();
+				return Mono.create(s -> {
+					Subscription sub = command.toObservable().subscribe(s::success,
+							s::error, s::success);
+					s.onCancel(sub::unsubscribe);
+				}).onErrorResume((Function<Throwable, Mono<Void>>) throwable -> {
+					if (throwable instanceof HystrixRuntimeException) {
+						HystrixRuntimeException e = (HystrixRuntimeException) throwable;
+						HystrixRuntimeException.FailureType failureType = e
+								.getFailureType();
 
-					switch (failureType) {
-					case TIMEOUT:
-						return Mono.error(new TimeoutException());
-					case COMMAND_EXCEPTION: {
-						Throwable cause = e.getCause();
+						switch (failureType) {
+						case TIMEOUT:
+							return Mono.error(new TimeoutException());
+						case COMMAND_EXCEPTION: {
+							Throwable cause = e.getCause();
 
-						/*
-						 * We forsake here the null check for cause as
-						 * HystrixRuntimeException will always have a cause if the failure
-						 * type is COMMAND_EXCEPTION.
-						 */
-						if (cause instanceof ResponseStatusException
-								|| AnnotatedElementUtils.findMergedAnnotation(
-										cause.getClass(), ResponseStatus.class) != null) {
-							return Mono.error(cause);
+							/*
+							 * We forsake here the null check for cause as
+							 * HystrixRuntimeException will always have a cause if the
+							 * failure type is COMMAND_EXCEPTION.
+							 */
+							if (cause instanceof ResponseStatusException
+									|| AnnotatedElementUtils.findMergedAnnotation(
+											cause.getClass(),
+											ResponseStatus.class) != null) {
+								return Mono.error(cause);
+							}
+						}
+						default:
+							break;
 						}
 					}
-					default:
-						break;
-					}
-				}
-				return Mono.error(throwable);
-			}).then();
+					return Mono.error(throwable);
+				}).then();
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(HystrixGatewayFilterFactory.this)
+						.append("name", config.getName())
+						.append("fallback", config.fallbackUri).toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactory.java
@@ -130,8 +130,8 @@ public class HystrixGatewayFilterFactory
 			public Mono<Void> filter(ServerWebExchange exchange,
 					GatewayFilterChain chain) {
 				RouteHystrixCommand command = new RouteHystrixCommand(
-						createCommandSetter(config, exchange),
-						config.fallbackUri, exchange, chain);
+						createCommandSetter(config, exchange), config.fallbackUri,
+						exchange, chain);
 
 				return Mono.create(s -> {
 					Subscription sub = command.toObservable().subscribe(s::success,

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/PreserveHostHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/PreserveHostHeaderGatewayFilterFactory.java
@@ -16,8 +16,13 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import org.springframework.cloud.gateway.filter.GatewayFilter;
+import reactor.core.publisher.Mono;
 
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.PRESERVE_HOST_HEADER_ATTRIBUTE;
 
 /**
@@ -31,9 +36,19 @@ public class PreserveHostHeaderGatewayFilterFactory extends AbstractGatewayFilte
 	}
 
 	public GatewayFilter apply(Object config) {
-		return (exchange, chain) -> {
-			exchange.getAttributes().put(PRESERVE_HOST_HEADER_ATTRIBUTE, true);
-			return chain.filter(exchange);
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				exchange.getAttributes().put(PRESERVE_HOST_HEADER_ATTRIBUTE, true);
+				return chain.filter(exchange);
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(PreserveHostHeaderGatewayFilterFactory.this)
+						.toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestHeaderGatewayFilterFactory.java
@@ -19,8 +19,14 @@ package org.springframework.cloud.gateway.filter.factory;
 import java.util.Arrays;
 import java.util.List;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * @author Spencer Gibb
@@ -39,11 +45,22 @@ public class RemoveRequestHeaderGatewayFilterFactory
 
 	@Override
 	public GatewayFilter apply(NameConfig config) {
-		return (exchange, chain) -> {
-			ServerHttpRequest request = exchange.getRequest().mutate()
-					.headers(httpHeaders -> httpHeaders.remove(config.getName())).build();
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				ServerHttpRequest request = exchange.getRequest().mutate()
+						.headers(httpHeaders -> httpHeaders.remove(config.getName()))
+						.build();
 
-			return chain.filter(exchange.mutate().request(request).build());
+				return chain.filter(exchange.mutate().request(request).build());
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(RemoveRequestHeaderGatewayFilterFactory.this)
+						.append("name", config.getName()).toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveResponseHeaderGatewayFilterFactory.java
@@ -22,6 +22,10 @@ import java.util.List;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * @author Spencer Gibb
@@ -40,9 +44,21 @@ public class RemoveResponseHeaderGatewayFilterFactory
 
 	@Override
 	public GatewayFilter apply(NameConfig config) {
-		return (exchange, chain) -> chain.filter(exchange).then(Mono.fromRunnable(() -> {
-			exchange.getResponse().getHeaders().remove(config.getName());
-		}));
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				return chain.filter(exchange).then(Mono.fromRunnable(() -> exchange
+						.getResponse().getHeaders().remove(config.getName())));
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(
+						RemoveResponseHeaderGatewayFilterFactory.this)
+								.append("name", config.getName()).toString();
+			}
+		};
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactory.java
@@ -27,7 +27,11 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
 import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * This filter changes the request uri by a request header.
@@ -47,6 +51,21 @@ public class RequestHeaderToRequestUriGatewayFilterFactory extends
 	@Override
 	public List<String> shortcutFieldOrder() {
 		return Arrays.asList(NAME_KEY);
+	}
+
+	@Override
+	public GatewayFilter apply(NameConfig config) {
+		// AbstractChangeRequestUriGatewayFilterFactory.apply() returns
+		// OrderedGatewayFilter
+		OrderedGatewayFilter gatewayFilter = (OrderedGatewayFilter) super.apply(config);
+		return new OrderedGatewayFilter(gatewayFilter, gatewayFilter.getOrder()) {
+			@Override
+			public String toString() {
+				return filterToStringCreator(
+						RequestHeaderToRequestUriGatewayFilterFactory.this)
+								.append("name", config.getName()).toString();
+			}
+		};
 	}
 
 	@Override

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SaveSessionGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SaveSessionGatewayFilterFactory.java
@@ -16,8 +16,14 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.server.WebSession;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * Save the current {@link WebSession} before executing the rest of the
@@ -33,8 +39,20 @@ public class SaveSessionGatewayFilterFactory extends AbstractGatewayFilterFactor
 
 	@Override
 	public GatewayFilter apply(Object config) {
-		return (exchange, chain) -> exchange.getSession().map(WebSession::save)
-				.then(chain.filter(exchange));
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				return exchange.getSession().map(WebSession::save)
+						.then(chain.filter(exchange));
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(SaveSessionGatewayFilterFactory.this)
+						.toString();
+			}
+		};
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -18,8 +18,14 @@ package org.springframework.cloud.gateway.filter.factory;
 
 import java.util.List;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * https://blog.appcanary.com/2017/http-security-headers.html.
@@ -78,48 +84,60 @@ public class SecureHeadersGatewayFilterFactory extends AbstractGatewayFilterFact
 	public GatewayFilter apply(Object config) {
 		// TODO: allow args to override properties
 
-		return (exchange, chain) -> {
-			HttpHeaders headers = exchange.getResponse().getHeaders();
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				HttpHeaders headers = exchange.getResponse().getHeaders();
 
-			List<String> disabled = properties.getDisable();
+				List<String> disabled = properties.getDisable();
 
-			if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
-				headers.add(X_XSS_PROTECTION_HEADER, properties.getXssProtectionHeader());
+				if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
+					headers.add(X_XSS_PROTECTION_HEADER,
+							properties.getXssProtectionHeader());
+				}
+
+				if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
+					headers.add(STRICT_TRANSPORT_SECURITY_HEADER,
+							properties.getStrictTransportSecurity());
+				}
+
+				if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
+					headers.add(X_FRAME_OPTIONS_HEADER, properties.getFrameOptions());
+				}
+
+				if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
+					headers.add(X_CONTENT_TYPE_OPTIONS_HEADER,
+							properties.getContentTypeOptions());
+				}
+
+				if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
+					headers.add(REFERRER_POLICY_HEADER, properties.getReferrerPolicy());
+				}
+
+				if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
+					headers.add(CONTENT_SECURITY_POLICY_HEADER,
+							properties.getContentSecurityPolicy());
+				}
+
+				if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
+					headers.add(X_DOWNLOAD_OPTIONS_HEADER,
+							properties.getDownloadOptions());
+				}
+
+				if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
+					headers.add(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
+							properties.getPermittedCrossDomainPolicies());
+				}
+
+				return chain.filter(exchange);
 			}
 
-			if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
-				headers.add(STRICT_TRANSPORT_SECURITY_HEADER,
-						properties.getStrictTransportSecurity());
+			@Override
+			public String toString() {
+				return filterToStringCreator(SecureHeadersGatewayFilterFactory.this)
+						.toString();
 			}
-
-			if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
-				headers.add(X_FRAME_OPTIONS_HEADER, properties.getFrameOptions());
-			}
-
-			if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
-				headers.add(X_CONTENT_TYPE_OPTIONS_HEADER,
-						properties.getContentTypeOptions());
-			}
-
-			if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
-				headers.add(REFERRER_POLICY_HEADER, properties.getReferrerPolicy());
-			}
-
-			if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
-				headers.add(CONTENT_SECURITY_POLICY_HEADER,
-						properties.getContentSecurityPolicy());
-			}
-
-			if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
-				headers.add(X_DOWNLOAD_OPTIONS_HEADER, properties.getDownloadOptions());
-			}
-
-			if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
-				headers.add(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
-						properties.getPermittedCrossDomainPolicies());
-			}
-
-			return chain.filter(exchange);
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetPathGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetPathGatewayFilterFactory.java
@@ -21,10 +21,15 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriTemplate;
 
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.addOriginalRequestUrl;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.getUriTemplateVariables;
@@ -53,20 +58,30 @@ public class SetPathGatewayFilterFactory
 	public GatewayFilter apply(Config config) {
 		UriTemplate uriTemplate = new UriTemplate(config.template);
 
-		return (exchange, chain) -> {
-			ServerHttpRequest req = exchange.getRequest();
-			addOriginalRequestUrl(exchange, req.getURI());
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				ServerHttpRequest req = exchange.getRequest();
+				addOriginalRequestUrl(exchange, req.getURI());
 
-			Map<String, String> uriVariables = getUriTemplateVariables(exchange);
+				Map<String, String> uriVariables = getUriTemplateVariables(exchange);
 
-			URI uri = uriTemplate.expand(uriVariables);
-			String newPath = uri.getRawPath();
+				URI uri = uriTemplate.expand(uriVariables);
+				String newPath = uri.getRawPath();
 
-			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri);
+				exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri);
 
-			ServerHttpRequest request = req.mutate().path(newPath).build();
+				ServerHttpRequest request = req.mutate().path(newPath).build();
 
-			return chain.filter(exchange.mutate().request(request).build());
+				return chain.filter(exchange.mutate().request(request).build());
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(SetPathGatewayFilterFactory.this)
+						.append("template", config.getTemplate()).toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactory.java
@@ -20,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -37,9 +38,9 @@ public class SetRequestHeaderGatewayFilterFactory
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange,
 					GatewayFilterChain chain) {
+				String value = ServerWebExchangeUtils.expand(exchange, config.getValue());
 				ServerHttpRequest request = exchange.getRequest().mutate()
-						.headers(
-								httpHeaders -> httpHeaders.set(config.name, config.value))
+						.headers(httpHeaders -> httpHeaders.set(config.name, value))
 						.build();
 
 				return chain.filter(exchange.mutate().request(request).build());

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactory.java
@@ -16,8 +16,14 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * @author Spencer Gibb
@@ -27,12 +33,23 @@ public class SetRequestHeaderGatewayFilterFactory
 
 	@Override
 	public GatewayFilter apply(NameValueConfig config) {
-		return (exchange, chain) -> {
-			ServerHttpRequest request = exchange.getRequest().mutate()
-					.headers(httpHeaders -> httpHeaders.set(config.name, config.value))
-					.build();
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				ServerHttpRequest request = exchange.getRequest().mutate()
+						.headers(
+								httpHeaders -> httpHeaders.set(config.name, config.value))
+						.build();
 
-			return chain.filter(exchange.mutate().request(request).build());
+				return chain.filter(exchange.mutate().request(request).build());
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(SetRequestHeaderGatewayFilterFactory.this)
+						.append(config.getName(), config.getValue()).toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactory.java
@@ -20,6 +20,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
@@ -36,8 +37,9 @@ public class SetResponseHeaderGatewayFilterFactory
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange,
 					GatewayFilterChain chain) {
+				String value = ServerWebExchangeUtils.expand(exchange, config.getValue());
 				return chain.filter(exchange).then(Mono.fromRunnable(() -> exchange
-						.getResponse().getHeaders().set(config.name, config.value)));
+						.getResponse().getHeaders().set(config.name, value)));
 			}
 
 			@Override

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactory.java
@@ -19,6 +19,10 @@ package org.springframework.cloud.gateway.filter.factory;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
  * @author Spencer Gibb
@@ -28,9 +32,20 @@ public class SetResponseHeaderGatewayFilterFactory
 
 	@Override
 	public GatewayFilter apply(NameValueConfig config) {
-		return (exchange, chain) -> chain.filter(exchange).then(Mono.fromRunnable(() -> {
-			exchange.getResponse().getHeaders().set(config.name, config.value);
-		}));
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				return chain.filter(exchange).then(Mono.fromRunnable(() -> exchange
+						.getResponse().getHeaders().set(config.name, config.value)));
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(SetResponseHeaderGatewayFilterFactory.this)
+						.append(config.getName(), config.getValue()).toString();
+			}
+		};
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
@@ -23,6 +23,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.cloud.gateway.support.BodyInserterContext;
 import org.springframework.core.io.buffer.DataBuffer;
@@ -37,8 +38,10 @@ import org.springframework.web.reactive.function.server.HandlerStrategies;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ServerWebExchange;
 
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
+
 /**
- * This filter is BETA and may be subject to change in a future release.
+ * GatewayFilter that modifies the request body.
  */
 public class ModifyRequestBodyGatewayFilterFactory extends
 		AbstractGatewayFilterFactory<ModifyRequestBodyGatewayFilterFactory.Config> {
@@ -58,40 +61,52 @@ public class ModifyRequestBodyGatewayFilterFactory extends
 	@Override
 	@SuppressWarnings("unchecked")
 	public GatewayFilter apply(Config config) {
-		return (exchange, chain) -> {
-			Class inClass = config.getInClass();
-			ServerRequest serverRequest = ServerRequest.create(exchange,
-					this.messageReaders);
+		return new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				Class inClass = config.getInClass();
+				ServerRequest serverRequest = ServerRequest.create(exchange,
+						messageReaders);
 
-			// TODO: flux or mono
-			Mono<?> modifiedBody = serverRequest.bodyToMono(inClass)
-					// .log("modify_request_mono", Level.INFO)
-					.flatMap(o -> config.rewriteFunction.apply(exchange, o));
+				// TODO: flux or mono
+				Mono<?> modifiedBody = serverRequest.bodyToMono(inClass)
+						// .log("modify_request_mono", Level.INFO)
+						.flatMap(o -> config.rewriteFunction.apply(exchange, o));
 
-			BodyInserter bodyInserter = BodyInserters.fromPublisher(modifiedBody,
-					config.getOutClass());
-			HttpHeaders headers = new HttpHeaders();
-			headers.putAll(exchange.getRequest().getHeaders());
+				BodyInserter bodyInserter = BodyInserters.fromPublisher(modifiedBody,
+						config.getOutClass());
+				HttpHeaders headers = new HttpHeaders();
+				headers.putAll(exchange.getRequest().getHeaders());
 
-			// the new content type will be computed by bodyInserter
-			// and then set in the request decorator
-			headers.remove(HttpHeaders.CONTENT_LENGTH);
+				// the new content type will be computed by bodyInserter
+				// and then set in the request decorator
+				headers.remove(HttpHeaders.CONTENT_LENGTH);
 
-			// if the body is changing content types, set it here, to the bodyInserter
-			// will know about it
-			if (config.getContentType() != null) {
-				headers.set(HttpHeaders.CONTENT_TYPE, config.getContentType());
+				// if the body is changing content types, set it here, to the bodyInserter
+				// will know about it
+				if (config.getContentType() != null) {
+					headers.set(HttpHeaders.CONTENT_TYPE, config.getContentType());
+				}
+				CachedBodyOutputMessage outputMessage = new CachedBodyOutputMessage(
+						exchange, headers);
+				return bodyInserter.insert(outputMessage, new BodyInserterContext())
+						// .log("modify_request", Level.INFO)
+						.then(Mono.defer(() -> {
+							ServerHttpRequest decorator = decorate(exchange, headers,
+									outputMessage);
+							return chain
+									.filter(exchange.mutate().request(decorator).build());
+						}));
 			}
-			CachedBodyOutputMessage outputMessage = new CachedBodyOutputMessage(exchange,
-					headers);
-			return bodyInserter.insert(outputMessage, new BodyInserterContext())
-					// .log("modify_request", Level.INFO)
-					.then(Mono.defer(() -> {
-						ServerHttpRequest decorator = decorate(exchange, headers,
-								outputMessage);
-						return chain.filter(exchange.mutate().request(decorator).build());
-					}));
 
+			@Override
+			public String toString() {
+				return filterToStringCreator(ModifyRequestBodyGatewayFilterFactory.this)
+						.append("Content type", config.getContentType())
+						.append("In class", config.getInClass())
+						.append("Out class", config.getOutClass()).toString();
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/AsyncPredicate.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/AsyncPredicate.java
@@ -17,12 +17,15 @@
 package org.springframework.cloud.gateway.handler;
 
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import org.springframework.cloud.gateway.handler.predicate.GatewayPredicate;
 import org.springframework.util.Assert;
+import org.springframework.web.server.ServerWebExchange;
 
 /**
  * @author Ben Hale
@@ -30,21 +33,115 @@ import org.springframework.util.Assert;
 public interface AsyncPredicate<T> extends Function<T, Publisher<Boolean>> {
 
 	default AsyncPredicate<T> and(AsyncPredicate<? super T> other) {
-		Assert.notNull(other, "other must not be null");
-
-		return t -> Flux.zip(apply(t), other.apply(t))
-				.map(tuple -> tuple.getT1() && tuple.getT2());
+		return new AndAsyncPredicate<>(this, other);
 	}
 
 	default AsyncPredicate<T> negate() {
-		return t -> Mono.from(apply(t)).map(b -> !b);
+		return new NegateAsyncPredicate<>(this);
 	}
 
 	default AsyncPredicate<T> or(AsyncPredicate<? super T> other) {
-		Assert.notNull(other, "other must not be null");
+		return new OrAsyncPredicate<>(this, other);
+	}
 
-		return t -> Flux.zip(apply(t), other.apply(t))
-				.map(tuple -> tuple.getT1() || tuple.getT2());
+	static AsyncPredicate<ServerWebExchange> from(
+			Predicate<? super ServerWebExchange> predicate) {
+		return new DefaultAsyncPredicate<>(GatewayPredicate.wrapIfNeeded(predicate));
+	}
+
+	class DefaultAsyncPredicate<T> implements AsyncPredicate<T> {
+
+		private final Predicate<T> delegate;
+
+		public DefaultAsyncPredicate(Predicate<T> delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Publisher<Boolean> apply(T t) {
+			return Mono.just(delegate.test(t));
+		}
+
+		@Override
+		public String toString() {
+			return this.delegate.toString();
+		}
+
+	}
+
+	class NegateAsyncPredicate<T> implements AsyncPredicate<T> {
+
+		private final AsyncPredicate<? super T> predicate;
+
+		public NegateAsyncPredicate(AsyncPredicate<? super T> predicate) {
+			Assert.notNull(predicate, "predicate AsyncPredicate must not be null");
+			this.predicate = predicate;
+		}
+
+		@Override
+		public Publisher<Boolean> apply(T t) {
+			return Mono.from(predicate.apply(t)).map(b -> !b);
+		}
+
+		@Override
+		public String toString() {
+			return String.format("!%s", this.predicate);
+		}
+
+	}
+
+	class AndAsyncPredicate<T> implements AsyncPredicate<T> {
+
+		private final AsyncPredicate<? super T> left;
+
+		private final AsyncPredicate<? super T> right;
+
+		public AndAsyncPredicate(AsyncPredicate<? super T> left,
+				AsyncPredicate<? super T> right) {
+			Assert.notNull(left, "Left AsyncPredicate must not be null");
+			Assert.notNull(right, "Right AsyncPredicate must not be null");
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public Publisher<Boolean> apply(T t) {
+			return Flux.zip(left.apply(t), right.apply(t))
+					.map(tuple -> tuple.getT1() && tuple.getT2());
+		}
+
+		@Override
+		public String toString() {
+			return String.format("(%s && %s)", this.left, this.right);
+		}
+
+	}
+
+	class OrAsyncPredicate<T> implements AsyncPredicate<T> {
+
+		private final AsyncPredicate<? super T> left;
+
+		private final AsyncPredicate<? super T> right;
+
+		public OrAsyncPredicate(AsyncPredicate<? super T> left,
+				AsyncPredicate<? super T> right) {
+			Assert.notNull(left, "Left AsyncPredicate must not be null");
+			Assert.notNull(right, "Right AsyncPredicate must not be null");
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public Publisher<Boolean> apply(T t) {
+			return Flux.zip(left.apply(t), right.apply(t))
+					.map(tuple -> tuple.getT1() || tuple.getT2());
+		}
+
+		@Override
+		public String toString() {
+			return String.format("(%s || %s)", this.left, this.right);
+		}
+
 	}
 
 }

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/AfterRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/AfterRoutePredicateFactory.java
@@ -47,10 +47,17 @@ public class AfterRoutePredicateFactory
 
 	@Override
 	public Predicate<ServerWebExchange> apply(Config config) {
-		ZonedDateTime datetime = config.getDatetime();
-		return exchange -> {
-			final ZonedDateTime now = ZonedDateTime.now();
-			return now.isAfter(datetime);
+		return new GatewayPredicate() {
+			@Override
+			public boolean test(ServerWebExchange serverWebExchange) {
+				final ZonedDateTime now = ZonedDateTime.now();
+				return now.isAfter(config.getDatetime());
+			}
+
+			@Override
+			public String toString() {
+				return String.format("After: %s", config.getDatetime());
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactory.java
@@ -45,10 +45,17 @@ public class BeforeRoutePredicateFactory
 
 	@Override
 	public Predicate<ServerWebExchange> apply(Config config) {
-		ZonedDateTime datetime = config.getDatetime();
-		return exchange -> {
-			final ZonedDateTime now = ZonedDateTime.now();
-			return now.isBefore(datetime);
+		return new GatewayPredicate() {
+			@Override
+			public boolean test(ServerWebExchange serverWebExchange) {
+				final ZonedDateTime now = ZonedDateTime.now();
+				return now.isBefore(config.getDatetime());
+			}
+
+			@Override
+			public String toString() {
+				return String.format("Before: %s", config.getDatetime());
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactory.java
@@ -54,14 +54,22 @@ public class BetweenRoutePredicateFactory
 
 	@Override
 	public Predicate<ServerWebExchange> apply(Config config) {
-		ZonedDateTime datetime1 = config.datetime1;
-		ZonedDateTime datetime2 = config.datetime2;
-		Assert.isTrue(datetime1.isBefore(datetime2),
-				config.datetime1 + " must be before " + config.datetime2);
+		Assert.isTrue(config.getDatetime1().isBefore(config.getDatetime2()),
+				config.getDatetime1() + " must be before " + config.getDatetime2());
 
-		return exchange -> {
-			final ZonedDateTime now = ZonedDateTime.now();
-			return now.isAfter(datetime1) && now.isBefore(datetime2);
+		return new GatewayPredicate() {
+			@Override
+			public boolean test(ServerWebExchange serverWebExchange) {
+				final ZonedDateTime now = ZonedDateTime.now();
+				return now.isAfter(config.getDatetime1())
+						&& now.isBefore(config.getDatetime2());
+			}
+
+			@Override
+			public String toString() {
+				return String.format("Between: %s and %s", config.getDatetime1(),
+						config.getDatetime2());
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactory.java
@@ -53,18 +53,27 @@ public class CookieRoutePredicateFactory
 
 	@Override
 	public Predicate<ServerWebExchange> apply(Config config) {
-		return exchange -> {
-			List<HttpCookie> cookies = exchange.getRequest().getCookies()
-					.get(config.name);
-			if (cookies == null) {
+		return new GatewayPredicate() {
+			@Override
+			public boolean test(ServerWebExchange exchange) {
+				List<HttpCookie> cookies = exchange.getRequest().getCookies()
+						.get(config.name);
+				if (cookies == null) {
+					return false;
+				}
+				for (HttpCookie cookie : cookies) {
+					if (cookie.getValue().matches(config.regexp)) {
+						return true;
+					}
+				}
 				return false;
 			}
-			for (HttpCookie cookie : cookies) {
-				if (cookie.getValue().matches(config.regexp)) {
-					return true;
-				}
+
+			@Override
+			public String toString() {
+				return String.format("Cookie: name=%s regexp=%s", config.name,
+						config.regexp);
 			}
-			return false;
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/GatewayPredicate.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/GatewayPredicate.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.handler.predicate;
+
+import java.util.function.Predicate;
+
+import org.springframework.util.Assert;
+import org.springframework.web.server.ServerWebExchange;
+
+public interface GatewayPredicate extends Predicate<ServerWebExchange> {
+
+	@Override
+	default Predicate<ServerWebExchange> and(Predicate<? super ServerWebExchange> other) {
+		return new AndGatewayPredicate(this, wrapIfNeeded(other));
+	}
+
+	@Override
+	default Predicate<ServerWebExchange> negate() {
+		return new NegateGatewayPredicate(this);
+	}
+
+	@Override
+	default Predicate<ServerWebExchange> or(Predicate<? super ServerWebExchange> other) {
+		return new OrGatewayPredicate(this, wrapIfNeeded(other));
+	}
+
+	static GatewayPredicate wrapIfNeeded(Predicate<? super ServerWebExchange> other) {
+		GatewayPredicate right;
+
+		if (other instanceof GatewayPredicate) {
+			right = (GatewayPredicate) other;
+		}
+		else {
+			right = new GatewayPredicateWrapper(other);
+		}
+		return right;
+	}
+
+	class GatewayPredicateWrapper implements GatewayPredicate {
+
+		private final Predicate<? super ServerWebExchange> delegate;
+
+		public GatewayPredicateWrapper(Predicate<? super ServerWebExchange> delegate) {
+			Assert.notNull(delegate, "delegate GatewayPredicate must not be null");
+			this.delegate = delegate;
+		}
+
+		@Override
+		public boolean test(ServerWebExchange exchange) {
+			return this.delegate.test(exchange);
+		}
+
+		@Override
+		public String toString() {
+			return this.delegate.getClass().getSimpleName();
+		}
+
+	}
+
+	class NegateGatewayPredicate implements GatewayPredicate {
+
+		private final GatewayPredicate predicate;
+
+		public NegateGatewayPredicate(GatewayPredicate predicate) {
+			Assert.notNull(predicate, "predicate GatewayPredicate must not be null");
+			this.predicate = predicate;
+		}
+
+		@Override
+		public boolean test(ServerWebExchange t) {
+			return !this.predicate.test(t);
+		}
+
+		@Override
+		public String toString() {
+			return String.format("!%s", this.predicate);
+		}
+
+	}
+
+	class AndGatewayPredicate implements GatewayPredicate {
+
+		private final GatewayPredicate left;
+
+		private final GatewayPredicate right;
+
+		public AndGatewayPredicate(GatewayPredicate left, GatewayPredicate right) {
+			Assert.notNull(left, "Left GatewayPredicate must not be null");
+			Assert.notNull(right, "Right GatewayPredicate must not be null");
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public boolean test(ServerWebExchange t) {
+			return (this.left.test(t) && this.right.test(t));
+		}
+
+		@Override
+		public String toString() {
+			return String.format("(%s && %s)", this.left, this.right);
+		}
+
+	}
+
+	class OrGatewayPredicate implements GatewayPredicate {
+
+		private final GatewayPredicate left;
+
+		private final GatewayPredicate right;
+
+		public OrGatewayPredicate(GatewayPredicate left, GatewayPredicate right) {
+			Assert.notNull(left, "Left GatewayPredicate must not be null");
+			Assert.notNull(right, "Right GatewayPredicate must not be null");
+			this.left = left;
+			this.right = right;
+		}
+
+		@Override
+		public boolean test(ServerWebExchange t) {
+			return (this.left.test(t) || this.right.test(t));
+		}
+
+		@Override
+		public String toString() {
+			return String.format("(%s || %s)", this.left, this.right);
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactory.java
@@ -45,9 +45,17 @@ public class MethodRoutePredicateFactory
 
 	@Override
 	public Predicate<ServerWebExchange> apply(Config config) {
-		return exchange -> {
-			HttpMethod requestMethod = exchange.getRequest().getMethod();
-			return requestMethod == config.getMethod();
+		return new GatewayPredicate() {
+			@Override
+			public boolean test(ServerWebExchange exchange) {
+				HttpMethod requestMethod = exchange.getRequest().getMethod();
+				return requestMethod == config.getMethod();
+			}
+
+			@Override
+			public String toString() {
+				return String.format("Method: %s", config.getMethod());
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
@@ -84,31 +84,40 @@ public class WeightRoutePredicateFactory
 
 	@Override
 	public Predicate<ServerWebExchange> apply(WeightConfig config) {
-		return exchange -> {
-			Map<String, String> weights = exchange.getAttributeOrDefault(WEIGHT_ATTR,
-					Collections.emptyMap());
+		return new GatewayPredicate() {
+			@Override
+			public boolean test(ServerWebExchange exchange) {
+				Map<String, String> weights = exchange.getAttributeOrDefault(WEIGHT_ATTR,
+						Collections.emptyMap());
 
-			String routeId = exchange.getAttribute(GATEWAY_PREDICATE_ROUTE_ATTR);
+				String routeId = exchange.getAttribute(GATEWAY_PREDICATE_ROUTE_ATTR);
 
-			// all calculations and comparison against random num happened in
-			// WeightCalculatorWebFilter
-			String group = config.getGroup();
-			if (weights.containsKey(group)) {
+				// all calculations and comparison against random num happened in
+				// WeightCalculatorWebFilter
+				String group = config.getGroup();
+				if (weights.containsKey(group)) {
 
-				String chosenRoute = weights.get(group);
-				if (log.isTraceEnabled()) {
-					log.trace("in group weight: " + group + ", current route: " + routeId
-							+ ", chosen route: " + chosenRoute);
+					String chosenRoute = weights.get(group);
+					if (log.isTraceEnabled()) {
+						log.trace("in group weight: " + group + ", current route: "
+								+ routeId + ", chosen route: " + chosenRoute);
+					}
+
+					return routeId.equals(chosenRoute);
+				}
+				else if (log.isTraceEnabled()) {
+					log.trace("no weights found for group: " + group + ", current route: "
+							+ routeId);
 				}
 
-				return routeId.equals(chosenRoute);
-			}
-			else if (log.isTraceEnabled()) {
-				log.trace("no weights found for group: " + group + ", current route: "
-						+ routeId);
+				return false;
 			}
 
-			return false;
+			@Override
+			public String toString() {
+				return String.format("Weight: %s %s", config.getGroup(),
+						config.getWeight());
+			}
 		};
 	}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/GatewayToStringStyler.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/GatewayToStringStyler.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.support;
+
+import java.util.function.Function;
+
+import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.core.style.DefaultToStringStyler;
+import org.springframework.core.style.DefaultValueStyler;
+import org.springframework.core.style.ToStringCreator;
+import org.springframework.util.ClassUtils;
+
+public class GatewayToStringStyler extends DefaultToStringStyler {
+
+	private static final GatewayToStringStyler FILTER_INSTANCE = new GatewayToStringStyler(
+			GatewayFilterFactory.class, NameUtils::normalizeFilterFactoryName);
+
+	private final Function<Class, String> classNameFormatter;
+
+	private final Class instanceClass;
+
+	public static ToStringCreator filterToStringCreator(Object obj) {
+		return new ToStringCreator(obj, FILTER_INSTANCE);
+	}
+
+	public GatewayToStringStyler(Class instanceClass,
+			Function<Class, String> classNameFormatter) {
+		super(new DefaultValueStyler());
+		this.classNameFormatter = classNameFormatter;
+		this.instanceClass = instanceClass;
+	}
+
+	@Override
+	public void styleStart(StringBuilder buffer, Object obj) {
+		if (!obj.getClass().isArray()) {
+			String shortName;
+			if (instanceClass.isInstance(obj)) {
+				shortName = classNameFormatter.apply(obj.getClass());
+			}
+			else {
+				shortName = ClassUtils.getShortName(obj.getClass());
+			}
+			buffer.append('[').append(shortName);
+		}
+		else {
+			buffer.append('[');
+			styleValue(buffer, obj);
+		}
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -246,7 +246,7 @@ public final class ServerWebExchangeUtils {
 	public static AsyncPredicate<ServerWebExchange> toAsyncPredicate(
 			Predicate<? super ServerWebExchange> predicate) {
 		Assert.notNull(predicate, "predicate must not be null");
-		return t -> Mono.just(predicate.test(t));
+		return AsyncPredicate.from(predicate);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -249,6 +249,19 @@ public final class ServerWebExchangeUtils {
 		return AsyncPredicate.from(predicate);
 	}
 
+	public static String expand(ServerWebExchange exchange, String template) {
+		Assert.notNull(exchange, "exchange may not be null");
+		Assert.notNull(template, "template may not be null");
+
+		if (template.indexOf('{') == -1) { // short circuit
+			return template;
+		}
+
+		Map<String, String> variables = getUriTemplateVariables(exchange);
+		return UriComponentsBuilder.fromPath(template).build().expand(variables)
+				.getPath();
+	}
+
 	@SuppressWarnings("unchecked")
 	public static void putUriTemplateVariables(ServerWebExchange exchange,
 			Map<String, String> uriVariables) {

--- a/spring-cloud-gateway-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-gateway-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -17,6 +17,12 @@
       "type": "java.lang.Boolean",
       "description": "Enables the collection of metrics data.",
       "defaultValue": "true"
+    },
+    {
+      "name": "spring.cloud.gateway.httpserver.wiretap",
+      "type": "java.lang.Boolean",
+      "description": "Enables wiretap debugging for Netty HttpServer.",
+      "defaultValue": "false"
     }
   ]
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
@@ -27,7 +27,10 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.PermitAllSecurityConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -62,11 +65,28 @@ public class GatewayControllerEndpointTests {
 				});
 	}
 
+	@Test
+	public void testGetSpecificRoute() {
+		testClient.get().uri("http://localhost:" + port + "/actuator/gateway/routes/test-service")
+				.exchange().expectStatus().isOk().expectBodyList(Map.class)
+				.consumeWith(result -> {
+					List<Map> responseBody = result.getResponseBody();
+					assertThat(responseBody).isNotNull();
+					assertThat(responseBody.size()).isEqualTo(1);
+					assertThat(responseBody).isNotEmpty();
+				});
+	}
+
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
 	@Import(PermitAllSecurityConfiguration.class)
 	static class TestConfig {
-
+		@Bean
+		RouteLocator testRouteLocator(RouteLocatorBuilder routeLocatorBuilder) {
+			return routeLocatorBuilder.routes()
+					.route("test-service", routePredicate -> routePredicate.path("/test-service/**").uri("lb://test-service"))
+					.build();
+		}
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
@@ -117,22 +117,22 @@ public class GatewayAutoConfigurationTests {
 	}
 
 	@Test
-	public void legacyActuatorEnabledByDefault() {
+	public void verboseActuatorEnabledByDefault() {
 		try (ConfigurableApplicationContext ctx = SpringApplication.run(Config.class,
 				"--spring.jmx.enabled=false", "--server.port=0")) {
 			assertThat(ctx.getBeanNamesForType(GatewayControllerEndpoint.class))
-					.isEmpty();
-			assertThat(ctx.getBeanNamesForType(GatewayLegacyControllerEndpoint.class))
 					.hasSize(1);
+			assertThat(ctx.getBeanNamesForType(GatewayLegacyControllerEndpoint.class))
+					.isEmpty();
 		}
 	}
 
 	@Test
-	public void verboseActuatorEnabled() {
+	public void verboseActuatorDisabled() {
 		try (ConfigurableApplicationContext ctx = SpringApplication.run(Config.class,
 				"--spring.jmx.enabled=false", "--server.port=0",
-				"--spring.cloud.gateway.actuator.verbose.enabled=true")) {
-			assertThat(ctx.getBeanNamesForType(GatewayControllerEndpoint.class))
+				"--spring.cloud.gateway.actuator.verbose.enabled=false")) {
+			assertThat(ctx.getBeanNamesForType(GatewayLegacyControllerEndpoint.class))
 					.hasSize(1);
 		}
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
@@ -27,6 +27,8 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
 import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner;
+import org.springframework.cloud.gateway.actuate.GatewayControllerEndpoint;
+import org.springframework.cloud.gateway.actuate.GatewayLegacyControllerEndpoint;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.web.filter.reactive.HiddenHttpMethodFilter;
 import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
@@ -37,9 +39,8 @@ public class GatewayAutoConfigurationTests {
 
 	@Test
 	public void noHiddenHttpMethodFilter() {
-		try (ConfigurableApplicationContext ctx = SpringApplication.run(
-				NoHiddenHttpMethodFilterConfig.class, "--spring.jmx.enabled=false",
-				"--server.port=0")) {
+		try (ConfigurableApplicationContext ctx = SpringApplication.run(Config.class,
+				"--spring.jmx.enabled=false", "--server.port=0")) {
 			assertThat(ctx.getEnvironment()
 					.getProperty("spring.webflux.hiddenmethod.filter.enabled"))
 							.isEqualTo("false");
@@ -115,9 +116,30 @@ public class GatewayAutoConfigurationTests {
 				});
 	}
 
+	@Test
+	public void legacyActuatorEnabledByDefault() {
+		try (ConfigurableApplicationContext ctx = SpringApplication.run(Config.class,
+				"--spring.jmx.enabled=false", "--server.port=0")) {
+			assertThat(ctx.getBeanNamesForType(GatewayControllerEndpoint.class))
+					.isEmpty();
+			assertThat(ctx.getBeanNamesForType(GatewayLegacyControllerEndpoint.class))
+					.hasSize(1);
+		}
+	}
+
+	@Test
+	public void verboseActuatorEnabled() {
+		try (ConfigurableApplicationContext ctx = SpringApplication.run(Config.class,
+				"--spring.jmx.enabled=false", "--server.port=0",
+				"--spring.cloud.gateway.actuator.verbose.enabled=true")) {
+			assertThat(ctx.getBeanNamesForType(GatewayControllerEndpoint.class))
+					.hasSize(1);
+		}
+	}
+
 	@EnableAutoConfiguration
 	@SpringBootConfiguration
-	protected static class NoHiddenHttpMethodFilterConfig {
+	protected static class Config {
 
 	}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactoryTests.java
@@ -25,6 +25,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractNameValueGatewayFilterFactory.NameValueConfig;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -66,6 +68,14 @@ public class AddRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTest
 							"headers");
 					assertThat(headers).containsEntry("X-Request-Acme", "ValueB");
 				});
+	}
+
+	@Test
+	public void toStringFormat() {
+		NameValueConfig config = new NameValueConfig().setName("myname")
+				.setValue("myvalue");
+		GatewayFilter filter = new AddRequestHeaderGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("myname").contains("myvalue");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestHeaderGatewayFilterFactoryTests.java
@@ -66,7 +66,7 @@ public class AddRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTest
 				.exchange().expectBody(Map.class).consumeWith(result -> {
 					Map<String, Object> headers = getMap(result.getResponseBody(),
 							"headers");
-					assertThat(headers).containsEntry("X-Request-Acme", "ValueB");
+					assertThat(headers).containsEntry("X-Request-Acme", "ValueB-www");
 				});
 	}
 
@@ -89,9 +89,9 @@ public class AddRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTest
 		@Bean
 		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
 			return builder.routes().route("add_request_header_java_test",
-					r -> r.path("/headers").and().host("**.addrequestheaderjava.org")
+					r -> r.path("/headers").and().host("{sub}.addrequestheaderjava.org")
 							.filters(f -> f.prefixPath("/httpbin")
-									.addRequestHeader("X-Request-Acme", "ValueB"))
+									.addRequestHeader("X-Request-Acme", "ValueB-{sub}"))
 							.uri(uri))
 					.build();
 		}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactoryTests.java
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractNameValueGatewayFilterFactory.NameValueConfig;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -105,6 +107,15 @@ public class AddRequestParameterGatewayFilterFactoryTests extends BaseWebClientT
 						}
 					}
 				});
+	}
+
+	@Test
+	public void toStringFormat() {
+		NameValueConfig config = new NameValueConfig().setName("myname")
+				.setValue("myvalue");
+		GatewayFilter filter = new AddRequestParameterGatewayFilterFactory()
+				.apply(config);
+		assertThat(filter.toString()).contains("myname").contains("myvalue");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddRequestParameterGatewayFilterFactoryTests.java
@@ -68,7 +68,7 @@ public class AddRequestParameterGatewayFilterFactoryTests extends BaseWebClientT
 
 	@Test
 	public void addRequestParameterFilterWorksEncodedQueryJavaDsl() {
-		testRequestParameterFilter("www.addreqparamjava.org", "ValueB", "javaname",
+		testRequestParameterFilter("www.addreqparamjava.org", "ValueB-www", "javaname",
 				"%E6%89%8E%E6%A0%B9");
 	}
 
@@ -129,9 +129,9 @@ public class AddRequestParameterGatewayFilterFactoryTests extends BaseWebClientT
 		@Bean
 		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
 			return builder.routes().route("add_request_param_java_test",
-					r -> r.path("/get").and().host("**.addreqparamjava.org")
+					r -> r.path("/get").and().host("{sub}.addreqparamjava.org")
 							.filters(f -> f.prefixPath("/httpbin")
-									.addRequestParameter("example", "ValueB"))
+									.addRequestParameter("example", "ValueB-{sub}"))
 							.uri(uri))
 					.build();
 		}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddResponseHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/AddResponseHeaderGatewayFilterFactoryTests.java
@@ -59,7 +59,7 @@ public class AddResponseHeaderGatewayFilterFactoryTests extends BaseWebClientTes
 		URI uri = UriComponentsBuilder.fromUriString(this.baseUri + "/get").build(true)
 				.toUri();
 		String host = "www.addresponseheaderjava.org";
-		String expectedValue = "myresponsevalue";
+		String expectedValue = "myresponsevalue-www";
 		testClient.get().uri(uri).header("Host", host).exchange().expectHeader()
 				.valueEquals("example", expectedValue);
 	}
@@ -83,9 +83,9 @@ public class AddResponseHeaderGatewayFilterFactoryTests extends BaseWebClientTes
 		@Bean
 		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
 			return builder.routes().route("add_response_header_java_test",
-					r -> r.path("/get").and().host("**.addresponseheaderjava.org")
-							.filters(f -> f.prefixPath("/httpbin")
-									.addResponseHeader("example", "myresponsevalue"))
+					r -> r.path("/get").and().host("{sub}.addresponseheaderjava.org")
+							.filters(f -> f.prefixPath("/httpbin").addResponseHeader(
+									"example", "myresponsevalue-{sub}"))
 							.uri(uri))
 					.build();
 		}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactoryUnitTests.java
@@ -23,7 +23,12 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.gateway.filter.factory.DedupeResponseHeaderGatewayFilterFactory.Config;
+import static org.springframework.cloud.gateway.filter.factory.DedupeResponseHeaderGatewayFilterFactory.Strategy;
 
 public class DedupeResponseHeaderGatewayFilterFactoryUnitTests {
 
@@ -33,14 +38,14 @@ public class DedupeResponseHeaderGatewayFilterFactoryUnitTests {
 
 	private HttpHeaders headers;
 
-	private DedupeResponseHeaderGatewayFilterFactory.Config config;
+	private Config config;
 
 	private DedupeResponseHeaderGatewayFilterFactory filter;
 
 	@Before
 	public void setUp() {
 		headers = Mockito.mock(HttpHeaders.class);
-		config = new DedupeResponseHeaderGatewayFilterFactory.Config();
+		config = new Config();
 		filter = new DedupeResponseHeaderGatewayFilterFactory();
 	}
 
@@ -99,7 +104,7 @@ public class DedupeResponseHeaderGatewayFilterFactoryUnitTests {
 	@Test
 	public void dedupMultipleValuesRetainLast() {
 		config.setName(NAME_1);
-		config.setStrategy(DedupeResponseHeaderGatewayFilterFactory.Strategy.RETAIN_LAST);
+		config.setStrategy(Strategy.RETAIN_LAST);
 		Mockito.when(headers.get(NAME_1)).thenReturn(Arrays.asList("2", "3", "3", "4"));
 		filter.dedupe(headers, config);
 		Mockito.verify(headers).get(NAME_1);
@@ -110,14 +115,24 @@ public class DedupeResponseHeaderGatewayFilterFactoryUnitTests {
 	@Test
 	public void dedupMultipleValuesRetainUnique() {
 		config.setName(NAME_1);
-		config.setStrategy(
-				DedupeResponseHeaderGatewayFilterFactory.Strategy.RETAIN_UNIQUE);
+		config.setStrategy(Strategy.RETAIN_UNIQUE);
 		Mockito.when(headers.get(NAME_1)).thenReturn(Arrays.asList("2", "3", "3", "4"));
 		filter.dedupe(headers, config);
 		Mockito.verify(headers).get(NAME_1);
 		Mockito.verify(headers).put(Mockito.eq(NAME_1),
 				Mockito.eq(Arrays.asList("2", "3", "4")));
 		Mockito.verify(headers).put(Mockito.anyString(), Mockito.anyList());
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setName("myname");
+		config.setStrategy(Strategy.RETAIN_LAST);
+		GatewayFilter filter = new DedupeResponseHeaderGatewayFilterFactory()
+				.apply(config);
+		assertThat(filter.toString()).contains("myname")
+				.contains(Strategy.RETAIN_LAST.toString());
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/HystrixGatewayFilterFactoryTests.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
@@ -28,6 +29,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.Assert;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.cloud.gateway.filter.factory.ExceptionFallbackHandler.RETRIEVED_EXCEPTION;
@@ -115,6 +117,14 @@ public class HystrixGatewayFilterFactoryTests extends BaseWebClientTests {
 							body.contains("(type=Internal Server Error, status=500)"),
 							"Cannot find the expected error status report in the response");
 				});
+	}
+
+	@Test
+	public void toStringFormat() {
+		HystrixGatewayFilterFactory.Config config = new HystrixGatewayFilterFactory.Config()
+				.setName("myname").setFallbackUri("forward:/myfallback");
+		GatewayFilter filter = new HystrixGatewayFilterFactory(null).apply(config);
+		assertThat(filter.toString()).contains("myname").contains("forward:/myfallback");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.PrefixPathGatewayFilterFactory.Config;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
@@ -67,6 +68,14 @@ public class PrefixPathGatewayFilterFactoryTest {
 		LinkedHashSet<URI> uris = webExchange
 				.getRequiredAttribute(GATEWAY_ORIGINAL_REQUEST_URL_ATTR);
 		assertThat(uris).contains(request.getURI());
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setPrefix("myprefix");
+		GatewayFilter filter = new PrefixPathGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("myprefix");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/PreserveHostHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/PreserveHostHeaderGatewayFilterFactoryTests.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -54,6 +55,12 @@ public class PreserveHostHeaderGatewayFilterFactoryTests extends BaseWebClientTe
 							"headers");
 					assertThat(headers).containsEntry("Host", "myhost.net");
 				});
+	}
+
+	@Test
+	public void toStringFormat() {
+		GatewayFilter filter = new PreserveHostHeaderGatewayFilterFactory().apply();
+		assertThat(filter.toString()).contains("PreserveHostHeader");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToGatewayFilterFactoryTests.java
@@ -22,6 +22,8 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.RedirectToGatewayFilterFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -32,6 +34,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -51,6 +54,15 @@ public class RedirectToGatewayFilterFactoryTests extends BaseWebClientTests {
 		testClient.get().uri("/").header("Host", "www.relativeredirect.org").exchange()
 				.expectStatus().isEqualTo(HttpStatus.FOUND).expectHeader()
 				.valueEquals(HttpHeaders.LOCATION, "/index.html#/customers");
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setStatus("301");
+		config.setUrl("http://newurl");
+		GatewayFilter filter = new RedirectToGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("301").contains("http://newurl");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestHeaderGatewayFilterFactoryTests.java
@@ -24,6 +24,8 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory.NameConfig;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
@@ -47,6 +49,15 @@ public class RemoveRequestHeaderGatewayFilterFactoryTests extends BaseWebClientT
 							"headers");
 					assertThat(headers).doesNotContainKey("X-Request-Foo");
 				});
+	}
+
+	@Test
+	public void toStringFormat() {
+		NameConfig config = new NameConfig();
+		config.setName("myname");
+		GatewayFilter filter = new RemoveRequestHeaderGatewayFilterFactory()
+				.apply(config);
+		assertThat(filter.toString()).contains("myname");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveResponseHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveResponseHeaderGatewayFilterFactoryTests.java
@@ -22,11 +22,14 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory.NameConfig;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -39,6 +42,15 @@ public class RemoveResponseHeaderGatewayFilterFactoryTests extends BaseWebClient
 		testClient.get().uri("/headers").header("Host", "www.removereresponseheader.org")
 				.exchange().expectStatus().isOk().expectHeader()
 				.doesNotExist("X-Request-Foo");
+	}
+
+	@Test
+	public void toStringFormat() {
+		NameConfig config = new NameConfig();
+		config.setName("myname");
+		GatewayFilter filter = new RemoveResponseHeaderGatewayFilterFactory()
+				.apply(config);
+		assertThat(filter.toString()).contains("myname");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestHeaderToRequestUriGatewayFilterFactoryTests.java
@@ -24,6 +24,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory.NameConfig;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
@@ -96,6 +97,15 @@ public class RequestHeaderToRequestUriGatewayFilterFactoryTests {
 		URI uri = (URI) webExchange.getAttributes().get(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(uri).isNotNull();
 		assertThat(uri.toURL().toString()).isEqualTo("http://localhost");
+	}
+
+	@Test
+	public void toStringFormat() {
+		NameConfig config = new NameConfig();
+		config.setName("myname");
+		GatewayFilter filter = new RequestHeaderToRequestUriGatewayFilterFactory()
+				.apply(config);
+		assertThat(filter.toString()).contains("myname");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestSizeGatewayFilterFactoryTest.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestSizeGatewayFilterFactoryTest.java
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.RequestSizeGatewayFilterFactory.RequestSizeConfig;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -32,6 +34,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 /**
@@ -52,6 +55,14 @@ public class RequestSizeGatewayFilterFactoryTest extends BaseWebClientTests {
 				.header("content-length", "6").syncBody("123456").exchange()
 				.expectStatus().isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE).expectHeader()
 				.valueMatches("errorMessage", responseMesssage);
+	}
+
+	@Test
+	public void toStringFormat() {
+		RequestSizeConfig config = new RequestSizeConfig();
+		config.setMaxSize(1000L);
+		GatewayFilter filter = new RequestSizeGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("max").contains("1000");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -33,6 +34,8 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.RetryGatewayFilterFactory.RetryConfig;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -109,6 +112,18 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 							.get("headers");
 					assertThat(headers).containsEntry("X-Forwarded-Host", host);
 				});
+	}
+
+	@Test
+	public void toStringFormat() {
+		RetryConfig config = new RetryConfig();
+		config.setRetries(4);
+		config.setMethods(HttpMethod.GET);
+		config.setSeries(HttpStatus.Series.SERVER_ERROR);
+		config.setExceptions(IOException.class);
+		GatewayFilter filter = new RetryGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("4").contains("[GET]")
+				.contains("[SERVER_ERROR]").contains("[IOException]");
 	}
 
 	@RestController

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RewritePathGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RewritePathGatewayFilterFactoryTests.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.RewritePathGatewayFilterFactory.Config;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -99,6 +100,13 @@ public class RewritePathGatewayFilterFactoryTests {
 
 		URI uri = exchange.getRequest().getURI();
 		assertThat(uri.getRawQuery()).isEqualTo("name=%E6%89%8E%E6%A0%B9");
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config().setRegexp("regexp1").setReplacement("replacement1");
+		GatewayFilter filter = new RewritePathGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("regexp1").contains("replacement1");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RewriteResponseHeaderGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RewriteResponseHeaderGatewayFilterFactoryUnitTests.java
@@ -19,6 +19,9 @@ package org.springframework.cloud.gateway.filter.factory;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.RewriteResponseHeaderGatewayFilterFactory.Config;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RewriteResponseHeaderGatewayFilterFactoryUnitTests {
@@ -40,6 +43,18 @@ public class RewriteResponseHeaderGatewayFilterFactoryUnitTests {
 	public void testRewriteMultiple() {
 		assertThat(filterFactory.rewrite("/foo/bar/wat/bar", "bar", "cafe"))
 				.isEqualTo("/foo/cafe/wat/cafe");
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setName("myname");
+		config.setRegexp("myregexp");
+		config.setReplacement("myreplacement");
+		GatewayFilter filter = new RewriteResponseHeaderGatewayFilterFactory()
+				.apply(config);
+		assertThat(filter.toString()).contains("myname").contains("myregexp")
+				.contains("myreplacement");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SaveSessionGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SaveSessionGatewayFilterFactoryTests.java
@@ -28,6 +28,7 @@ import reactor.test.StepVerifier;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -37,6 +38,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.server.WebSession;
 import org.springframework.web.server.session.WebSessionManager;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -68,6 +70,12 @@ public class SaveSessionGatewayFilterFactoryTests extends BaseWebClientTests {
 		}).expectComplete().verify(Duration.ofMinutes(10));
 
 		verify(mockWebSession).save();
+	}
+
+	@Test
+	public void toStringFormat() {
+		GatewayFilter filter = new SaveSessionGatewayFilterFactory().apply("");
+		assertThat(filter.toString()).contains("SaveSession");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -107,6 +108,13 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 				CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER,
 				X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER);
 
+	}
+
+	@Test
+	public void toStringFormat() {
+		GatewayFilter filter = new SecureHeadersGatewayFilterFactory(
+				new SecureHeadersProperties()).apply("");
+		Assertions.assertThat(filter.toString()).contains("SecureHeaders");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetPathGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetPathGatewayFilterFactoryTests.java
@@ -26,6 +26,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.SetPathGatewayFilterFactory.Config;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -100,6 +101,14 @@ public class SetPathGatewayFilterFactoryTests {
 		LinkedHashSet<URI> uris = webExchange
 				.getRequiredAttribute(GATEWAY_ORIGINAL_REQUEST_URL_ATTR);
 		assertThat(uris).contains(request.getURI());
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setTemplate("mytemplate");
+		GatewayFilter filter = new SetPathGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("mytemplate");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactoryTests.java
@@ -25,6 +25,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractNameValueGatewayFilterFactory.NameValueConfig;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -55,6 +57,14 @@ public class SetRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTest
 							"headers");
 					assertThat(headers).containsEntry("X-Req-Foo", "Second");
 				});
+	}
+
+	@Test
+	public void toStringFormat() {
+		NameValueConfig config = new NameValueConfig().setName("myname")
+				.setValue("myvalue");
+		GatewayFilter filter = new SetRequestHeaderGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("myname").contains("myvalue");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetRequestHeaderGatewayFilterFactoryTests.java
@@ -55,7 +55,9 @@ public class SetRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTest
 				.consumeWith(result -> {
 					Map<String, Object> headers = getMap(result.getResponseBody(),
 							"headers");
-					assertThat(headers).containsEntry("X-Req-Foo", "Second");
+					// add was called first, so sets will overwrite
+					assertThat(headers).doesNotContainEntry("X-Req-Foo", "First");
+					assertThat(headers).containsEntry("X-Req-Foo", "Second-www");
 				});
 	}
 
@@ -78,10 +80,10 @@ public class SetRequestHeaderGatewayFilterFactoryTests extends BaseWebClientTest
 		@Bean
 		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
 			return builder.routes().route("test_set_request_header",
-					r -> r.order(-1).host("**.setrequestheader.org")
+					r -> r.order(-1).host("{sub}.setrequestheader.org")
 							.filters(f -> f.prefixPath("/httpbin")
 									.addRequestHeader("X-Req-Foo", "First")
-									.setRequestHeader("X-Req-Foo", "Second"))
+									.setRequestHeader("X-Req-Foo", "Second-{sub}"))
 							.uri(uri))
 					.build();
 		}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactoryTests.java
@@ -22,11 +22,14 @@ import org.junit.runner.RunWith;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AbstractNameValueGatewayFilterFactory.NameValueConfig;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -39,6 +42,14 @@ public class SetResponseHeaderGatewayFilterFactoryTests extends BaseWebClientTes
 		testClient.get().uri("/headers").header("Host", "www.setreresponseheader.org")
 				.exchange().expectStatus().isOk().expectHeader()
 				.valueEquals("X-Request-Foo", "Bar");
+	}
+
+	@Test
+	public void toStringFormat() {
+		NameValueConfig config = new NameValueConfig().setName("myname")
+				.setValue("myvalue");
+		GatewayFilter filter = new SetResponseHeaderGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("myname").contains("myvalue");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetResponseHeaderGatewayFilterFactoryTests.java
@@ -19,12 +19,16 @@ package org.springframework.cloud.gateway.filter.factory;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractNameValueGatewayFilterFactory.NameValueConfig;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -41,7 +45,14 @@ public class SetResponseHeaderGatewayFilterFactoryTests extends BaseWebClientTes
 	public void setResponseHeaderFilterWorks() {
 		testClient.get().uri("/headers").header("Host", "www.setreresponseheader.org")
 				.exchange().expectStatus().isOk().expectHeader()
-				.valueEquals("X-Request-Foo", "Bar");
+				.valueEquals("X-Response-Foo", "Bar");
+	}
+
+	@Test
+	public void setResponseHeaderFilterWorksJavaDsl() {
+		testClient.get().uri("/headers").header("Host", "www.setresponseheaderdsl.org")
+				.exchange().expectStatus().isOk().expectHeader()
+				.valueEquals("X-Res-Foo", "Second-www");
 	}
 
 	@Test
@@ -56,6 +67,20 @@ public class SetResponseHeaderGatewayFilterFactoryTests extends BaseWebClientTes
 	@SpringBootConfiguration
 	@Import(DefaultTestConfig.class)
 	public static class TestConfig {
+
+		@Value("${test.uri}")
+		String uri;
+
+		@Bean
+		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
+			return builder.routes().route("test_set_response_header_dsl",
+					r -> r.order(-1).host("{sub}.setresponseheaderdsl.org")
+							.filters(f -> f.prefixPath("/httpbin")
+									.addResponseHeader("X-Res-Foo", "First")
+									.setResponseHeader("X-Res-Foo", "Second-{sub}"))
+							.uri(uri))
+					.build();
+		}
 
 	}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetStatusGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SetStatusGatewayFilterFactoryTests.java
@@ -24,6 +24,8 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.SetStatusGatewayFilterFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -74,6 +76,14 @@ public class SetStatusGatewayFilterFactoryTests extends BaseWebClientTests {
 		 * testClient.get() .uri("/status/432") .exchange() .expectStatus().isEqualTo(432)
 		 * .expectBody(String.class).isEqualTo("Failed with 432");
 		 */
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setStatus("401");
+		GatewayFilter filter = new SetStatusGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("401");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/StripPrefixGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/StripPrefixGatewayFilterFactoryTests.java
@@ -25,6 +25,7 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.factory.StripPrefixGatewayFilterFactory.Config;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
@@ -83,6 +84,14 @@ public class StripPrefixGatewayFilterFactoryTests {
 		LinkedHashSet<URI> uris = webExchange
 				.getRequiredAttribute(GATEWAY_ORIGINAL_REQUEST_URL_ATTR);
 		assertThat(uris).contains(request.getURI());
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setParts(2);
+		GatewayFilter filter = new StripPrefixGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("2");
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryUnitTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.rewrite;
+
+import org.junit.Test;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.rewrite.ModifyRequestBodyGatewayFilterFactory.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModifyRequestBodyGatewayFilterFactoryUnitTests {
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setInClass(String.class);
+		config.setOutClass(Integer.class);
+		config.setContentType("mycontenttype");
+		GatewayFilter filter = new ModifyRequestBodyGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("String").contains("Integer")
+				.contains("mycontenttype");
+	}
+
+}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactoryUnitTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.rewrite;
+
+import org.junit.Test;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.rewrite.ModifyResponseBodyGatewayFilterFactory.Config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ModifyResponseBodyGatewayFilterFactoryUnitTests {
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setInClass(String.class);
+		config.setOutClass(Integer.class);
+		config.setNewContentType("mycontenttype");
+		GatewayFilter filter = new ModifyResponseBodyGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("String").contains("Integer")
+				.contains("mycontenttype");
+	}
+
+}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/AfterRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/AfterRoutePredicateFactoryTests.java
@@ -18,8 +18,11 @@ package org.springframework.cloud.gateway.handler.predicate;
 
 import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.function.Predicate;
 
 import org.junit.Test;
+
+import org.springframework.cloud.gateway.handler.predicate.AfterRoutePredicateFactory.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.gateway.handler.predicate.AfterRoutePredicateFactory.DATETIME_KEY;
@@ -84,9 +87,17 @@ public class AfterRoutePredicateFactoryTests {
 		map.put(DATETIME_KEY, dateString);
 		AfterRoutePredicateFactory factory = new AfterRoutePredicateFactory();
 
-		AfterRoutePredicateFactory.Config config = bindConfig(map, factory);
+		Config config = bindConfig(map, factory);
 
 		return factory.apply(config).test(getExchange());
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setDatetime(ZonedDateTime.now());
+		Predicate predicate = new AfterRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("After: " + config.getDatetime());
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactoryTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.handler.predicate;
 
 import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.function.Predicate;
 
 import org.junit.Test;
 
@@ -88,6 +89,14 @@ public class BeforeRoutePredicateFactoryTests {
 		BeforeRoutePredicateFactory.Config config = bindConfig(map, factory);
 
 		return factory.apply(config).test(getExchange());
+	}
+
+	@Test
+	public void toStringFormat() {
+		BeforeRoutePredicateFactory.Config config = new BeforeRoutePredicateFactory.Config();
+		config.setDatetime(ZonedDateTime.now());
+		Predicate predicate = new BeforeRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("Before: " + config.getDatetime());
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactoryTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gateway.handler.predicate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.function.Predicate;
 
 import org.junit.Test;
 
@@ -158,6 +159,16 @@ public class BetweenRoutePredicateFactoryTests {
 		BetweenRoutePredicateFactory.Config config = bindConfig(map, factory);
 
 		return factory.apply(config).test(getExchange());
+	}
+
+	@Test
+	public void toStringFormat() {
+		BetweenRoutePredicateFactory.Config config = new BetweenRoutePredicateFactory.Config();
+		config.setDatetime1(ZonedDateTime.now());
+		config.setDatetime2(ZonedDateTime.now().plusHours(1));
+		Predicate predicate = new BetweenRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains(
+				"Between: " + config.getDatetime1() + " and " + config.getDatetime2());
 	}
 
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactoryTests.java
@@ -57,4 +57,14 @@ public class CookieRoutePredicateFactoryTests extends BaseWebClientTests {
 		assertThat(predicate.test(exchange)).isTrue();
 	}
 
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setName("mycookie");
+		config.setRegexp("myregexp");
+		Predicate predicate = new CookieRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString())
+				.contains("Cookie: name=mycookie regexp=myregexp");
+	}
+
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactoryTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.function.Predicate;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -24,6 +26,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
+import org.springframework.cloud.gateway.handler.predicate.HeaderRoutePredicateFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -32,6 +35,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -66,6 +70,15 @@ public class HeaderRoutePredicateFactoryTests extends BaseWebClientTests {
 				.valueEquals(HANDLER_MAPPER_HEADER,
 						RoutePredicateHandlerMapping.class.getSimpleName())
 				.expectHeader().valueEquals(ROUTE_ID_HEADER, "header_exists_dsl");
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setHeader("myheader");
+		config.setRegexp("myregexp");
+		Predicate predicate = new HeaderRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("Header: myheader regexp=myregexp");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/HostRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/HostRoutePredicateFactoryTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.Arrays;
+import java.util.function.Predicate;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -24,6 +27,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
+import org.springframework.cloud.gateway.handler.predicate.HostRoutePredicateFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -32,6 +36,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -73,6 +78,13 @@ public class HostRoutePredicateFactoryTests extends BaseWebClientTests {
 	public void mulitHostRouteDslWorks() {
 		expectHostRoute("www.hostmultidsl1.org", "host_multi_dsl");
 		expectHostRoute("www.hostmultidsl2.org", "host_multi_dsl");
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config().setPatterns(Arrays.asList("pattern1", "pattern2"));
+		Predicate predicate = new HostRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("pattern1").contains("pattern2");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactoryTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.function.Predicate;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -23,11 +25,14 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
+import org.springframework.cloud.gateway.handler.predicate.MethodRoutePredicateFactory.Config;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpMethod;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -42,6 +47,14 @@ public class MethodRoutePredicateFactoryTests extends BaseWebClientTests {
 				.valueEquals(HANDLER_MAPPER_HEADER,
 						RoutePredicateHandlerMapping.class.getSimpleName())
 				.expectHeader().valueEquals(ROUTE_ID_HEADER, "method_test");
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setMethod(HttpMethod.GET);
+		Predicate predicate = new MethodRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("Method: " + config.getMethod());
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.Arrays;
+import java.util.function.Predicate;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -24,6 +27,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
+import org.springframework.cloud.gateway.handler.predicate.PathRoutePredicateFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -33,6 +37,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @RunWith(SpringRunner.class)
@@ -91,6 +96,15 @@ public class PathRoutePredicateFactoryTests extends BaseWebClientTests {
 				.valueEquals(HANDLER_MAPPER_HEADER,
 						RoutePredicateHandlerMapping.class.getSimpleName())
 				.expectHeader().valueEquals(ROUTE_ID_HEADER, "path_test");
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config().setPatterns(Arrays.asList("patternA", "patternB"))
+				.setMatchOptionalTrailingSeparator(false);
+		Predicate predicate = new PathRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("patternA").contains("patternB")
+				.contains("false");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/QueryRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/QueryRoutePredicateFactoryTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.function.Predicate;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +27,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.cloud.gateway.handler.predicate.QueryRoutePredicateFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -33,6 +36,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -65,6 +69,15 @@ public class QueryRoutePredicateFactoryTests extends BaseWebClientTests {
 				.valueEquals(ROUTE_ID_HEADER, "default_path_to_httpbin");
 		output.expect(not(
 				containsString("Error applying predicate for route: foo_query_param")));
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setParam("myparam");
+		config.setRegexp("myregexp");
+		Predicate predicate = new QueryRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("Query: param=myparam regexp=myregexp");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyPredicateFactoryTest.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyPredicateFactoryTest.java
@@ -28,6 +28,8 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cloud.gateway.handler.AsyncPredicate;
+import org.springframework.cloud.gateway.handler.predicate.ReadBodyPredicateFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.PermitAllSecurityConfiguration;
@@ -45,7 +47,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.server.ServerWebExchange;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 /**
@@ -74,6 +78,15 @@ public class ReadBodyPredicateFactoryTest {
 				.expectStatus().isOk().expectBody().jsonPath("$.headers.World")
 				.isEqualTo("Hello");
 
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setInClass(String.class);
+		AsyncPredicate<ServerWebExchange> predicate = new ReadBodyPredicateFactory()
+				.applyAsync(config);
+		assertThat(predicate.toString()).contains("ReadBody: " + config.getInClass());
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gateway.handler.predicate;
 
 import java.time.Duration;
+import java.util.function.Predicate;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.handler.predicate.RemoteAddrRoutePredicateFactory.Config;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.support.ipresolver.XForwardedRemoteAddressResolver;
@@ -39,6 +41,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.reactive.function.client.ClientResponse;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 
@@ -74,6 +77,14 @@ public class RemoteAddrRoutePredicateFactoryTests extends BaseWebClientTests {
 		StepVerifier.create(result)
 				.consumeNextWith(response -> assertStatus(response, HttpStatus.OK))
 				.expectComplete().verify(Duration.ofSeconds(20));
+	}
+
+	@Test
+	public void toStringFormat() {
+		Config config = new Config();
+		config.setSources("1.2.3.4", "5.6.7.8");
+		Predicate predicate = new RemoteAddrRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("RemoteAddrs: [1.2.3.4, 5.6.7.8]");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactoryIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gateway.handler.predicate;
 
 import java.util.Random;
+import java.util.function.Predicate;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,6 +30,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.filter.WeightCalculatorWebFilter;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.support.WeightConfig;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -36,6 +38,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -70,6 +73,13 @@ public class WeightRoutePredicateFactoryIntegrationTests extends BaseWebClientTe
 		testClient.get().uri("/get").header(HttpHeaders.HOST, "www.weightlow.org")
 				.exchange().expectStatus().isOk().expectHeader()
 				.valueEquals(ROUTE_ID_HEADER, "weight_low_test");
+	}
+
+	@Test
+	public void toStringFormat() {
+		WeightConfig config = new WeightConfig("mygroup", "myroute", 5);
+		Predicate predicate = new WeightRoutePredicateFactory().apply(config);
+		assertThat(predicate.toString()).contains("Weight: mygroup 5");
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocatorTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocatorTests.java
@@ -35,6 +35,7 @@ import org.springframework.cloud.gateway.handler.predicate.HostRoutePredicateFac
 import org.springframework.cloud.gateway.handler.predicate.PredicateDefinition;
 import org.springframework.cloud.gateway.handler.predicate.RoutePredicateFactory;
 import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -74,10 +75,10 @@ public class RouteDefinitionRouteLocatorTests {
 				.block();
 		List<GatewayFilter> filters = routes.get(0).getFilters();
 		assertThat(filters).hasSize(3);
-		assertThat(getFilterClassName(filters.get(0))).startsWith("RemoveResponseHeader");
-		assertThat(getFilterClassName(filters.get(1))).startsWith("AddResponseHeader");
+		assertThat(getFilterClassName(filters.get(0))).contains("RemoveResponseHeader");
+		assertThat(getFilterClassName(filters.get(1))).contains("AddResponseHeader");
 		assertThat(getFilterClassName(filters.get(2)))
-				.startsWith("RouteDefinitionRouteLocatorTests$TestOrderedGateway");
+				.contains("RouteDefinitionRouteLocatorTests$TestOrderedGateway");
 	}
 
 	private String getFilterClassName(GatewayFilter target) {
@@ -85,7 +86,12 @@ public class RouteDefinitionRouteLocatorTests {
 			return getFilterClassName(((OrderedGatewayFilter) target).getDelegate());
 		}
 		else {
-			return target.getClass().getSimpleName();
+			String simpleName = target.getClass().getSimpleName();
+			if (StringUtils.isEmpty(simpleName)) {
+				// maybe a lambda using new toString methods
+				simpleName = target.toString();
+			}
+			return simpleName;
 		}
 	}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtilsTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtilsTests.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.support;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.expand;
+
+public class ServerWebExchangeUtilsTests {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void expandWorks() {
+		HashMap<String, String> vars = new HashMap<>();
+		vars.put("foo", "bar");
+		vars.put("baz", "bam");
+
+		MockServerWebExchange exchange = mockExchange(vars);
+
+		String expanded = expand(exchange, "my-{foo}-{baz}");
+		assertThat(expanded).isEqualTo("my-bar-bam");
+
+		expanded = expand(exchange, "my-noop");
+		assertThat(expanded).isEqualTo("my-noop");
+	}
+
+	@Test
+	public void missingVarThrowsException() {
+		MockServerWebExchange exchange = mockExchange(Collections.emptyMap());
+		thrown.expect(IllegalArgumentException.class);
+		expand(exchange, "my-{foo}-{baz}");
+	}
+
+	private MockServerWebExchange mockExchange(Map<String, String> vars) {
+		MockServerHttpRequest request = MockServerHttpRequest.get("/get").build();
+		MockServerWebExchange exchange = MockServerWebExchange.from(request);
+		ServerWebExchangeUtils.putUriTemplateVariables(exchange, vars);
+		return exchange;
+	}
+
+}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/GatewayTestApplication.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/test/GatewayTestApplication.java
@@ -25,10 +25,12 @@ import org.springframework.cloud.gateway.discovery.DiscoveryClientRouteDefinitio
 import org.springframework.cloud.gateway.discovery.DiscoveryLocatorProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 
 @SpringBootConfiguration
 @EnableAutoConfiguration
+@Import(PermitAllSecurityConfiguration.class)
 public class GatewayTestApplication {
 
 	public static void main(String[] args) {

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -384,3 +384,8 @@ eureka:
   client:
     enabled: false
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -303,9 +303,9 @@ spring:
         - Host=**.setreresponseheader.org
         - Path=/headers
         filters:
-        - AddResponseHeader=X-Request-Foo, Bar1
-        - AddResponseHeader=X-Request-Foo, Bar2
-        - SetResponseHeader=X-Request-Foo, Bar
+        - AddResponseHeader=X-Response-Foo, Bar1
+        - AddResponseHeader=X-Response-Foo, Bar2
+        - SetResponseHeader=X-Response-Foo, Bar
 
       # =====================================
       - id: set_status_int_test


### PR DESCRIPTION
Fixes [issue 1167](https://github.com/spring-cloud/spring-cloud-gateway/issues/1167), which is also described on [StackOverflow](https://stackoverflow.com/questions/56919079/spring-cloud-gateway-routelocator-java-code-can-not-get-with-specific-route-id).

Basically reused existing logic, probably there is room to improve. I also added a basic (unit) test which was missing before.