### PR TITLE
Fixes cache is cleared on refresh but not actually refreshed. Fixes gh-1168.

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CachingRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CachingRouteDefinitionLocator.java
@@ -23,7 +23,6 @@ import java.util.stream.Collectors;
 
 import reactor.cache.CacheFlux;
 import reactor.core.publisher.Flux;
-import reactor.core.scheduler.Schedulers;
 
 import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
 import org.springframework.context.ApplicationListener;
@@ -69,8 +68,7 @@ public class CachingRouteDefinitionLocator
 	@Override
 	public void onApplicationEvent(RefreshRoutesEvent event) {
 		fetch().materialize().collect(Collectors.toList())
-				.map(routes -> cache.put(CACHE_KEY, routes))
-				.subscribeOn(Schedulers.elastic()).subscribe();
+				.map(routes -> cache.put(CACHE_KEY, routes)).subscribe();
 	}
 
 	@Deprecated

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CachingRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CachingRouteDefinitionLocator.java
@@ -16,12 +16,14 @@
 
 package org.springframework.cloud.gateway.route;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import reactor.cache.CacheFlux;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
 import org.springframework.context.ApplicationListener;
@@ -32,17 +34,22 @@ import org.springframework.context.ApplicationListener;
 public class CachingRouteDefinitionLocator
 		implements RouteDefinitionLocator, ApplicationListener<RefreshRoutesEvent> {
 
+	private static final String CACHE_KEY = "routeDefs";
+
 	private final RouteDefinitionLocator delegate;
 
 	private final Flux<RouteDefinition> routeDefinitions;
 
-	private final Map<String, List> cache = new HashMap<>();
+	private final Map<String, List> cache = new ConcurrentHashMap<>();
 
 	public CachingRouteDefinitionLocator(RouteDefinitionLocator delegate) {
 		this.delegate = delegate;
-		routeDefinitions = CacheFlux.lookup(cache, "routeDefs", RouteDefinition.class)
-				.onCacheMissResume(this.delegate::getRouteDefinitions);
+		routeDefinitions = CacheFlux.lookup(cache, CACHE_KEY, RouteDefinition.class)
+				.onCacheMissResume(this::fetch);
+	}
 
+	private Flux<RouteDefinition> fetch() {
+		return this.delegate.getRouteDefinitions();
 	}
 
 	@Override
@@ -61,7 +68,9 @@ public class CachingRouteDefinitionLocator
 
 	@Override
 	public void onApplicationEvent(RefreshRoutesEvent event) {
-		refresh();
+		fetch().materialize().collect(Collectors.toList())
+				.map(routes -> cache.put(CACHE_KEY, routes))
+				.subscribeOn(Schedulers.elastic()).subscribe();
 	}
 
 	@Deprecated

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/CachingRouteDefinitionLocatorTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/CachingRouteDefinitionLocatorTests.java
@@ -18,9 +18,13 @@ package org.springframework.cloud.gateway.route;
 
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 
+import org.junit.Assert;
 import org.junit.Test;
 import reactor.core.publisher.Flux;
+
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,17 +48,8 @@ public class CachingRouteDefinitionLocatorTests {
 		RouteDefinition routeDef1 = routeDef(1);
 		RouteDefinition routeDef2 = routeDef(2);
 		CachingRouteDefinitionLocator locator = new CachingRouteDefinitionLocator(
-				new RouteDefinitionLocator() {
-					int i = 0;
-
-					@Override
-					public Flux<RouteDefinition> getRouteDefinitions() {
-						if (i++ == 0) {
-							return Flux.just(routeDef2);
-						}
-						return Flux.just(routeDef2, routeDef1);
-					}
-				});
+				new StubRouteDefinitionLocator(Flux.just(routeDef2),
+						Flux.just(routeDef1, routeDef2)));
 
 		List<RouteDefinition> routes = locator.getRouteDefinitions().collectList()
 				.block();
@@ -64,12 +59,109 @@ public class CachingRouteDefinitionLocatorTests {
 		assertThat(routes).containsExactlyInAnyOrder(routeDef1, routeDef2);
 	}
 
+	@Test
+	public void cacheIsNotClearedOnEvent() {
+		RouteDefinition routeDef1 = routeDef(1);
+		RouteDefinition routeDef2 = routeDef(2);
+
+		CountDownLatch latch = new CountDownLatch(1);
+		CachingRouteDefinitionLocator locator = new CachingRouteDefinitionLocator(
+				new StubRouteDefinitionLocator(Flux.just(routeDef1), Flux.defer(() -> {
+					try {
+						latch.await();
+					}
+					catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+						throw new IllegalStateException(e);
+					}
+					return Flux.just(routeDef1, routeDef2);
+				})));
+
+		List<RouteDefinition> routes = locator.getRouteDefinitions().collectList()
+				.block();
+		assertThat(routes).containsExactlyInAnyOrder(routeDef1);
+
+		locator.onApplicationEvent(new RefreshRoutesEvent(this));
+
+		routes = locator.getRouteDefinitions().collectList().block();
+		assertThat(routes).containsExactlyInAnyOrder(routeDef1);
+
+		latch.countDown();
+	}
+
+	@Test
+	public void cacheIsRefreshedInTheBackgroundOnEvent() {
+		RouteDefinition routeDef1 = routeDef(1);
+		RouteDefinition routeDef2 = routeDef(2);
+
+		CachingRouteDefinitionLocator locator = new CachingRouteDefinitionLocator(
+				new StubRouteDefinitionLocator(Flux.just(routeDef1),
+						Flux.defer(() -> Flux.just(routeDef1, routeDef2))));
+
+		List<RouteDefinition> routes = locator.getRouteDefinitions().collectList()
+				.block();
+		assertThat(routes).containsExactlyInAnyOrder(routeDef1);
+
+		locator.onApplicationEvent(new RefreshRoutesEvent(this));
+
+		poll(() -> {
+			List<RouteDefinition> updatedRoutes = locator.getRouteDefinitions()
+					.collectList().block();
+			assertThat(updatedRoutes).containsExactlyInAnyOrder(routeDef1, routeDef2);
+		});
+	}
+
+	private void poll(Runnable runnable) {
+		for (int i = 0; i < 40; i++) {
+			try {
+				try {
+					runnable.run();
+					return;
+				}
+				catch (AssertionError ignored) {
+					Thread.sleep(50);
+				}
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException(e);
+			}
+		}
+		Assert.fail("Not able to obtain updated route definitions after 2 seconds.");
+	}
+
 	RouteDefinition routeDef(int id) {
 		RouteDefinition def = new RouteDefinition();
 		def.setId(String.valueOf(id));
 		def.setUri(URI.create("http://localhost/" + id));
 		def.setOrder(id);
 		return def;
+	}
+
+	private static final class StubRouteDefinitionLocator
+			implements RouteDefinitionLocator {
+
+		private final Flux<RouteDefinition> first;
+
+		private final Flux<RouteDefinition> second;
+
+		int i;
+
+		private StubRouteDefinitionLocator(Flux<RouteDefinition> first,
+				Flux<RouteDefinition> second) {
+			this.first = first;
+			this.second = second;
+			i = 0;
+		}
+
+		@Override
+		public Flux<RouteDefinition> getRouteDefinitions() {
+			if (i++ == 0) {
+				return first;
+			}
+			return second;
+		}
+
 	}
 
 }


### PR DESCRIPTION
The cache is now replaced instead of cleared and set at a later point in time.

As the cache is updated in the background I only came up with some sort of polling to validate the behaviour. I would have chosen a signalling solution, but when `RouteDefinitionLocator` returns, the cache can take a few extra milliseconds to be updated.