### PR TITLE
fix double call chain

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/AdaptCachedBodyGlobalFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/AdaptCachedBodyGlobalFilter.java
@@ -70,11 +70,9 @@ public class AdaptCachedBodyGlobalFilter
 			return chain.filter(exchange);
 		}
 
-		return ServerWebExchangeUtils
-				.cacheRequestBody(exchange,
-						(serverHttpRequest) -> chain.filter(
-								exchange.mutate().request(serverHttpRequest).build()))
-				.switchIfEmpty(chain.filter(exchange));
+		return ServerWebExchangeUtils.cacheRequestBody(exchange,
+				(serverHttpRequest) -> chain
+						.filter(exchange.mutate().request(serverHttpRequest).build()));
 	}
 
 	@Override

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -333,6 +333,7 @@ public final class ServerWebExchangeUtils {
 			Function<ServerHttpRequest, Mono<T>> function) {
 		// Join all the DataBuffers so we have a single DataBuffer for the body
 		return DataBufferUtils.join(exchange.getRequest().getBody())
+				.defaultIfEmpty(exchange.getResponse().bufferFactory().wrap(new byte[0]))
 				.flatMap(dataBuffer -> {
 					if (dataBuffer.readableByteCount() > 0) {
 						if (log.isTraceEnabled()) {


### PR DESCRIPTION
AdaptCachedBodyGlobalFilter causes DefaultGatewayFilterChain to get called twice when **posted with non-zero body size**.

Mono<Void> is always empty.

  Mono<Void> defer = Mono.defer(() -> {
			System.out.println("defer");
			return Mono.empty();
		});
  Mono<Void> voidMono = defer.switchIfEmpty(Mono.defer(() -> {
                        //always print
			System.out.println("defer-2");
			return Mono.empty();
		}));


In AdaptCachedBodyGlobalFilter, switchIfEmpty will always get called when the return statement is 
reached.


		return ServerWebExchangeUtils
				.cacheRequestBody(exchange,
						(serverHttpRequest) -> chain.filter(
								exchange.mutate().request(serverHttpRequest).build()))
				.switchIfEmpty(chain.filter(exchange));

If any filter modifies the response headers without checking the response status, the following exception will throw, the example is from RequestRateLimiter


java.lang.UnsupportedOperationException: null
	at org.springframework.http.ReadOnlyHttpHeaders.add(ReadOnlyHttpHeaders.java:84) ~[spring-web-5.1.8.RELEASE.jar:5.1.8.RELEASE]
	at org.springframework.cloud.gateway.filter.factory.RequestRateLimiterGatewayFilterFactory.lambda$null$0(RequestRateLimiterGatewayFilterFactory.java:113)


