### PR TITLE
FIX #1282 Rewrite filter example

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -854,7 +854,7 @@ spring:
         predicates:
         - Path=/foo/**
         filters:
-        - RewritePath=/foo/(?<segment>.*), /$\{segment}
+        - RewritePath=/foo(?<segment>/?.*), $\{segment}
 ----
 
 For a request path of `/foo/bar`, this will set the path to `/bar` before making the downstream request. Notice the `$` Should be replaced with `$\` because of the YAML spec.


### PR DESCRIPTION
Fix for the case described in https://github.com/spring-cloud/spring-cloud-gateway/issues/1282

The regexp now treats the possible root trailing slash as optional.