### PR TITLE
[Docs] Fix broken image link

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -40,7 +40,7 @@ IMPORTANT: Spring Cloud Gateway requires the Netty runtime provided by Spring Bo
 [[gateway-how-it-works]]
 == How It Works
 
-image::{imagesurl}/spring_cloud_gateway_diagram.png[Spring Cloud Gateway Diagram]
+image::spring_cloud_gateway_diagram.png[Spring Cloud Gateway Diagram]
 
 Clients make requests to Spring Cloud Gateway. If the Gateway Handler Mapping determines that a request matches a Route, it is sent to the Gateway Web Handler. This handler runs sends the request through a filter chain that is specific to the request. The reason the filters are divided by the dotted line, is that filters may execute logic before the proxy request is sent or after. All "pre" filter logic is executed, then the proxy request is made. After the proxy request is made, the "post" filter logic is executed.
 


### PR DESCRIPTION
current spring_cloud_gateway_diagram image in website https://cloud.spring.io/spring-cloud-gateway/reference/html/ is broken. 
![image](https://user-images.githubusercontent.com/20021316/64870806-91ac8b80-d676-11e9-8e75-3ef46c1d13b6.png)

As it may bring bad user expierence when reading the doc. Applying a quick hotfix for the issue.

@pivotal-issuemaster This is an Obvious Fix