### PR TITLE
Fixes gh-1305 Modify newContentType to be reflected in downstream requests in ModifyRequestBodyGatewayFilterFactory

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
@@ -117,7 +117,7 @@ public class ModifyRequestBodyGatewayFilterFactory extends
 			public HttpHeaders getHeaders() {
 				long contentLength = headers.getContentLength();
 				HttpHeaders httpHeaders = new HttpHeaders();
-				httpHeaders.putAll(super.getHeaders());
+				httpHeaders.putAll(headers);
 				if (contentLength > 0) {
 					httpHeaders.setContentLength(contentLength);
 				}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.rewrite;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
+import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.reactive.function.BodyInserters;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Junghoon Song
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DirtiesContext
+public class ModifyRequestBodyGatewayFilterFactoryTests extends BaseWebClientTests {
+
+	@Test
+	public void modifyRequestBody() {
+		testClient.post().uri("/post").header("Host", "www.modifyrequestbody.org")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_XML_VALUE)
+				.body(BodyInserters.fromValue("request"))
+				.exchange()
+				.expectStatus().isEqualTo(HttpStatus.OK)
+				.expectBody()
+				.jsonPath("headers.Content-Type").isEqualTo(MediaType.APPLICATION_JSON_VALUE)
+				.jsonPath("data").isEqualTo("modifyrequest");
+	}
+
+	@EnableAutoConfiguration
+	@SpringBootConfiguration
+	@Import(DefaultTestConfig.class)
+	public static class TestConfig {
+
+		@Value("${test.uri}")
+		String uri;
+
+		@Bean
+		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
+			return builder.routes()
+					.route("test_modify_request_body",
+							r -> r.order(-1).host("**.modifyrequestbody.org")
+									.filters(f -> f.modifyRequestBody(String.class, String.class,
+											MediaType.APPLICATION_JSON_VALUE, (serverWebExchange, aVoid) -> {
+												return Mono.just("modifyrequest");
+											})
+									)
+									.uri(uri))
+					.build();
+		}
+	}
+}


### PR DESCRIPTION
Fixes issue #1305.

Fixed the use of the header value of delegate, ignoring the changed header in the ServerHttpRequest Decorator.
