### PR TITLE
Added support for rate limits bellow 1 req/s

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -895,10 +895,15 @@ The `redis-rate-limiter.burstCapacity` is the maximum number of requests a user 
 This is the number of tokens the token bucket can hold.
 Setting this value to zero blocks all requests.
 
+The `redis-rate-limiter.requestedTokens` is how many tokens a request costs.
+This is the number of tokens taken from the bucket for each request and defaults to `1`.
+
 A steady rate is accomplished by setting the same value in `replenishRate` and `burstCapacity`.
 Temporary bursts can be allowed by setting `burstCapacity` higher than `replenishRate`.
 In this case, the rate limiter needs to be allowed some time between bursts (according to `replenishRate`), as two consecutive bursts will result in dropped requests (`HTTP 429 - Too Many Requests`).
 The following listing configures a `redis-rate-limiter`:
+
+Rate limits bellow `1 request/s` are accomplished by setting `replenishRate` to the wanted number of requests, `requestedTokens` to the timespan in seconds and `burstCapacity` to the product of `replenishRate` and `requestedTokens`, e.g. setting `replenishRate=1`, `requestedTokens=60` and `burstCapacity=60` will result in a limit of `1 request/min`.
 
 .application.yml
 ====
@@ -915,6 +920,7 @@ spring:
           args:
             redis-rate-limiter.replenishRate: 10
             redis-rate-limiter.burstCapacity: 20
+            redis-rate-limiter.requestedTokens: 1
 
 ----
 ====

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
@@ -49,6 +49,7 @@ import org.springframework.validation.annotation.Validated;
  *
  * @author Spencer Gibb
  * @author Ronny Bräunlich
+ * @author Denis Cutic
  */
 @ConfigurationProperties("spring.cloud.gateway.redis-rate-limiter")
 public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Config>
@@ -87,9 +88,14 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 	public static final String REPLENISH_RATE_HEADER = "X-RateLimit-Replenish-Rate";
 
 	/**
-	 * Burst Capacity Header name.
+	 * Burst Capacity header name.
 	 */
 	public static final String BURST_CAPACITY_HEADER = "X-RateLimit-Burst-Capacity";
+
+	/**
+	 * Requested Tokens header name.
+	 */
+	public static final String REQUESTED_TOKENS_HEADER = "X-RateLimit-Requested-Tokens";
 
 	private Log log = LogFactory.getLog(getClass());
 
@@ -120,6 +126,9 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 	/** The name of the header that returns the burst capacity configuration. */
 	private String burstCapacityHeader = BURST_CAPACITY_HEADER;
 
+	/** The name of the header that returns the requested tokens configuration. */
+	private String requestedTokensHeader = REQUESTED_TOKENS_HEADER;
+
 	public RedisRateLimiter(ReactiveStringRedisTemplate redisTemplate,
 			RedisScript<List<Long>> script, ConfigurationService configurationService) {
 		super(Config.class, CONFIGURATION_PROPERTY_NAME, configurationService);
@@ -141,12 +150,25 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 	 * This creates an instance with default static configuration, useful in Java DSL.
 	 * @param defaultReplenishRate how many tokens per second in token-bucket algorithm.
 	 * @param defaultBurstCapacity how many tokens the bucket can hold in token-bucket
-	 * alogritm.
+	 * algorithm.
 	 */
 	public RedisRateLimiter(int defaultReplenishRate, int defaultBurstCapacity) {
 		super(Config.class, CONFIGURATION_PROPERTY_NAME, (ConfigurationService) null);
 		this.defaultConfig = new Config().setReplenishRate(defaultReplenishRate)
 				.setBurstCapacity(defaultBurstCapacity);
+	}
+
+	/**
+	 * This creates an instance with default static configuration, useful in Java DSL.
+	 * @param defaultReplenishRate how many tokens per second in token-bucket algorithm.
+	 * @param defaultBurstCapacity how many tokens the bucket can hold in token-bucket
+	 * algorithm.
+	 * @param defaultRequestedTokens how many tokens are requested per request.
+	 */
+	public RedisRateLimiter(int defaultReplenishRate, int defaultBurstCapacity,
+			int defaultRequestedTokens) {
+		this(defaultReplenishRate, defaultBurstCapacity);
+		this.defaultConfig.setRequestedTokens(defaultRequestedTokens);
 	}
 
 	static List<String> getKeys(String id) {
@@ -194,6 +216,14 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		this.burstCapacityHeader = burstCapacityHeader;
 	}
 
+	String getRequestedTokensHeader() {
+		return requestedTokensHeader;
+	}
+
+	void setRequestedTokensHeader(String requestedTokensHeader) {
+		this.requestedTokensHeader = requestedTokensHeader;
+	}
+
 	/**
 	 * Used when setting default configuration in constructor.
 	 * @param context the ApplicationContext object to be used by this object
@@ -237,12 +267,16 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		// How much bursting do you want to allow?
 		int burstCapacity = routeConfig.getBurstCapacity();
 
+		// How many tokens are requested per request?
+		int requestedTokens = routeConfig.getRequestedTokens();
+
 		try {
 			List<String> keys = getKeys(id);
 
 			// The arguments to the LUA script. time() returns unixtime in seconds.
 			List<String> scriptArgs = Arrays.asList(replenishRate + "",
-					burstCapacity + "", Instant.now().getEpochSecond() + "", "1");
+					burstCapacity + "", Instant.now().getEpochSecond() + "",
+					requestedTokens + "");
 			// allowed, tokens_left = redis.eval(SCRIPT, keys, args)
 			Flux<List<Long>> flux = this.redisTemplate.execute(this.script, keys,
 					scriptArgs);
@@ -298,6 +332,8 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 					String.valueOf(config.getReplenishRate()));
 			headers.put(this.burstCapacityHeader,
 					String.valueOf(config.getBurstCapacity()));
+			headers.put(this.requestedTokensHeader,
+					String.valueOf(config.getRequestedTokens()));
 		}
 		return headers;
 	}
@@ -310,6 +346,9 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 
 		@Min(1)
 		private int burstCapacity = 1;
+
+		@Min(1)
+		private int requestedTokens = 1;
 
 		public int getReplenishRate() {
 			return replenishRate;
@@ -329,10 +368,19 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 			return this;
 		}
 
+		public int getRequestedTokens() {
+			return requestedTokens;
+		}
+
+		public Config setRequestedTokens(int requestedTokens) {
+			this.requestedTokens = requestedTokens;
+			return this;
+		}
+
 		@Override
 		public String toString() {
 			return "Config{" + "replenishRate=" + replenishRate + ", burstCapacity="
-					+ burstCapacity + '}';
+					+ burstCapacity + ", requestedTokens=" + requestedTokens + '}';
 		}
 
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
@@ -57,21 +57,26 @@ public class RedisRateLimiterConfigTests {
 
 	@Test
 	public void redisRateConfiguredFromEnvironment() {
-		assertFilter("redis_rate_limiter_config_test", 10, 20, false);
+		assertFilter("redis_rate_limiter_config_test", 10, 20, 1, false);
+	}
+
+	@Test
+	public void redisRateConfiguredFromEnvironmentMinimal() {
+		assertFilter("redis_rate_limiter_minimal_config_test", 2, 1, 1, false);
 	}
 
 	@Test
 	public void redisRateConfiguredFromJavaAPI() {
-		assertFilter("custom_redis_rate_limiter", 20, 40, false);
+		assertFilter("custom_redis_rate_limiter", 20, 40, 10, false);
 	}
 
 	@Test
 	public void redisRateConfiguredFromJavaAPIDirectBean() {
-		assertFilter("alt_custom_redis_rate_limiter", 30, 60, true);
+		assertFilter("alt_custom_redis_rate_limiter", 30, 60, 20, true);
 	}
 
 	private void assertFilter(String key, int replenishRate, int burstCapacity,
-			boolean useDefaultConfig) {
+			int requestedTokens, boolean useDefaultConfig) {
 		RedisRateLimiter.Config config;
 
 		if (useDefaultConfig) {
@@ -84,6 +89,7 @@ public class RedisRateLimiterConfigTests {
 		assertThat(config).isNotNull();
 		assertThat(config.getReplenishRate()).isEqualTo(replenishRate);
 		assertThat(config.getBurstCapacity()).isEqualTo(burstCapacity);
+		assertThat(config.getRequestedTokens()).isEqualTo(requestedTokens);
 
 		Route route = routeLocator.getRoutes().filter(r -> r.getId().equals(key)).next()
 				.block();
@@ -100,7 +106,8 @@ public class RedisRateLimiterConfigTests {
 			return builder.routes().route("custom_redis_rate_limiter",
 					r -> r.path("/custom").filters(f -> f.requestRateLimiter()
 							.rateLimiter(RedisRateLimiter.class,
-									rl -> rl.setBurstCapacity(40).setReplenishRate(20))
+									rl -> rl.setBurstCapacity(40).setReplenishRate(20)
+											.setRequestedTokens(10))
 							.and()).uri("http://localhost"))
 					.route("alt_custom_redis_rate_limiter",
 							r -> r.path("/custom")
@@ -113,7 +120,7 @@ public class RedisRateLimiterConfigTests {
 
 		@Bean
 		public RedisRateLimiter myRateLimiter() {
-			return new RedisRateLimiter(30, 60);
+			return new RedisRateLimiter(30, 60, 20);
 		}
 
 	}

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterDefaultFilterConfigTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterDefaultFilterConfigTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Spencer Gibb
+ * @author Denis Cutic
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest
@@ -57,14 +58,15 @@ public class RedisRateLimiterDefaultFilterConfigTests {
 	public void redisRateConfiguredFromEnvironmentDefaultFilters() {
 		String routeId = "redis_rate_limiter_config_default_test";
 		RedisRateLimiter.Config config = rateLimiter.loadConfiguration(routeId);
-		assertConfigAndRoute(routeId, 70, 80, config);
+		assertConfigAndRoute(routeId, 70, 80, 10, config);
 	}
 
 	private void assertConfigAndRoute(String key, int replenishRate, int burstCapacity,
-			RedisRateLimiter.Config config) {
+			int requestedTokens, RedisRateLimiter.Config config) {
 		assertThat(config).isNotNull();
 		assertThat(config.getReplenishRate()).isEqualTo(replenishRate);
 		assertThat(config.getBurstCapacity()).isEqualTo(burstCapacity);
+		assertThat(config.getRequestedTokens()).isEqualTo(requestedTokens);
 
 		Route route = routeLocator.getRoutes().filter(r -> r.getId().equals(key)).next()
 				.block();

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterUnitTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterUnitTests.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.ratelimit;
+
+import io.lettuce.core.RedisException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.gateway.support.ConfigurationService;
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.MapEntry.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Denis Cutic
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class RedisRateLimiterUnitTests {
+
+	private static final int DEFAULT_REPLENISH_RATE = 1;
+
+	private static final int DEFAULT_BURST_CAPACITY = 1;
+
+	public static final String ROUTE_ID = "routeId";
+
+	public static final String REQUEST_ID = "id";
+
+	public static final String[] CONFIGURATION_SERVICE_BEANS = new String[0];
+
+	public static final RedisException REDIS_EXCEPTION = new RedisException(
+			"Mocked problem");
+
+	@Mock
+	private ApplicationContext applicationContext;
+
+	@Mock
+	private ReactiveStringRedisTemplate redisTemplate;
+
+	private RedisRateLimiter redisRateLimiter;
+
+	@Before
+	public void setUp() {
+		when(applicationContext.getBean(ReactiveStringRedisTemplate.class))
+				.thenReturn(redisTemplate);
+		when(applicationContext.getBeanNamesForType(ConfigurationService.class))
+				.thenReturn(CONFIGURATION_SERVICE_BEANS);
+		redisRateLimiter = new RedisRateLimiter(DEFAULT_REPLENISH_RATE,
+				DEFAULT_BURST_CAPACITY);
+	}
+
+	@After
+	public void tearDown() {
+		Mockito.reset(applicationContext);
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void shouldThrowWhenNotInitialized() {
+		redisRateLimiter.isAllowed(ROUTE_ID, REQUEST_ID);
+	}
+
+	@Test
+	public void shouldAllowRequestWhenRedisIssueOccurs() {
+		when(redisTemplate.execute(any(), anyList(), anyList()))
+				.thenThrow(REDIS_EXCEPTION);
+		redisRateLimiter.setApplicationContext(applicationContext);
+		Mono<RateLimiter.Response> response = redisRateLimiter.isAllowed(ROUTE_ID,
+				REQUEST_ID);
+		assertThat(response.block()).extracting(RateLimiter.Response::isAllowed)
+				.isEqualTo(true);
+	}
+
+	@Test
+	public void shouldReturnHeadersWhenRedisIssueOccurs() {
+		when(redisTemplate.execute(any(), anyList(), anyList()))
+				.thenThrow(REDIS_EXCEPTION);
+		redisRateLimiter.setApplicationContext(applicationContext);
+		Mono<RateLimiter.Response> response = redisRateLimiter.isAllowed(ROUTE_ID,
+				REQUEST_ID);
+		assertThat(response.block().getHeaders()).containsOnly(
+				entry(redisRateLimiter.getRemainingHeader(), "-1"),
+				entry(redisRateLimiter.getBurstCapacityHeader(),
+						DEFAULT_BURST_CAPACITY + ""),
+				entry(redisRateLimiter.getReplenishRateHeader(),
+						DEFAULT_REPLENISH_RATE + ""),
+				entry(redisRateLimiter.getRequestedTokensHeader(), "1"));
+	}
+
+}

--- a/spring-cloud-gateway-core/src/test/resources/application-redis-rate-limiter-config.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-redis-rate-limiter-config.yml
@@ -14,4 +14,13 @@ spring:
             redis-rate-limiter:
               replenish-rate: 10
               burst-capacity: 20
+      - id: redis_rate_limiter_minimal_config_test
+        uri: ${test.uri}
+        predicates:
+          - Path=/
+        filters:
+          - name: RequestRateLimiter
+            args:
+              redis-rate-limiter:
+                replenish-rate: 2
 

--- a/spring-cloud-gateway-core/src/test/resources/application-redis-rate-limiter-default-config.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-redis-rate-limiter-default-config.yml
@@ -7,6 +7,7 @@ spring:
           redis-rate-limiter:
             replenish-rate: 70
             burst-capacity: 80
+            requested-tokens: 10
       routes:
       # =====================================
       - id: redis_rate_limiter_config_default_test


### PR DESCRIPTION
Make the 'requested tokens' redis template argument configurable in
order to allow defining rate limits lower than 1 req/s, e.g. 1 req/m.

This is accomplished by setting:
- replenishRate = requestRate
- burstRate = requestRate * timeSpanInSeconds
- requestedTokens = timeSpanInSeconds

For 1 req/m this would be accomplished by:
- replenishRate = 1
- burstRate = 60
- requestedTokens = 60