### PR TITLE
Fix retry filter retries on all operations when a response timeout occurs 

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -121,6 +121,7 @@ public class RetryGatewayFilterFactory
 		Retry<ServerWebExchange> exceptionRetry = null;
 		if (!retryConfig.getExceptions().isEmpty()) {
 			Predicate<RetryContext<ServerWebExchange>> retryContextPredicate = context -> {
+				ServerWebExchange exchange = context.applicationContext();
 				if (exceedsMaxIterations(context.applicationContext(), retryConfig)) {
 					return false;
 				}
@@ -133,7 +134,10 @@ public class RetryGatewayFilterFactory
 						trace("exception or its cause is retryable %s, configured exceptions %s",
 								() -> getExceptionNameWithCause(exception),
 								retryConfig::getExceptions);
-						return true;
+
+						HttpMethod httpMethod = exchange.getRequest().getMethod();
+
+						return retryConfig.getMethods().contains(httpMethod);
 					}
 				}
 				trace("exception or its cause is not retryable %s, configured exceptions %s",

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -135,9 +135,12 @@ public class RetryGatewayFilterFactory
 								() -> getExceptionNameWithCause(exception),
 								retryConfig::getExceptions);
 
-						HttpMethod httpMethod = exchange.getRequest().getMethod();
-
-						return retryConfig.getMethods().contains(httpMethod);
+						if (retryConfig.retryIgnoreMethods) {
+							return true;
+						} else {
+							HttpMethod httpMethod = exchange.getRequest().getMethod();
+							return retryConfig.getMethods().contains(httpMethod);
+						}
 					}
 				}
 				trace("exception or its cause is not retryable %s, configured exceptions %s",
@@ -286,6 +289,8 @@ public class RetryGatewayFilterFactory
 		private List<Class<? extends Throwable>> exceptions = toList(IOException.class,
 				TimeoutException.class);
 
+		private boolean retryIgnoreMethods = false;
+
 		private BackoffConfig backoff;
 
 		public RetryConfig allMethods() {
@@ -372,6 +377,15 @@ public class RetryGatewayFilterFactory
 
 		public RetryConfig setExceptions(Class<? extends Throwable>... exceptions) {
 			this.exceptions = Arrays.asList(exceptions);
+			return this;
+		}
+
+		public boolean getRetryIgnoreMethods() {
+			return retryIgnoreMethods;
+		}
+
+		public RetryConfig setRetryIgnoreMethods(boolean retryIgnoreMethods) {
+			this.retryIgnoreMethods = retryIgnoreMethods;
 			return this;
 		}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
@@ -153,6 +153,16 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 	}
 
 	@Test
+	public void retriesSleepyRequestPut() throws Exception {
+		testClient.mutate().responseTimeout(Duration.ofSeconds(10)).build().put()
+				.uri("/sleep?key=sleepyRequestPut&millis=3000")
+				.header(HttpHeaders.HOST, "www.retryjava.org").exchange()
+				.expectStatus().isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+
+		assertThat(TestConfig.map.get("sleepyRequestPut")).isNotNull().hasValue(1);
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	public void retryFilterLoadBalancedWithMultipleServers() {
 		String host = "www.retrywithloadbalancer.org";


### PR DESCRIPTION
Fix https://github.com/spring-cloud/spring-cloud-gateway/issues/1372.

I think this is unexpected for end user: I configured retry only for certain methods but Spring Cloud Gateway will retry for timeout on all methods.

Example: I develop online game in which there are money transfer operations (PUT) to another user are without confirmation for better user experience. So I send money to my friend, and I catch some network disruption, so with current state of SCG I will send money twice, thrice and so on... But I expect exactly one request, because I configured only GET.

In other words, when I declare only GET method in retry config I expect retry only for GET.

Several releases ago seems we had retry only for GET method, consequently there are not many users which relying on retry all methods(are these users exists?), so effectively I returned old behaviour but more configurable.


UPD: introduced boolean retryIgnoreMethods for old behaviour