### PR TITLE
Fix retry filter retries on all operations when a response timeout occurs (redesigned)

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -121,6 +121,9 @@ public class RetryGatewayFilterFactory
 		Retry<ServerWebExchange> exceptionRetry = null;
 		if (!retryConfig.getExceptions().isEmpty()) {
 			Predicate<RetryContext<ServerWebExchange>> retryContextPredicate = context -> {
+
+				ServerWebExchange exchange = context.applicationContext();
+
 				if (exceedsMaxIterations(context.applicationContext(), retryConfig)) {
 					return false;
 				}
@@ -133,7 +136,14 @@ public class RetryGatewayFilterFactory
 						trace("exception or its cause is retryable %s, configured exceptions %s",
 								() -> getExceptionNameWithCause(exception),
 								retryConfig::getExceptions);
-						return true;
+
+						HttpMethod httpMethod = exchange.getRequest().getMethod();
+						boolean retryableMethod = retryConfig.getMethods()
+								.contains(httpMethod);
+						trace("retryableMethod: %b, httpMethod %s, configured methods %s",
+								() -> retryableMethod, () -> httpMethod,
+								retryConfig::getMethods);
+						return retryableMethod;
 					}
 				}
 				trace("exception or its cause is not retryable %s, configured exceptions %s",

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
@@ -148,6 +148,26 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 	}
 
 	@Test
+	public void shouldNotRetryWhenSleepyRequestPost() throws Exception {
+		testClient.mutate().responseTimeout(Duration.ofSeconds(10)).build().post()
+				.uri("/sleep?key=notRetriesSleepyRequestPost&millis=3000")
+				.header(HttpHeaders.HOST, "www.retry-only-get.org").exchange()
+				.expectStatus().isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+
+		assertThat(TestConfig.map.get("notRetriesSleepyRequestPost")).isNotNull().hasValue(1);
+	}
+
+	@Test
+	public void shouldRetryWhenSleepyRequestGet() throws Exception {
+		testClient.mutate().responseTimeout(Duration.ofSeconds(10)).build().get()
+				.uri("/sleep?key=sleepyRequestGet&millis=3000")
+				.header(HttpHeaders.HOST, "www.retry-only-get.org").exchange()
+				.expectStatus().isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+
+		assertThat(TestConfig.map.get("sleepyRequestGet")).isNotNull().hasValue(3);
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	public void retryFilterLoadBalancedWithMultipleServers() {
 		String host = "www.retrywithloadbalancer.org";
@@ -253,7 +273,11 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 									.retry(config -> config.setRetries(2)
 											.setMethods(HttpMethod.POST, HttpMethod.GET)))
 							.uri(uri))
-
+					.route("retry_only_get", r -> r.host("**.retry-only-get.org")
+							.filters(f -> f.prefixPath("/httpbin")
+									.retry(config -> config.setRetries(2)
+											.setMethods(HttpMethod.GET)))
+							.uri(uri))
 					.route("retry_with_backoff", r -> r.host("**.retrywithbackoff.org")
 							.filters(f -> f.prefixPath("/httpbin").retry(config -> {
 								config.setRetries(2).setBackoff(Duration.ofMillis(100),


### PR DESCRIPTION
Fix https://github.com/spring-cloud/spring-cloud-gateway/issues/1372.

Introduced retryableMethods and repeatableMethods and left backward-compatibility setMethods()

```	
public static class RetryConfig implements HasRouteId {

		...

		private int retries = 3;

		private List<Series> series = toList(Series.SERVER_ERROR);

		private List<HttpStatus> statuses = new ArrayList<>();

		private List<HttpMethod> retryableMethods = HttpMethod.values();

		private List<HttpMethod> repeatableMethods = toList(HttpMethod.GET);

		private List<Class<? extends Throwable>> exceptions = toList(IOException.class,
				TimeoutException.class);

		...
		@Deprecated // use setRepeatableMethods()
		public RetryConfig setMethods(HttpMethod... methods) {
			return setRepeatableMethods(methods);
		}

		public RetryConfig setRetryableMethods(HttpMethod... methods) {
			this.retryableMethods = Arrays.asList(methods);
			return this;
		}

		public RetryConfig setRepeatableMethods(HttpMethod... methods) {
			this.repeatableMethods = Arrays.asList(methods);
			return this;
		}

```

Previous request was [closed](https://github.com/spring-cloud/spring-cloud-gateway/pull/1383#issuecomment-548279888) so I try to make more accurate changes.