### PR TITLE
Keep Host header in the outbound request

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.List;
 
 import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -117,7 +118,12 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 				.getAttributeOrDefault(PRESERVE_HOST_HEADER_ATTRIBUTE, false);
 
 		Flux<HttpClientResponse> responseFlux = this.httpClient.headers(headers -> {
+			String originalHost = headers.get(HttpHeaderNames.HOST);
 			headers.add(httpHeaders);
+			if (originalHost != null) {
+				headers.set(HttpHeaderNames.HOST, originalHost);
+			}
+
 			if (preserveHost) {
 				String host = request.getHeaders().getFirst(HttpHeaders.HOST);
 				headers.add(HttpHeaders.HOST, host);


### PR DESCRIPTION
Commit 0d2b87af30a86e10ce1e42bd1415f9c90ce8c5e5 changed how outbound
request headers are managed, instead of using
`HttpClientOperations.headers()` method to merged headers, `HttpHeaders.add()`
is now used.

However `HttpClientOperations.headers()` method treats `Host` header
specially and do not override it from the provided headers collection.

This fix just copies the same logic within `NettyRoutingFilter` for
backward compatibility.

gh-1345