### PR TITLE
Allow to configure maxIdleTime property for HttpClient

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -28,6 +28,7 @@
 |spring.cloud.gateway.httpclient.connect-timeout |  | The connect timeout in millis, the default is 45s.
 |spring.cloud.gateway.httpclient.pool.acquire-timeout |  | Only for type FIXED, the maximum time in millis to wait for aquiring.
 |spring.cloud.gateway.httpclient.pool.max-connections |  | Only for type FIXED, the maximum number of connections before starting pending acquisition on existing ones.
+|spring.cloud.gateway.httpclient.pool.max-idle-time |  | Time in millis after which the channel will be closed. If NULL, there is no max idle time.
 |spring.cloud.gateway.httpclient.pool.name | proxy | The channel pool map name, defaults to proxy.
 |spring.cloud.gateway.httpclient.pool.type |  | Type of pool for HttpClient to use, defaults to ELASTIC.
 |spring.cloud.gateway.httpclient.proxy.host |  | Hostname for proxy configuration of Netty HttpClient.

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -152,6 +152,7 @@ import static org.springframework.cloud.gateway.config.HttpClientProperties.Pool
 
 /**
  * @author Spencer Gibb
+ * @author Ziemowit Stolarczyk
  */
 @Configuration
 @ConditionalOnProperty(name = "spring.cloud.gateway.enabled", matchIfMissing = true)

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -586,10 +586,12 @@ public class GatewayAutoConfiguration {
 			}
 			else if (pool.getType() == FIXED) {
 				connectionProvider = ConnectionProvider.fixed(pool.getName(),
-						pool.getMaxConnections(), pool.getAcquireTimeout());
+						pool.getMaxConnections(), pool.getAcquireTimeout(),
+						pool.getMaxIdleTime());
 			}
 			else {
-				connectionProvider = ConnectionProvider.elastic(pool.getName());
+				connectionProvider = ConnectionProvider.elastic(pool.getName(),
+						pool.getMaxIdleTime());
 			}
 
 			HttpClient httpClient = HttpClient.create(connectionProvider)

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
@@ -29,6 +29,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 import javax.net.ssl.KeyManagerFactory;
 
@@ -157,6 +158,12 @@ public class HttpClientProperties {
 		/** Only for type FIXED, the maximum time in millis to wait for aquiring. */
 		private Long acquireTimeout = ConnectionProvider.DEFAULT_POOL_ACQUIRE_TIMEOUT;
 
+		/**
+		 * Time in millis after which the channel will be closed,
+		 * if NULL there is no max idle time.
+		 */
+		private Long maxIdleTime = null;
+
 		public PoolType getType() {
 			return type;
 		}
@@ -187,6 +194,15 @@ public class HttpClientProperties {
 
 		public void setAcquireTimeout(Long acquireTimeout) {
 			this.acquireTimeout = acquireTimeout;
+		}
+
+		public Duration getMaxIdleTime() {
+			return Optional.ofNullable(maxIdleTime)
+					.map(it -> Duration.ofMillis(maxIdleTime)).orElse(null);
+		}
+
+		public void setMaxIdleTime(Long maxIdleTime) {
+			this.maxIdleTime = maxIdleTime;
 		}
 
 		@Override

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
@@ -29,7 +29,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import javax.net.ssl.KeyManagerFactory;
 
@@ -159,10 +158,10 @@ public class HttpClientProperties {
 		private Long acquireTimeout = ConnectionProvider.DEFAULT_POOL_ACQUIRE_TIMEOUT;
 
 		/**
-		 * Time in millis after which the channel will be closed,
-		 * if NULL there is no max idle time.
+		 * Time in millis after which the channel will be closed.
+		 * If NULL, there is no max idle time.
 		 */
-		private Long maxIdleTime = null;
+		private Duration maxIdleTime = null;
 
 		public PoolType getType() {
 			return type;
@@ -197,11 +196,10 @@ public class HttpClientProperties {
 		}
 
 		public Duration getMaxIdleTime() {
-			return Optional.ofNullable(maxIdleTime)
-					.map(it -> Duration.ofMillis(maxIdleTime)).orElse(null);
+			return maxIdleTime;
 		}
 
-		public void setMaxIdleTime(Long maxIdleTime) {
+		public void setMaxIdleTime(Duration maxIdleTime) {
 			this.maxIdleTime = maxIdleTime;
 		}
 


### PR DESCRIPTION
Since 0.9.0.RELEASE of reactor netty there is a possibility
to configure the pooled connection max idle time.

This commit gives the possibility to set it via spring configuration.