### PR TITLE
fixes gh-1326: inferring the prefix when it equals the actual resource

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -27,6 +27,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
 
+import static org.apache.commons.lang.StringUtils.substringBeforeLast;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ORIGINAL_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 
@@ -271,7 +272,7 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 			String originalUriPath, String requestUriPath) {
 		String prefix;
 		if (requestUriPath != null && (originalUriPath.endsWith(requestUriPath))) {
-			prefix = originalUriPath.replace(requestUriPath, "");
+			prefix = substringBeforeLast(originalUriPath, requestUriPath);
 			if (prefix != null && prefix.length() > 0
 					&& prefix.length() <= originalUri.getPath().length()) {
 				write(updated, X_FORWARDED_PREFIX_HEADER, prefix, isPrefixAppend());

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -195,6 +195,35 @@ public class XForwardedHeadersFilterTests {
 	}
 
 	@Test
+	public void prefixToInferWhenEqualsResource() throws Exception {
+		MockServerHttpRequest request = MockServerHttpRequest
+				.get("https://originalhost:8080/prefix/get")
+				.remoteAddress(
+						new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
+				.build();
+
+		XForwardedHeadersFilter filter = new XForwardedHeadersFilter();
+		filter.setPrefixAppend(true);
+		filter.setPrefixEnabled(true);
+
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
+		originalUris.add(UriComponentsBuilder
+				.fromUriString("https://originalhost:8080/resource/resource/").build()
+				.toUri()); // trailing slash
+		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
+		URI requestUri = UriComponentsBuilder
+				.fromUriString("https://routedservice:8090/resource").build().toUri();
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
+
+		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);
+
+		assertThat(headers).containsKeys(X_FORWARDED_PREFIX_HEADER);
+
+		assertThat(headers.getFirst(X_FORWARDED_PREFIX_HEADER)).isEqualTo("/resource");
+	}
+
+	@Test
 	public void prefixAddedWithoutTrailingSlash() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest
 				.get("https://originalhost:8080/foo/bar")

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -197,7 +197,7 @@ public class XForwardedHeadersFilterTests {
 	@Test
 	public void prefixToInferWhenEqualsResource() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest
-				.get("https://originalhost:8080/prefix/get")
+				.get("https://originalhost:8080/resource/resource/")
 				.remoteAddress(
 						new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
 				.build();


### PR DESCRIPTION
fixes gh-1326, inferring the prefix when it's name also equals the actual resource