### PR TITLE
Keep Host header in the outbound request for 2.1.x

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -123,6 +123,10 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 				String host = request.getHeaders().getFirst(HttpHeaders.HOST);
 				headers.add(HttpHeaders.HOST, host);
 			}
+			else {
+				// let Netty set it based on hostname
+				headers.remove(HttpHeaders.HOST);
+			}
 		}).request(method).uri(url).send((req, nettyOutbound) -> {
 			if (log.isTraceEnabled()) {
 				nettyOutbound.withConnection(connection -> log.trace(


### PR DESCRIPTION
After upgrading our Spring Cloud Gateway from Greenwich.SR3 to Greenwich.SR4, we ran into issue #1345. The host header in the request was no longer updated due to the changes from commit https://github.com/spring-cloud/spring-cloud-gateway/commit/0d2b87af30a86e10ce1e42bd1415f9c90ce8c5e5.

PR https://github.com/spring-cloud/spring-cloud-gateway/pull/1412 fixed this by restoring the original behavior. The PR was merged into master and will be included in 2.2.x (Hoxton). This pull requests cherry-picks the same fix to the 2.1.x (Greenwich) branch so that it can be included in a potential Greenwich.SR5 release.