### PR TITLE
Fix some typos in documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1365,7 +1365,7 @@ As Spring Cloud Gateway distinguishes between "pre" and "post" phases for filter
 ----
 @Bean
 public GlobalFilter customFilter() {
-    return CustomGlobalFilter();
+    return new CustomGlobalFilter();
 }
 
 public class CustomGlobalFilter implements GlobalFilter, Ordered {
@@ -1462,7 +1462,7 @@ The `NettyWriteResponseFilter` runs if there is a Netty `HttpClientResponse` in 
 
 === RouteToRequestUrl Filter
 
-The `RouteToRequestUrlFilter` runs if there is a `Route` object in the `ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR` exchange attribute. It creates a new URI, based off of the request URI, but updated with the URI attribute of the `Route` object. The new URI is placed in the `ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR` exchange attribute`.
+The `RouteToRequestUrlFilter` runs if there is a `Route` object in the `ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR` exchange attribute. It creates a new URI, based off of the request URI, but updated with the URI attribute of the `Route` object. The new URI is placed in the `ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR` exchange attribute.
 
 If the URI has a scheme prefix, such as `lb:ws://serviceid`, the `lb` scheme is stripped from the URI and placed in the `ServerWebExchangeUtils.GATEWAY_SCHEME_PREFIX_ATTR` for use later in the filter chain.
 
@@ -1486,7 +1486,7 @@ spring:
         uri: http://localhost:3001
         predicates:
         - Path=/websocket/info/**
-      # Normwal Websocket route
+      # Normal Websocket route
       - id: websocket_route
         uri: ws://localhost:3001
         predicates:
@@ -1582,7 +1582,7 @@ spring:
 
 == Configuration
 
-Configuration for Spring Cloud Gateway is driven by a collection of `RouteDefinitionLocator`s.
+Configuration for Spring Cloud Gateway is driven by a collection of ``RouteDefinitionLocator``s.
 
 .RouteDefinitionLocator.java
 [source,java]


### PR DESCRIPTION
Hello, this PR proposes some fixes to documentation,

---
(from the commit message):

In particular:

- add missing `new` operator
- ensure that `RouteDefinitionLocators` is properly formatted in the "Configuration" section
- "Normwal" -> "Normal"
- remove extra "`"