### PR TITLE
Handle decorated responses with non-standard status codes.

### DIFF
--- a/spring-cloud-gateway-core/src/test/resources/application-logging.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-logging.yml
@@ -4,6 +4,6 @@ logging:
     org.springframework.http.server.reactive: DEBUG
     org.springframework.web.reactive: DEBUG
     org.springframework.boot.autoconfigure.web: DEBUG
-    org.springframework.cloud.gateway.actuate: TRACE
+    org.springframework.cloud.gateway.actuate: DEBUG
     reactor.netty: DEBUG
     redisratelimiter: DEBUG

--- a/spring-cloud-gateway-core/src/test/resources/application-logging.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application-logging.yml
@@ -4,5 +4,6 @@ logging:
     org.springframework.http.server.reactive: DEBUG
     org.springframework.web.reactive: DEBUG
     org.springframework.boot.autoconfigure.web: DEBUG
+    org.springframework.cloud.gateway.actuate: TRACE
     reactor.netty: DEBUG
     redisratelimiter: DEBUG


### PR DESCRIPTION
Unwrap decorated responses repeatedly, until the underlying abstract server response is reached, to set the non-standard status code, instead of giving up immediately.

Fixes gh-1450