### PR TITLE
Fixed Duplicate Host Header Issue

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -118,13 +118,10 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 		Flux<HttpClientResponse> responseFlux = this.httpClient.headers(headers -> {
 			headers.add(httpHeaders);
+			headers.remove(HttpHeaders.HOST); //Will either be set below, or later by Netty
 			if (preserveHost) {
 				String host = request.getHeaders().getFirst(HttpHeaders.HOST);
 				headers.add(HttpHeaders.HOST, host);
-			}
-			else {
-				// let Netty set it based on hostname
-				headers.remove(HttpHeaders.HOST);
 			}
 		}).request(method).uri(url).send((req, nettyOutbound) -> {
 			if (log.isTraceEnabled()) {

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/PreserveHostHeaderGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/PreserveHostHeaderGatewayFilterFactoryTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -46,14 +47,17 @@ import static org.springframework.cloud.gateway.test.TestUtils.getMap;
 @DirtiesContext
 public class PreserveHostHeaderGatewayFilterFactoryTests extends BaseWebClientTests {
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void preserveHostHeaderGatewayFilterFactoryWorks() {
-		testClient.get().uri("/headers").header("Host", "www.preservehostheader.org")
+		testClient.get().uri("/multivalueheaders").header("Host", "www.preservehostheader.org")
 				.exchange().expectStatus().isOk().expectBody(Map.class)
 				.consumeWith(result -> {
 					Map<String, Object> headers = getMap(result.getResponseBody(),
 							"headers");
-					assertThat(headers).containsEntry("Host", "myhost.net");
+					assertThat(headers).containsKey("Host");
+					List<String> values = (List<String>) headers.get("Host");
+					assertThat(values).containsExactly("myhost.net");
 				});
 	}
 


### PR DESCRIPTION
This change fixes the issue where a duplicate *Host* header is added when **PreserveHostHeader** is used

See also: https://github.com/spring-cloud/spring-cloud-gateway/pull/1464