### PR TITLE
Add ServiceInstance metadata to RouteDefinition metadata

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
@@ -167,9 +167,8 @@ public class DiscoveryClientRouteDefinitionLocator implements RouteDefinitionLoc
 		Map<String, Object> metadata = new HashMap<>(serviceInstance.getMetadata());
 		for (Map.Entry<String, Object> entry : metadata.entrySet()) {
 			Object value = entry.getValue();
-			List<String> intKeys = Arrays.asList(RouteMetadataUtils.CONNECT_TIMEOUT_ATTR, RouteMetadataUtils.RESPONSE_TIMEOUT_ATTR);
-			// since ServiceInstance metadata contains all Strings, must parse Strings to Integers
-			if (value != null && intKeys.contains(entry.getKey())) {
+			// since ServiceInstance metadata contains all Strings, must parse some Strings to Integers
+			if (value != null && RouteMetadataUtils.INTEGER_VALUE_KEYS.contains(entry.getKey())) {
 				try {
 					metadata.put(entry.getKey(), Integer.parseInt((String)value));
 				} catch (NumberFormatException ex) {

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.gateway.discovery;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gateway.discovery;
 
 import java.net.URI;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -122,9 +123,12 @@ public class DiscoveryClientRouteDefinitionLocator implements RouteDefinitionLoc
 				.map(instances -> instances.get(0)).filter(includePredicate)
 				.map(instance -> {
 					String serviceId = instance.getServiceId();
+					Map<String, Object> metadata = new HashMap<>();
+					metadata.putAll(instance.getMetadata());
 
 					RouteDefinition routeDefinition = new RouteDefinition();
 					routeDefinition.setId(this.routeIdPrefix + serviceId);
+					routeDefinition.setMetadata(metadata);
 					String uri = urlExpr.getValue(evalCtxt, instance, String.class);
 					routeDefinition.setUri(URI.create(uri));
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/RouteMetadataUtils.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/RouteMetadataUtils.java
@@ -32,7 +32,7 @@ public final class RouteMetadataUtils {
 	public static final String CONNECT_TIMEOUT_ATTR = "connect-timeout";
 
 	/**
-	 * Attributes which are expected to have Integer values
+	 * Attributes which are expected to have Integer values.
 	 */
 	public static final List<String> INTEGER_VALUE_KEYS = Arrays.asList(RESPONSE_TIMEOUT_ATTR, CONNECT_TIMEOUT_ATTR);
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/RouteMetadataUtils.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/RouteMetadataUtils.java
@@ -16,6 +16,9 @@
 
 package org.springframework.cloud.gateway.support;
 
+import java.util.Arrays;
+import java.util.List;
+
 public final class RouteMetadataUtils {
 
 	/**
@@ -27,6 +30,11 @@ public final class RouteMetadataUtils {
 	 * Connect timeout attribute name.
 	 */
 	public static final String CONNECT_TIMEOUT_ATTR = "connect-timeout";
+
+	/**
+	 * Attributes which are expected to have Integer values
+	 */
+	public static final List<String> INTEGER_VALUE_KEYS = Arrays.asList(RESPONSE_TIMEOUT_ATTR, CONNECT_TIMEOUT_ATTR);
 
 	private RouteMetadataUtils() {
 		throw new AssertionError("Must not instantiate utility class.");


### PR DESCRIPTION
I want to extend the ability to override custom response and connect timeouts (implemented in https://github.com/spring-cloud/spring-cloud-gateway/pull/1120) to routes discovered from discovery client as well as statically defined via configuration. 

Short of implementing my own `RouteDefinitionLocator`, I could not find a way to do this. 
By adding the metadata from the `ServiceInstance`, I can set the timeout properties that will be used in the `NettyRoutingFilter` to set these timeouts.