### PR TITLE
Adjust position of AfterRoutePredicateFactory

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -324,11 +324,6 @@ public class GatewayAutoConfiguration {
 		return new WeightCalculatorWebFilter(routeLocator, configurationService);
 	}
 
-	@Bean
-	public AfterRoutePredicateFactory afterRoutePredicateFactory() {
-		return new AfterRoutePredicateFactory();
-	}
-
 	/*
 	 * @Bean //TODO: default over netty? configurable public WebClientHttpRoutingFilter
 	 * webClientHttpRoutingFilter() { //TODO: WebClient bean return new
@@ -339,6 +334,11 @@ public class GatewayAutoConfiguration {
 	 */
 
 	// Predicate Factory beans
+
+	@Bean
+	public AfterRoutePredicateFactory afterRoutePredicateFactory() {
+		return new AfterRoutePredicateFactory();
+	}
 
 	@Bean
 	public BeforeRoutePredicateFactory beforeRoutePredicateFactory() {


### PR DESCRIPTION
`AfterRoutePredicateFactory` should be placed after `// Predicate Factory beans` comment.