### PR TITLE
Add Protected reconstructURI Method for ReactiveLoadBalancerClientFilter

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
@@ -108,13 +108,17 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 			DelegatingServiceInstance serviceInstance = new DelegatingServiceInstance(
 					response.getServer(), overrideScheme);
 
-			URI requestUrl = LoadBalancerUriTools.reconstructURI(serviceInstance, uri);
+			URI requestUrl = reconstructURI(serviceInstance, uri);
 
 			if (log.isTraceEnabled()) {
 				log.trace("LoadBalancerClientFilter url chosen: " + requestUrl);
 			}
 			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
 		}).then(chain.filter(exchange));
+	}
+
+	protected URI reconstructURI(ServiceInstance serviceInstance, URI original) {
+		return LoadBalancerUriTools.reconstructURI(serviceInstance, original);
 	}
 
 	private Mono<Response<ServiceInstance>> choose(ServerWebExchange exchange) {


### PR DESCRIPTION
Fixes #1524

Allows URI mapping behavior to be overridden for classes extending `ReactiveLoadBalancerClientFilter`.