### PR TITLE
Fix possible NPE in ForwardedHeadersFilter

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -116,7 +116,10 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 
 		InetSocketAddress remoteAddress = request.getRemoteAddress();
 		if (remoteAddress != null) {
-			String forValue = remoteAddress.getAddress().getHostAddress();
+			// If remoteAddress is unresolved, calling getHostAddress() would cause a NullPointerException.
+			String forValue = remoteAddress.isUnresolved()
+					? remoteAddress.getHostName()
+					: remoteAddress.getAddress().getHostAddress();
 			int port = remoteAddress.getPort();
 			if (port >= 0) {
 				forValue = forValue + ":" + port;


### PR DESCRIPTION
Dear maintainer,

ForwardedHeadersFilter could previously throw a NullPointerException if the request's remote address was unresolved. At work we observe one such NPE every few minutes on a fairly busy (hundreds of req/s) API gateway.

An InetSocketAddress being unresolved can happen for two reasons:

* The object was created using `InetSocketAddress.createUnresolved()`, e.g. by another request filter.
* (Reverse) DNS resolution of the remote address failed for some reason.

If it is unresolved, `InetSocketAddress.getAddress()` will return null, causing an NPE when trying to call the return value's `getHostAddress()` method.

In this PR, I implement a fallback to the unresolved / unresolvable hostname of the InetSocketAddress. An alternative to this would be to skip adding the "for" value to the forwarded entry entirely. If you'd prefer that, please let me know and I'll adapt the PR accordingly.