### PR TITLE
Fix RemoveRequestParameterGatewayFilterFactory to deal with query par…

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactory.java
@@ -61,7 +61,7 @@ public class RemoveRequestParameterGatewayFilterFactory
 
 				URI newUri = UriComponentsBuilder.fromUri(request.getURI())
 						.replaceQueryParams(unmodifiableMultiValueMap(queryParams))
-						.build(true).toUri();
+						.build().toUri();
 
 				ServerHttpRequest updatedRequest = exchange.getRequest().mutate()
 						.uri(newUri).build();

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryIntegrationTests.java
@@ -47,11 +47,12 @@ public class RemoveRequestParameterGatewayFilterFactoryIntegrationTests
 
 	@Test
 	public void removeResponseHeaderFilterWorks() {
-		testClient.get().uri("/get?foo=bar&baz=bam")
+		testClient.get().uri("/get?foo=bar&baz=bam%20bar")
 				.header("Host", "www.removerequestparamjava.org").exchange()
 				.expectStatus().isOk().expectBody(Map.class).consumeWith(result -> {
 					Map<String, Object> params = getMap(result.getResponseBody(), "args");
 					assertThat(params).doesNotContainKey("foo");
+					assertThat(params).containsEntry("baz", "bam%20bar");
 				});
 	}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
@@ -103,4 +103,27 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 				singletonList("xyz"));
 	}
 
+	@Test
+	public void removeRequestParameterFilterShouldHandleRemainingParamsWhichRequiringEncoding() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+				.queryParam("foo", "bar").queryParam("aaa", "abc xyz")
+				.queryParam("bbb", "[xyz").queryParam("ccc", ",xyz").build();
+		exchange = MockServerWebExchange.from(request);
+		NameConfig config = new NameConfig();
+		config.setName("foo");
+		GatewayFilter filter = new RemoveRequestParameterGatewayFilterFactory()
+				.apply(config);
+
+		filter.filter(exchange, filterChain);
+
+		ServerHttpRequest actualRequest = captor.getValue().getRequest();
+		assertThat(actualRequest.getQueryParams()).doesNotContainKey("foo");
+		assertThat(actualRequest.getQueryParams()).containsEntry("aaa",
+				singletonList("abc xyz"));
+		assertThat(actualRequest.getQueryParams()).containsEntry("bbb",
+				singletonList("[xyz"));
+		assertThat(actualRequest.getQueryParams()).containsEntry("ccc",
+				singletonList(",xyz"));
+	}
+
 }


### PR DESCRIPTION
The RemoveRequestParameterGatewayFilterFactory class builds up a new URI once it removes the request parameter outlined in the filter config, however, currently expects the remaining request parameters to all be encoded and they are not. When the request query params are determined, they are decoded in AbstractServerHttpRequest and are not subsequently encoded again before the filter builds up the URI.

Currently, when the remaining request parameters have a character that requires encoding, you get an "Invalid character ' ' for QUERY_PARAM" error.