### PR TITLE
Updates UriSpec.uri() to be a terminal dsl method.

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/Route.java
@@ -29,6 +29,7 @@ import java.util.function.Predicate;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.handler.AsyncPredicate;
+import org.springframework.cloud.gateway.route.builder.Buildable;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.Ordered;
 import org.springframework.util.Assert;
@@ -150,7 +151,8 @@ public class Route implements Ordered {
 		return sb.toString();
 	}
 
-	public abstract static class AbstractBuilder<B extends AbstractBuilder<B>> {
+	public abstract static class AbstractBuilder<B extends AbstractBuilder<B>>
+			implements Buildable<Route> {
 
 		protected String id;
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/Buildable.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/Buildable.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.route.builder;
+
+public interface Buildable<T> {
+
+	T build();
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/RouteLocatorBuilder.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/RouteLocatorBuilder.java
@@ -51,7 +51,7 @@ public class RouteLocatorBuilder {
 	 */
 	public static class Builder {
 
-		private List<Route.AsyncBuilder> routes = new ArrayList<>();
+		private List<Buildable<Route>> routes = new ArrayList<>();
 
 		private ConfigurableApplicationContext context;
 
@@ -66,8 +66,8 @@ public class RouteLocatorBuilder {
 		 * {@link Route.AsyncBuilder}
 		 * @return a {@link Builder}
 		 */
-		public Builder route(String id, Function<PredicateSpec, Route.AsyncBuilder> fn) {
-			Route.AsyncBuilder routeBuilder = fn.apply(new RouteSpec(this).id(id));
+		public Builder route(String id, Function<PredicateSpec, Buildable<Route>> fn) {
+			Buildable<Route> routeBuilder = fn.apply(new RouteSpec(this).id(id));
 			add(routeBuilder);
 			return this;
 		}
@@ -78,8 +78,8 @@ public class RouteLocatorBuilder {
 		 * {@link Route.AsyncBuilder}
 		 * @return a {@link Builder}
 		 */
-		public Builder route(Function<PredicateSpec, Route.AsyncBuilder> fn) {
-			Route.AsyncBuilder routeBuilder = fn.apply(new RouteSpec(this).randomId());
+		public Builder route(Function<PredicateSpec, Buildable<Route>> fn) {
+			Buildable<Route> routeBuilder = fn.apply(new RouteSpec(this).randomId());
 			add(routeBuilder);
 			return this;
 		}
@@ -97,7 +97,7 @@ public class RouteLocatorBuilder {
 			return context;
 		}
 
-		void add(Route.AsyncBuilder route) {
+		void add(Buildable<Route> route) {
 			routes.add(route);
 		}
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/UriSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/UriSpec.java
@@ -17,6 +17,8 @@
 package org.springframework.cloud.gateway.route.builder;
 
 import java.net.URI;
+import java.util.Map;
+import java.util.function.Consumer;
 
 import org.springframework.cloud.gateway.route.Route;
 
@@ -34,21 +36,41 @@ public class UriSpec {
 		this.builder = builder;
 	}
 
+	public UriSpec customize(Consumer<Route.AsyncBuilder> routeConsumer) {
+		routeConsumer.accept(this.routeBuilder);
+		return this;
+	}
+
+	public UriSpec replaceMetadata(Map<String, Object> metadata) {
+		this.routeBuilder.replaceMetadata(metadata);
+		return this;
+	}
+
+	public UriSpec metadata(Map<String, Object> metadata) {
+		this.routeBuilder.metadata(metadata);
+		return this;
+	}
+
+	public UriSpec metadata(String key, Object value) {
+		this.routeBuilder.metadata(key, value);
+		return this;
+	}
+
 	/**
 	 * Set the URI for the route.
 	 * @param uri the URI for the route
 	 * @return a {@link Route.AsyncBuilder}
 	 */
-	public Route.AsyncBuilder uri(String uri) {
+	public Buildable<Route> uri(String uri) {
 		return this.routeBuilder.uri(uri);
 	}
 
 	/**
 	 * Set the URI for the route.
 	 * @param uri the URI for the route.
-	 * @return a {@link Route.AsyncBuilder}
+	 * @return a {@link Route.AsyncBuilder}S
 	 */
-	public Route.AsyncBuilder uri(URI uri) {
+	public Buildable<Route> uri(URI uri) {
 		return this.routeBuilder.uri(uri);
 	}
 

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/builder/RouteBuilderTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/route/builder/RouteBuilderTests.java
@@ -74,7 +74,7 @@ public class RouteBuilderTests {
 		RouteLocator routeLocator = this.routeLocatorBuilder.routes()
 				.route("test1", r -> r.host("*.somehost.org").and().path("/somepath")
 						.filters(f -> f.addRequestHeader("header1", "header-value-1"))
-						.uri("http://someuri").metadata("key", "value"))
+						.metadata("key", "value").uri("http://someuri"))
 				.route("test2", r -> r.host("*.somehost2.org")
 						.filters(f -> f.addResponseHeader("header-response-1",
 								"header-response-1"))
@@ -99,8 +99,8 @@ public class RouteBuilderTests {
 				.route("test1", r -> {
 					return r.host("*.somehost.org").and().path("/somepath")
 							.filters(f -> f.addRequestHeader("header1", "header-value-1"))
-							.uri("http://someuri").metadata(RESPONSE_TIMEOUT_ATTR, 1)
-							.metadata(CONNECT_TIMEOUT_ATTR, 1);
+							.metadata(RESPONSE_TIMEOUT_ATTR, 1)
+							.metadata(CONNECT_TIMEOUT_ATTR, 1).uri("http://someuri");
 				})
 				.route("test2", r -> r.host("*.somehost2.org")
 						.filters(f -> f.addResponseHeader("header-response-1",


### PR DESCRIPTION
It returns a new Buildable interface rather than the Route.AsyncBuilder.

Adds metadata methods and customize(Route.AsyncBuilder) to UriSpec.

This disambiguates the java route dsl from the builder provided by the Route object.

Fixes gh-1647

/cc @bsideup