### PR TITLE
Preserve the relative order in which property based routes are defined

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CompositeRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CompositeRouteDefinitionLocator.java
@@ -49,7 +49,8 @@ public class CompositeRouteDefinitionLocator implements RouteDefinitionLocator {
 
 	@Override
 	public Flux<RouteDefinition> getRouteDefinitions() {
-		return this.delegates.flatMap(RouteDefinitionLocator::getRouteDefinitions)
+		return this.delegates
+				.flatMapSequential(RouteDefinitionLocator::getRouteDefinitions)
 				.flatMap(routeDefinition -> {
 					if (routeDefinition.getId() == null) {
 						return randomId().map(id -> {

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CompositeRouteLocator.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/CompositeRouteLocator.java
@@ -31,7 +31,7 @@ public class CompositeRouteLocator implements RouteLocator {
 
 	@Override
 	public Flux<Route> getRoutes() {
-		return this.delegates.flatMap(RouteLocator::getRoutes);
+		return this.delegates.flatMapSequential(RouteLocator::getRoutes);
 	}
 
 }


### PR DESCRIPTION
Addresses #1660 

- this would ensure that route definitions from properties do not lose their relative ordering
- only affects routes that end up having the same order, such as ones typically defined via properties (default order = 0)
- using flatMap does not guarantee to preserve the order of elements, hence a switch to flatMapSequential to preserve order before the `AnnotationAwareOrderComparator` is used for sorting.

This would obviously have some overhead for needing to buffer elements to ensure ordering guarantees but probably isn't a big issue since there wouldn't be an extremely large amount of routes per locator.