### PR TITLE
Fix dashboard panels datasource

### DIFF
--- a/docs/src/main/asciidoc/gateway-grafana-dashboard.json
+++ b/docs/src/main/asciidoc/gateway-grafana-dashboard.json
@@ -68,7 +68,7 @@
             "rgba(191, 148, 112, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "format": "none",
           "gauge": {
@@ -156,7 +156,7 @@
             "rgba(191, 148, 112, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "format": "none",
           "gauge": {
@@ -244,7 +244,7 @@
             "rgba(191, 148, 112, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "format": "none",
           "gauge": {
@@ -343,7 +343,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -434,7 +434,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -527,7 +527,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -620,7 +620,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "fill": 1,
           "gridPos": {
             "h": 7,
@@ -728,7 +728,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -823,7 +823,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -920,7 +920,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -1017,7 +1017,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -1129,7 +1129,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -1229,7 +1229,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -1321,7 +1321,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -1415,7 +1415,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {
@@ -1509,7 +1509,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "prometheus",
+          "datasource": "${DS_PROMETHEUS}",
           "description": "",
           "fill": 1,
           "gridPos": {


### PR DESCRIPTION
Current dashboard uses hardcoded name of prometheus datasource, so if it differs from that value, dashboard won't work. This fix allows all panels to use datasource name, defined by user during the import.