### PR TITLE
Fix spring.codec.max-in-memory-size configuration is invalid for ReadBodyPredicateFactory. Fixes # 1658

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -394,8 +394,8 @@ public class GatewayAutoConfiguration {
 	}
 
 	@Bean
-	public ReadBodyPredicateFactory readBodyPredicateFactory() {
-		return new ReadBodyPredicateFactory();
+	public ReadBodyPredicateFactory readBodyPredicateFactory(ServerCodecConfigurer codecConfigurer) {
+		return new ReadBodyPredicateFactory(codecConfigurer.getReaders());
 	}
 
 	@Bean

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyPredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyPredicateFactory.java
@@ -46,14 +46,19 @@ public class ReadBodyPredicateFactory
 
 	private static final String CACHE_REQUEST_BODY_OBJECT_KEY = "cachedRequestBodyObject";
 
-	private static final List<HttpMessageReader<?>> messageReaders = HandlerStrategies
-			.withDefaults().messageReaders();
+	private final List<HttpMessageReader<?>> messageReaders;
 
 	public ReadBodyPredicateFactory() {
 		super(Config.class);
+		this.messageReaders = HandlerStrategies.withDefaults().messageReaders();
 	}
 
-	@Override
+	public ReadBodyPredicateFactory(List<HttpMessageReader<?>> messageReaders) {
+		super(Config.class);
+		this.messageReaders = messageReaders;
+	}
+
+		@Override
 	@SuppressWarnings("unchecked")
 	public AsyncPredicate<ServerWebExchange> applyAsync(Config config) {
 		return new AsyncPredicate<ServerWebExchange>() {

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyPredicateFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyPredicateFactory.java
@@ -58,7 +58,7 @@ public class ReadBodyPredicateFactory
 		this.messageReaders = messageReaders;
 	}
 
-		@Override
+	@Override
 	@SuppressWarnings("unchecked")
 	public AsyncPredicate<ServerWebExchange> applyAsync(Config config) {
 		return new AsyncPredicate<ServerWebExchange>() {


### PR DESCRIPTION
when i request the body length > 256*1024,tell me the wrong as follow message.
org.springframework.core.io.buffer.DataBufferLimitException: Exceeded limit on max bytes to buffer : 262144.
i set spring.codec.max-in-memory-size not work

Fixes #1658 