### PR TITLE
correcting a typo in RewritePath GatewayFilter document

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1079,7 +1079,7 @@ spring:
       - id: rewritepath_route
         uri: https://example.org
         predicates:
-        - Path=/foo/**
+        - Path=/red/**
         filters:
         - RewritePath=/red(?<segment>/?.*), $\{segment}
 ----


### PR DESCRIPTION
I found a typo in this document.

https://cloud.spring.io/spring-cloud-static/spring-cloud-gateway/2.2.2.RELEASE/reference/html/#the-rewritepath-gatewayfilter-factory

```Before```

~~~yaml
spring:
  cloud:
    gateway:
      routes:
      - id: rewritepath_route
        uri: https://example.org
        predicates:
        - Path=/foo/**
        filters:
        - RewritePath=/red(?<segment>/?.*), $\{segment}
~~~

This is a example for RewirtePath GatewayFilter. But the filter was not working in the example.


```After```

~~~yaml
spring:
  cloud:
    gateway:
      routes:
      - id: rewritepath_route
        uri: https://example.org
        predicates:
        - Path=/red/**
        filters:
        - RewritePath=/red(?<segment>/?.*), $\{segment}
~~~

The ```- Path=/foo/**``` is modified to ```- Path=/red/**```.
And the filter is working.
