### PR TITLE
Translate status code to exception to be used in conjunction with circuit breaker filter

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -65,6 +65,7 @@ import org.springframework.cloud.gateway.filter.factory.AddRequestHeaderGatewayF
 import org.springframework.cloud.gateway.filter.factory.AddRequestParameterGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.AddResponseHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.DedupeResponseHeaderGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.ErrorStatusCodeToExceptionGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.MapRequestHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.PrefixPathGatewayFilterFactory;
@@ -576,6 +577,11 @@ public class GatewayAutoConfiguration {
 	@Bean
 	public GzipMessageBodyResolver gzipMessageBodyResolver() {
 		return new GzipMessageBodyResolver();
+	}
+
+	@Bean
+	public ErrorStatusCodeToExceptionGatewayFilterFactory errorStatusCodeToExceptionGatewayFilterFactory() {
+		return new ErrorStatusCodeToExceptionGatewayFilterFactory();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/ErrorStatusCodeToExceptionGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/ErrorStatusCodeToExceptionGatewayFilterFactory.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
+import static org.springframework.http.HttpStatus.Series.CLIENT_ERROR;
+import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
+
+/**
+ * A filter that translates the error code from mesh implementations like Istio to a
+ * forced @{@link ResponseStatusException} to gracefully honor
+ * the @{@link SpringCloudCircuitBreakerFilterFactory} fallback logic. To be used in
+ * conjunction with
+ * @{@link SpringCloudCircuitBreakerFilterFactory} filter. You might need to
+ * add @{@link DedupeResponseHeaderGatewayFilterFactory} as well to remove duplicate
+ * response headers.
+ * 
+ * // @formatter:off
+ * <p>
+ * Usage: 
+ *        To translate 4xx errors' to exception, 
+ *         filters:
+ *         - name: ErrorStatusCodeToException
+ *           args:
+ *             name: MeshErrorCodeToException
+ *             responseStatusCodeSeries:
+ *             - CLIENT_ERROR
+ *
+ * 		  To translate 4xx and 5xx errors' to exception, 
+ *         filters:
+ *         - name: ErrorStatusCodeToException
+ *           args:
+ *             name: MeshErrorCodeToException
+ *             responseStatusCodeSeries:
+ *             - CLIENT_ERROR
+ *             - SERVER_ERROR
+ * </p>
+ * // @formatter:on
+ * 
+ * @author Srinivasa Vasu
+ */
+public class ErrorStatusCodeToExceptionGatewayFilterFactory extends
+		AbstractGatewayFilterFactory<ErrorStatusCodeToExceptionGatewayFilterFactory.Config> {
+
+	public ErrorStatusCodeToExceptionGatewayFilterFactory() {
+		super(Config.class);
+	}
+
+	@Override
+	public GatewayFilter apply(Config config) {
+
+		return new OrderedGatewayFilter(new GatewayFilter() {
+			@Override
+			public Mono<Void> filter(ServerWebExchange exchange,
+					GatewayFilterChain chain) {
+				return chain.filter(exchange).then(Mono.defer(() -> {
+					ServerHttpResponse response = exchange.getResponse();
+					if (response.getStatusCode() != null
+							&& config.getResponseStatusCodeSeries()
+									.contains(response.getStatusCode().series())) {
+						return Mono.error(
+								new ResponseStatusException(response.getStatusCode(),
+										response.getStatusCode().getReasonPhrase()));
+					}
+					return Mono.empty();
+				}));
+			}
+
+			@Override
+			public String toString() {
+				return filterToStringCreator(
+						ErrorStatusCodeToExceptionGatewayFilterFactory.this)
+								.append("name", config.getName())
+								.append("responseStatusCodeSeries",
+										config.getResponseStatusCodeSeries())
+								.toString();
+
+			}
+		}, this.getOrder());
+
+	}
+
+	@Override
+	public List<String> shortcutFieldOrder() {
+		return Collections.singletonList("responseStatusCodeSeries");
+	}
+
+	@Override
+	public String name() {
+		return "ErrorStatusCodeToException";
+	}
+
+	public int getOrder() {
+		return Ordered.LOWEST_PRECEDENCE;
+	}
+
+	public static class Config extends AbstractGatewayFilterFactory.NameConfig {
+
+		List<HttpStatus.Series> responseStatusCodeSeries = new ArrayList<HttpStatus.Series>() {
+			{
+				add(SERVER_ERROR);
+				add(CLIENT_ERROR);
+			}
+		};
+
+		public List<HttpStatus.Series> getResponseStatusCodeSeries() {
+			return responseStatusCodeSeries;
+		}
+
+		public Config setResponseStatusCodeSeries(
+				List<HttpStatus.Series> responseStatusCodeSeries) {
+			this.responseStatusCodeSeries = responseStatusCodeSeries;
+			return this;
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/ErrorStatusCodeToExceptionGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/ErrorStatusCodeToExceptionGatewayFilterFactory.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -40,22 +40,24 @@ import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
  * forced @{@link ResponseStatusException} to gracefully honor
  * the @{@link SpringCloudCircuitBreakerFilterFactory} fallback logic. To be used in
  * conjunction with
+ *
  * @{@link SpringCloudCircuitBreakerFilterFactory} filter. You might need to
  * add @{@link DedupeResponseHeaderGatewayFilterFactory} as well to remove duplicate
  * response headers.
- * 
- * // @formatter:off
- * <p>
- * Usage: 
- *        To translate 4xx errors' to exception, 
+ *
+ * <pre>
+ * Usage:
+ *        To translate 4xx errors' to exception,
+ * {@code
  *         filters:
  *         - name: ErrorStatusCodeToException
  *           args:
  *             name: MeshErrorCodeToException
  *             responseStatusCodeSeries:
  *             - CLIENT_ERROR
- *
- * 		  To translate 4xx and 5xx errors' to exception, 
+ * }
+ * 		  To translate 4xx and 5xx errors' to exception,
+ * {@code
  *         filters:
  *         - name: ErrorStatusCodeToException
  *           args:
@@ -63,9 +65,8 @@ import static org.springframework.http.HttpStatus.Series.SERVER_ERROR;
  *             responseStatusCodeSeries:
  *             - CLIENT_ERROR
  *             - SERVER_ERROR
- * </p>
- * // @formatter:on
- * 
+ * }
+ * </pre>
  * @author Srinivasa Vasu
  */
 public class ErrorStatusCodeToExceptionGatewayFilterFactory extends
@@ -125,12 +126,8 @@ public class ErrorStatusCodeToExceptionGatewayFilterFactory extends
 
 	public static class Config extends AbstractGatewayFilterFactory.NameConfig {
 
-		List<HttpStatus.Series> responseStatusCodeSeries = new ArrayList<HttpStatus.Series>() {
-			{
-				add(SERVER_ERROR);
-				add(CLIENT_ERROR);
-			}
-		};
+		List<HttpStatus.Series> responseStatusCodeSeries = Arrays.asList(SERVER_ERROR,
+				CLIENT_ERROR);
 
 		public List<HttpStatus.Series> getResponseStatusCodeSeries() {
 			return responseStatusCodeSeries;

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -41,6 +41,7 @@ import org.springframework.cloud.gateway.filter.factory.AddRequestParameterGatew
 import org.springframework.cloud.gateway.filter.factory.AddResponseHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.DedupeResponseHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.DedupeResponseHeaderGatewayFilterFactory.Strategy;
+import org.springframework.cloud.gateway.filter.factory.ErrorStatusCodeToExceptionGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.FallbackHeadersGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.MapRequestHeaderGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.PrefixPathGatewayFilterFactory;
@@ -75,6 +76,7 @@ import org.springframework.cloud.gateway.route.Route;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.unit.DataSize;
+import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -262,6 +264,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <T> the original request body class
 	 * @param <R> the new request body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 * 
 	 * <pre>
 	 * {@code
 	 * ...
@@ -284,9 +287,9 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that can be used to modify the response body.
 	 * @param inClass the class to conver the response body to
 	 * @param outClass the class the Gateway will add to the response before it is
-	 * returned to the client
+	 *     returned to the client
 	 * @param rewriteFunction the {@link RewriteFunction} that transforms the response
-	 * body
+	 *     body
 	 * @param <T> the original response body class
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
@@ -301,10 +304,10 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that can be used to modify the response body.
 	 * @param inClass the class to conver the response body to
 	 * @param outClass the class the Gateway will add to the response before it is
-	 * returned to the client
+	 *     returned to the client
 	 * @param newContentType the new Content-Type header to be returned
 	 * @param rewriteFunction the {@link RewriteFunction} that transforms the response
-	 * body
+	 *     body
 	 * @param <T> the original response body class
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
@@ -324,6 +327,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <T> the original response body class
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 * 
 	 * <pre>
 	 * {@code
 	 * ...
@@ -362,8 +366,7 @@ public class GatewayFilterSpec extends UriSpec {
 	}
 
 	/**
-	 * A filter that will set the Host header to
-	 * {@param hostName} on the outgoing request
+	 * A filter that will set the Host header to {@param hostName} on the outgoing request
 	 * @param hostName the updated Host header value
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
@@ -376,7 +379,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 * header
+	 *     header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(int status, URI url) {
@@ -387,7 +390,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 * header
+	 *     header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(int status, String url) {
@@ -398,7 +401,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 * header
+	 *     header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(String status, URI url) {
@@ -409,7 +412,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 * header
+	 *     header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(String status, String url) {
@@ -420,7 +423,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 * header
+	 *     header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(HttpStatus status, URL url) {
@@ -469,7 +472,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter that will set up a request rate limiter for a route.
 	 * @param configConsumer a {@link Consumer} that will return configuration for the
-	 * rate limiter
+	 *     rate limiter
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec requestRateLimiter(
@@ -513,8 +516,8 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter that will retry failed requests.
 	 * @param retryConsumer a {@link Consumer} which returns a
-	 * {@link org.springframework.cloud.gateway.filter.factory.RetryGatewayFilterFactory.RetryConfig}
-	 * to configure the retry functionality
+	 *     {@link org.springframework.cloud.gateway.filter.factory.RetryGatewayFilterFactory.RetryConfig}
+	 *     to configure the retry functionality
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec retry(
@@ -551,7 +554,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter that sets the path of the request before it is routed by the Gateway.
 	 * @param template the path to set on the request, allows multiple matching segments
-	 * using URI templates from Spring Framework
+	 *     using URI templates from Spring Framework
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec setPath(String template) {
@@ -603,7 +606,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param locationHeaderName a location header name
 	 * @param hostValue host value
 	 * @param protocolsRegex a valid regex String, against which the protocol name will be
-	 * matched
+	 *     matched
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec rewriteLocationResponseHeader(String stripVersionMode,
@@ -686,7 +689,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter which change the URI the request will be routed to by the Gateway.
 	 * @param determineRequestUri a {@link Function} which takes a
-	 * {@link ServerWebExchange} and returns a URI to route the request to
+	 *     {@link ServerWebExchange} and returns a URI to route the request to
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec changeRequestUri(
@@ -736,8 +739,8 @@ public class GatewayFilterSpec extends UriSpec {
 	 * org.springframework.cloud::spring-cloud-starter-netflix-hystrix} being on the
 	 * classpath, {@see https://cloud.spring.io/spring-cloud-netflix/}
 	 * @param config a {@link FallbackHeadersGatewayFilterFactory.Config} which provides
-	 * the header names. If header names arguments are not provided, default values are
-	 * used.
+	 *     the header names. If header names arguments are not provided, default values
+	 *     are used.
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec fallbackHeaders(
@@ -751,14 +754,30 @@ public class GatewayFilterSpec extends UriSpec {
 	 * org.springframework.cloud::spring-cloud-starter-netflix-hystrix} being on the
 	 * classpath, {@see https://cloud.spring.io/spring-cloud-netflix/}
 	 * @param configConsumer a {@link Consumer} which can be used to set up the names of
-	 * the headers in the config. If header names arguments are not provided, default
-	 * values are used.
+	 *     the headers in the config. If header names arguments are not provided, default
+	 *     values are used.
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec fallbackHeaders(
 			Consumer<FallbackHeadersGatewayFilterFactory.Config> configConsumer) {
 		FallbackHeadersGatewayFilterFactory factory = getFallbackHeadersGatewayFilterFactory();
 		return filter(factory.apply(configConsumer));
+	}
+
+	/**
+	 * A filter that translates the error code from mesh implementations like Istio to a
+	 * forced @{@link ResponseStatusException} to gracefully honor
+	 * the @{@link SpringCloudCircuitBreakerFilterFactory} fallback logic. To be used in
+	 * conjunction with
+	 * @{@link SpringCloudCircuitBreakerFilterFactory} filter
+	 * @param responseStatusCodeSeries error response series to be considered to convert
+	 *     to response exception
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec errorResponseStatusCodeToException(
+			List<HttpStatus.Series> responseStatusCodeSeries) {
+		return filter(getBean(ErrorStatusCodeToExceptionGatewayFilterFactory.class)
+				.apply(c -> c.setResponseStatusCodeSeries(responseStatusCodeSeries)));
 	}
 
 	private FallbackHeadersGatewayFilterFactory getFallbackHeadersGatewayFilterFactory() {

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -264,7 +264,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <T> the original request body class
 	 * @param <R> the new request body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
-	 * 
+	 *
 	 * <pre>
 	 * {@code
 	 * ...
@@ -287,9 +287,9 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that can be used to modify the response body.
 	 * @param inClass the class to conver the response body to
 	 * @param outClass the class the Gateway will add to the response before it is
-	 *     returned to the client
+	 * returned to the client
 	 * @param rewriteFunction the {@link RewriteFunction} that transforms the response
-	 *     body
+	 * body
 	 * @param <T> the original response body class
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
@@ -304,10 +304,10 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that can be used to modify the response body.
 	 * @param inClass the class to conver the response body to
 	 * @param outClass the class the Gateway will add to the response before it is
-	 *     returned to the client
+	 * returned to the client
 	 * @param newContentType the new Content-Type header to be returned
 	 * @param rewriteFunction the {@link RewriteFunction} that transforms the response
-	 *     body
+	 * body
 	 * @param <T> the original response body class
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
@@ -327,7 +327,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <T> the original response body class
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
-	 * 
+	 *
 	 * <pre>
 	 * {@code
 	 * ...
@@ -366,7 +366,8 @@ public class GatewayFilterSpec extends UriSpec {
 	}
 
 	/**
-	 * A filter that will set the Host header to {@param hostName} on the outgoing request
+	 * A filter that will set the Host header to
+	 * {@param hostName} on the outgoing request
 	 * @param hostName the updated Host header value
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
@@ -379,7 +380,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 *     header
+	 * header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(int status, URI url) {
@@ -390,7 +391,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 *     header
+	 * header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(int status, String url) {
@@ -401,7 +402,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 *     header
+	 * header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(String status, URI url) {
@@ -412,7 +413,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 *     header
+	 * header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(String status, String url) {
@@ -423,7 +424,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that will return a redirect response back to the client.
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
-	 *     header
+	 * header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(HttpStatus status, URL url) {
@@ -472,7 +473,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter that will set up a request rate limiter for a route.
 	 * @param configConsumer a {@link Consumer} that will return configuration for the
-	 *     rate limiter
+	 * rate limiter
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec requestRateLimiter(
@@ -516,8 +517,8 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter that will retry failed requests.
 	 * @param retryConsumer a {@link Consumer} which returns a
-	 *     {@link org.springframework.cloud.gateway.filter.factory.RetryGatewayFilterFactory.RetryConfig}
-	 *     to configure the retry functionality
+	 * {@link org.springframework.cloud.gateway.filter.factory.RetryGatewayFilterFactory.RetryConfig}
+	 * to configure the retry functionality
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec retry(
@@ -554,7 +555,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter that sets the path of the request before it is routed by the Gateway.
 	 * @param template the path to set on the request, allows multiple matching segments
-	 *     using URI templates from Spring Framework
+	 * using URI templates from Spring Framework
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec setPath(String template) {
@@ -606,7 +607,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param locationHeaderName a location header name
 	 * @param hostValue host value
 	 * @param protocolsRegex a valid regex String, against which the protocol name will be
-	 *     matched
+	 * matched
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec rewriteLocationResponseHeader(String stripVersionMode,
@@ -689,7 +690,7 @@ public class GatewayFilterSpec extends UriSpec {
 	/**
 	 * A filter which change the URI the request will be routed to by the Gateway.
 	 * @param determineRequestUri a {@link Function} which takes a
-	 *     {@link ServerWebExchange} and returns a URI to route the request to
+	 * {@link ServerWebExchange} and returns a URI to route the request to
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec changeRequestUri(
@@ -739,8 +740,8 @@ public class GatewayFilterSpec extends UriSpec {
 	 * org.springframework.cloud::spring-cloud-starter-netflix-hystrix} being on the
 	 * classpath, {@see https://cloud.spring.io/spring-cloud-netflix/}
 	 * @param config a {@link FallbackHeadersGatewayFilterFactory.Config} which provides
-	 *     the header names. If header names arguments are not provided, default values
-	 *     are used.
+	 * the header names. If header names arguments are not provided, default values are
+	 * used.
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec fallbackHeaders(
@@ -754,8 +755,8 @@ public class GatewayFilterSpec extends UriSpec {
 	 * org.springframework.cloud::spring-cloud-starter-netflix-hystrix} being on the
 	 * classpath, {@see https://cloud.spring.io/spring-cloud-netflix/}
 	 * @param configConsumer a {@link Consumer} which can be used to set up the names of
-	 *     the headers in the config. If header names arguments are not provided, default
-	 *     values are used.
+	 * the headers in the config. If header names arguments are not provided, default
+	 * values are used.
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec fallbackHeaders(
@@ -771,7 +772,7 @@ public class GatewayFilterSpec extends UriSpec {
 	 * conjunction with
 	 * @{@link SpringCloudCircuitBreakerFilterFactory} filter
 	 * @param responseStatusCodeSeries error response series to be considered to convert
-	 *     to response exception
+	 * to response exception
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec errorResponseStatusCodeToException(

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -29,8 +29,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import reactor.retry.Repeat;
-import reactor.retry.Retry;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -76,8 +74,10 @@ import org.springframework.cloud.gateway.route.Route;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.unit.DataSize;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.server.ServerWebExchange;
+
+import reactor.retry.Repeat;
+import reactor.retry.Retry;
 
 /**
  * Applies specific filters to routes.
@@ -767,12 +767,11 @@ public class GatewayFilterSpec extends UriSpec {
 
 	/**
 	 * A filter that translates the error code from mesh implementations like Istio to a
-	 * forced @{@link ResponseStatusException} to gracefully honor
-	 * the @{@link SpringCloudCircuitBreakerFilterFactory} fallback logic. To be used in
-	 * conjunction with
-	 * @{@link SpringCloudCircuitBreakerFilterFactory} filter
-	 * @param responseStatusCodeSeries error response series to be considered to convert
-	 * to response exception
+	 * forced exception to gracefully support the
+	 * {@link SpringCloudCircuitBreakerFilterFactory} fallback logic. To be used in
+	 * conjunction with {@link SpringCloudCircuitBreakerFilterFactory} filter
+	 * @param responseStatusCodeSeries error response series codes to be checked to
+	 * convert to a response exception
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec errorResponseStatusCodeToException(

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -29,6 +29,8 @@ import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import reactor.retry.Repeat;
+import reactor.retry.Retry;
 
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -75,9 +77,6 @@ import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.util.unit.DataSize;
 import org.springframework.web.server.ServerWebExchange;
-
-import reactor.retry.Repeat;
-import reactor.retry.Retry;
 
 /**
  * Applies specific filters to routes.
@@ -264,7 +263,6 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <T> the original request body class
 	 * @param <R> the new request body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
-	 *
 	 * <pre>
 	 * {@code
 	 * ...
@@ -327,7 +325,6 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param <T> the original response body class
 	 * @param <R> the new response body class
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
-	 *
 	 * <pre>
 	 * {@code
 	 * ...

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/ErrorStatusCodeToExceptionGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/ErrorStatusCodeToExceptionGatewayFilterFactoryTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * @author Srinivasa Vasu
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DirtiesContext
+public class ErrorStatusCodeToExceptionGatewayFilterFactoryTests
+		extends BaseWebClientTests {
+
+	@Test
+	public void set4xxStatusCodeFilterWorks() {
+		testClient.get().uri("/errorresponse/status/code/4xx").exchange().expectStatus()
+				.is4xxClientError().expectBody().json("{\"message\": \"Not Found\"}");
+	}
+
+	@Test
+	public void set5xxStatusCodeFilterWorks() {
+		testClient.get().uri("/errorresponse/status/code/5xx").exchange().expectStatus()
+				.is5xxServerError().expectBody()
+				.json("{\"message\": \"Service Unavailable\"}");
+	}
+
+	@Test
+	public void toStringFormat() {
+		GatewayFilter filter = new ErrorStatusCodeToExceptionGatewayFilterFactory()
+				.apply(c -> c.setName("MeshErrorStatusCodeToException"));
+		assertThat(filter.toString()).contains("MeshErrorStatusCodeToException");
+	}
+
+	@EnableAutoConfiguration
+	@SpringBootConfiguration
+	@RestController
+	@Import(DefaultTestConfig.class)
+	public static class TestConfig {
+
+		@Value("${test.uri}")
+		String uri;
+
+		@RequestMapping("/httpbin/errorresponse/status/code/4xx")
+		public ResponseEntity<?> error4xxResponse(ServerHttpResponse httpResponse) {
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+
+		}
+
+		@RequestMapping("/httpbin/errorresponse/status/code/5xx")
+		public ResponseEntity<?> error5xxResponse(ServerHttpResponse httpResponse) {
+			return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
+
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -435,7 +435,8 @@ spring:
           args:
             name: MeshErrorCodeToException
             responseStatusCodeSeries:
-              - CLIENT_ERROR
+            - CLIENT_ERROR
+            clearResponseHeader: "true"
 
       # =====================================
       - id: error_status_5xx
@@ -447,7 +448,7 @@ spring:
           args:
             name: MeshErrorCodeToException
             responseStatusCodeSeries:
-              - SERVER_ERROR
+            - SERVER_ERROR
 
       # =====================================
       # should be last and not follow alphabetical order

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -426,6 +426,30 @@ spring:
         - Weight=group1, 8
 
       # =====================================
+      - id: error_status_4xx
+        uri: ${test.uri}
+        predicates:
+          - Path=/errorresponse/status/code/4xx
+        filters:
+        - name: ErrorStatusCodeToException
+          args:
+            name: MeshErrorCodeToException
+            responseStatusCodeSeries:
+              - CLIENT_ERROR
+
+      # =====================================
+      - id: error_status_5xx
+        uri: ${test.uri}
+        predicates:
+          - Path=/errorresponse/status/code/5xx
+        filters:
+        - name: ErrorStatusCodeToException
+          args:
+            name: MeshErrorCodeToException
+            responseStatusCodeSeries:
+              - SERVER_ERROR
+
+      # =====================================
       # should be last and not follow alphabetical order
       - id: default_path_to_httpbin
         uri: ${test.uri}


### PR DESCRIPTION
**Context**

When CB filter used alongside mesh implementations like Istio, Istio suppresses the exceptions of downstream service failures and responds with appropriate error codes. This will skip the fallback logic. 

This filter is to translate those HTTP responses with error codes to a forced exception. This would make the downstream failure service calls to go through the CB fallback logic properly. When Istio is involved, this filter is expected to be used in conjunction with the CB filter

