### PR TITLE
Memory leak when gzip encoded response body is modified 

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
@@ -306,8 +306,11 @@ public class ModifyResponseBodyGatewayFilterFactory extends
 				MessageBodyEncoder encoder = messageBodyEncoders.get(encoding);
 				if (encoder != null) {
 					DataBufferFactory dataBufferFactory = httpResponse.bufferFactory();
-					response = response.publishOn(Schedulers.parallel())
-							.map(encoder::encode).map(dataBufferFactory::wrap);
+					response = response.publishOn(Schedulers.parallel()).map(buffer -> {
+						byte[] encodedResponse = encoder.encode(buffer);
+						DataBufferUtils.release(buffer);
+						return encodedResponse;
+					}).map(dataBufferFactory::wrap);
 					break;
 				}
 			}


### PR DESCRIPTION
Hi,

In normal flow when response body is not gzip encoded we create data buffer only once(for modified body). However when response body is encoded we first create a data buffer to modify decoded body and then another one where we put gzip encoded modified body. As the result of that substitution first buffer is not released. This is the fix to solve this issue.

To reproduce the issue you can just create a simple rest endpoint which returns gzip compressed body and run gateway agains it with netty leak detection on paranoid level. 