### PR TITLE
Add the ability to trip the circuit breaker based on returned status code

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -831,6 +831,55 @@ It is added to the `ServerWebExchange` as the `ServerWebExchangeUtils.CIRCUITBRE
 For the external controller/handler scenario, headers can be added with exception details.
 You can find more information on doing so in  the <<fallback-headers, FallbackHeaders GatewayFilter Factory section>>.
 
+[[circuit-breaker-status-codes]]
+==== Tripping The Circuit Breaker On Status Codes
+
+In some cases you might want to trip a circuit breaker based on the status code
+returned from the route it wraps.  The circuit breaker config object takes a list of
+status codes that if returned will cause the the circuit breaker to be tripped.  When setting the
+status codes you want to trip the circuit breaker you can either use a integer with the status code
+value or the String representation of the `HttpStatus` enumeration.
+
+.application.yml
+====
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: circuitbreaker_route
+        uri: lb://backing-service:8088
+        predicates:
+        - Path=/consumingServiceEndpoint
+        filters:
+        - name: CircuitBreaker
+          args:
+            name: myCircuitBreaker
+            fallbackUri: forward:/inCaseOfFailureUseThis
+            statusCodes:
+              - 500
+              - "NOT_FOUND"
+----
+====
+
+.Application.java
+====
+[source,java]
+----
+@Bean
+public RouteLocator routes(RouteLocatorBuilder builder) {
+    return builder.routes()
+        .route("circuitbreaker_route", r -> r.path("/consumingServiceEndpoint")
+            .filters(f -> f.circuitBreaker(c -> c.name("myCircuitBreaker").fallbackUri("forward:/inCaseOfFailureUseThis").addStatusCode("INTERNAL_SERVER_ERROR"))
+                .rewritePath("/consumingServiceEndpoint", "/backingServiceEndpoint")).uri("lb://backing-service:8088")
+        .build();
+}
+----
+====
+
+
+
 [[fallback-headers]]
 === The `FallbackHeaders` `GatewayFilter` Factory
 

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -20,9 +20,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -40,6 +38,7 @@ import org.springframework.cloud.gateway.event.EnableBodyCachingEvent;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.support.HasRouteId;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.cloud.gateway.support.TimeoutException;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
@@ -48,8 +47,6 @@ import org.springframework.util.Assert;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
-import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.CLIENT_RESPONSE_HEADER_NAMES;
-import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.removeAlreadyRouted;
 
 public class RetryGatewayFilterFactory
 		extends AbstractGatewayFilterFactory<RetryGatewayFilterFactory.RetryConfig> {
@@ -211,13 +208,12 @@ public class RetryGatewayFilterFactory
 		return exceeds;
 	}
 
+	@Deprecated
+	/**
+	 * Use {@link ServerWebExchangeUtils#reset(ServerWebExchange)}
+	 */
 	public void reset(ServerWebExchange exchange) {
-		// TODO: what else to do to reset exchange?
-		Set<String> addedHeaders = exchange.getAttributeOrDefault(
-				CLIENT_RESPONSE_HEADER_NAMES, Collections.emptySet());
-		addedHeaders
-				.forEach(header -> exchange.getResponse().getHeaders().remove(header));
-		removeAlreadyRouted(exchange);
+		ServerWebExchangeUtils.reset(exchange);
 	}
 
 	@Deprecated

--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -17,9 +17,11 @@
 package org.springframework.cloud.gateway.support;
 
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -191,6 +193,15 @@ public final class ServerWebExchangeUtils {
 					+ ". Response already committed.");
 		}
 		return response;
+	}
+
+	public static void reset(ServerWebExchange exchange) {
+		// TODO: what else to do to reset exchange?
+		Set<String> addedHeaders = exchange.getAttributeOrDefault(
+				CLIENT_RESPONSE_HEADER_NAMES, Collections.emptySet());
+		addedHeaders
+				.forEach(header -> exchange.getResponse().getHeaders().remove(header));
+		removeAlreadyRouted(exchange);
 	}
 
 	public static boolean setResponseStatus(ServerWebExchange exchange,

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
@@ -104,4 +104,22 @@ public abstract class SpringCloudCircuitBreakerFilterFactoryTests
 				.json("{\"from\":\"circuitbreakerfallbackcontroller3\"}");
 	}
 
+	@Test
+	public void filterStatusCodeFallback() {
+		testClient.get().uri("/status/500")
+				.header("Host", "www.circuitbreakerstatuscode.org").exchange()
+				.expectStatus().isOk().expectBody()
+				.json("{\"from\":\"statusCodeFallbackController\"}");
+
+		testClient.get().uri("/status/404")
+				.header("Host", "www.circuitbreakerstatuscode.org").exchange()
+				.expectStatus().isOk().expectBody()
+				.json("{\"from\":\"statusCodeFallbackController\"}");
+
+		testClient.get().uri("/status/200")
+				.header("Host", "www.circuitbreakerstatuscode.org").exchange()
+				.expectStatus().isOk().expectHeader()
+				.valueEquals(ROUTE_ID_HEADER, "circuitbreaker_fallback_test_statuscode");
+	}
+
 }

--- a/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
+++ b/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
@@ -36,6 +36,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.CIRCUITBREAKER_EXECUTION_EXCEPTION_ATTR;
 import static org.springframework.web.reactive.function.server.RequestPredicates.GET;
@@ -67,6 +68,11 @@ public class SpringCloudCircuitBreakerTestConfig {
 	@RequestMapping("/circuitbreakerFallbackController3")
 	public Map<String, String> fallbackcontroller3() {
 		return Collections.singletonMap("from", "circuitbreakerfallbackcontroller3");
+	}
+
+	@RequestMapping("/statusCodeFallbackController")
+	public Map<String, String> statusCodeFallbackController(ServerWebExchange exchange) {
+		return Collections.singletonMap("from", "statusCodeFallbackController");
 	}
 
 	@Bean

--- a/spring-cloud-gateway-core/src/test/resources/application.yml
+++ b/spring-cloud-gateway-core/src/test/resources/application.yml
@@ -94,6 +94,20 @@ spring:
               name: fallbackcmd
               fallbackUri: forward:/circuitbreakerFallbackController
 
+      # =====================================
+      - id: circuitbreaker_fallback_test_statuscode
+        uri: ${test.uri}
+        predicates:
+          - Host=**.circuitbreakerstatuscode.org
+        filters:
+          - name: CircuitBreaker
+            args:
+              name: fallbackcmd
+              statusCodes:
+                - 500
+                - "NOT_FOUND"
+              fallbackUri: forward:/statusCodeFallbackController
+
         # =====================================
       - id: change_uri_test
         uri: ${test.uri}


### PR DESCRIPTION
In some cases you might want to trip a circuit breaker based on the status code returned from the downstream service.  This provides a way to set a list of status codes to do this.