### PR TITLE
Document that is SCGW is built on top of WebFlux rather than MVC.

### DIFF
--- a/docs/src/main/asciidoc/sagan-index.adoc
+++ b/docs/src/main/asciidoc/sagan-index.adoc
@@ -1,4 +1,4 @@
-This project provides a library for building an API Gateway on top of Spring MVC. Spring Cloud Gateway aims to provide a simple, yet effective way to route to APIs and provide cross cutting concerns to them such as: security, monitoring/metrics, and resiliency.
+This project provides a library for building an API Gateway on top of Spring WebFlux. Spring Cloud Gateway aims to provide a simple, yet effective way to route to APIs and provide cross cutting concerns to them such as: security, monitoring/metrics, and resiliency.
 
 ## Features
 


### PR DESCRIPTION
The statement on spring.io that "_This project provides a library for building an API Gateway on top of **Spring MVC**._" seems to be misleading. Despite there being a subproject that uses Spring MVC, the gateway part that is widely known (e.g. via Spring Cloud Starter Gateway) uses WebFlux.