### PR TITLE
Expose NettyRoutingFilter order as static field

### DIFF
--- a/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-core/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -73,6 +73,8 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 	private static final Log log = LogFactory.getLog(NettyRoutingFilter.class);
 
+	public static final int ORDER = Ordered.LOWEST_PRECEDENCE;
+
 	private final HttpClient httpClient;
 
 	private final ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider;
@@ -99,7 +101,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 
 	@Override
 	public int getOrder() {
-		return Ordered.LOWEST_PRECEDENCE;
+		return ORDER;
 	}
 
 	@Override


### PR DESCRIPTION
I found myself writing a custom filter that I wanted to execute before the `NettyRoutingFilter`.
This PR makes it easier to get the filter order while configuring filters.