### PR TITLE
Match headers in spring-cloud-gateway-mvc case-insensitively

### DIFF
--- a/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/config/ProxyExchangeArgumentResolver.java
+++ b/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/config/ProxyExchangeArgumentResolver.java
@@ -33,6 +33,8 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import static java.util.stream.Collectors.toSet;
+
 /**
  * @author Dave Syer
  * @author Tim Ysewyn
@@ -56,7 +58,8 @@ public class ProxyExchangeArgumentResolver implements HandlerMethodArgumentResol
 	}
 
 	public void setAutoForwardedHeaders(Set<String> autoForwardedHeaders) {
-		this.autoForwardedHeaders = autoForwardedHeaders;
+		this.autoForwardedHeaders = autoForwardedHeaders.stream().map(String::toLowerCase)
+				.collect(toSet());
 	}
 
 	public void setSensitive(Set<String> sensitive) {
@@ -100,7 +103,7 @@ public class ProxyExchangeArgumentResolver implements HandlerMethodArgumentResol
 		HttpHeaders headers = new HttpHeaders();
 		while (headerNames.hasMoreElements()) {
 			String header = headerNames.nextElement();
-			if (this.autoForwardedHeaders.contains(header)) {
+			if (this.autoForwardedHeaders.contains(header.toLowerCase())) {
 				headers.addAll(header,
 						Collections.list(nativeRequest.getHeaders(header)));
 			}

--- a/spring-cloud-gateway-mvc/src/test/java/org/springframework/cloud/gateway/mvc/ProductionConfigurationTests.java
+++ b/spring-cloud-gateway-mvc/src/test/java/org/springframework/cloud/gateway/mvc/ProductionConfigurationTests.java
@@ -58,7 +58,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(properties = { "spring.cloud.gateway.proxy.auto-forward=baz" },
+@SpringBootTest(properties = { "spring.cloud.gateway.proxy.auto-forward=Baz" },
 		webEnvironment = WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(classes = TestApplication.class)
 public class ProductionConfigurationTests {
@@ -277,11 +277,14 @@ public class ProductionConfigurationTests {
 						RequestEntity
 								.get(rest.getRestTemplate().getUriTemplateHandler()
 										.expand("/proxy/headers"))
-								.header("foo", "bar").header("abc", "xyz")
+								.header("foo", "bar")
+								.header("abc", "xyz")
 								.header("baz", "fob").build(),
 						Map.class)
 				.getBody();
-		assertThat(headers).doesNotContainKey("foo").doesNotContainKey("hello")
+		assertThat(headers)
+				.doesNotContainKey("foo")
+				.doesNotContainKey("hello")
 				.containsKeys("bar", "abc");
 
 		assertThat(headers.get("bar")).containsOnly("hello");


### PR DESCRIPTION
Code was broken: it checks headers taken from the request using `Set#contains`  where the Set was used as given. HTTP headers should be matched in a case-insensitive fashion. 
I also looked at spring-cloud-gateway-webflux, but that always copies *all* headers (see https://github.com/spring-cloud/spring-cloud-gateway/blob/master/spring-cloud-gateway-webflux/src/main/java/org/springframework/cloud/gateway/webflux/ProxyExchange.java#L390), which invalidates the existing test (you can remove the config property that the 'baz' header needs to be forwarded, and the test still passes). Since that seems completely broken I didn't try to fix it in this commit. 