### PR TITLE
Fix broken link to filters unit tests

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -459,7 +459,7 @@ Route filters allow the modification of the incoming HTTP request or outgoing HT
 Route filters are scoped to a particular route.
 Spring Cloud Gateway includes many built-in GatewayFilter Factories.
 
-NOTE: For more detailed examples of how to use any of the following filters, take a look at the https://github.com/spring-cloud/spring-cloud-gateway/tree/master/spring-cloud-gateway-core/src/test/java/org/springframework/cloud/gateway/filter/factory[unit tests].
+NOTE: For more detailed examples of how to use any of the following filters, take a look at the https://github.com/spring-cloud/spring-cloud-gateway/tree/master/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory[unit tests].
 
 === The `AddRequestHeader` `GatewayFilter` Factory
 


### PR DESCRIPTION
A note about GatewayFilter factories contained a broken link to unit tests.