### PR TITLE
Fix the SetRequestHostHeader filter documentation.

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1539,11 +1539,11 @@ errorMessage` : `Request size is larger than permissible limit. Request size is 
 
 NOTE: The default request size is set to five MB if not provided as a filter argument in the route definition.
 
-=== The `SetRequestHost` `GatewayFilter` Factory
+=== The `SetRequestHostHeader` `GatewayFilter` Factory
 
-There are certain situation when the host header may need to be overridden. In this situation, the `SetRequestHost` `GatewayFilter` factory can replace the existing host header with a specified vaue.
+There are certain situation when the host header may need to be overridden. In this situation, the `SetRequestHostHeader` `GatewayFilter` factory can replace the existing host header with a specified vaue.
 The filter takes a `host` parameter.
-The following listing configures a `SetRequestHost` `GatewayFilter`:
+The following listing configures a `SetRequestHostHeader` `GatewayFilter`:
 
 .application.yml
 ====
@@ -1558,13 +1558,13 @@ spring:
         predicates:
         - Path=/headers
         filters:
-        - name: SetRequestHost
+        - name: SetRequestHostHeader
           args:
             host: example.org
 ----
 ====
 
-The `SetRequestHost` `GatewayFilter` factory replaces the value of the host header with `example.org`.
+The `SetRequestHostHeader` `GatewayFilter` factory replaces the value of the host header with `example.org`.
 
 === Modify a Request Body `GatewayFilter` Factory
 


### PR DESCRIPTION
There is a small mistake in the filter name in the documentation.

Trying to use the sample configuration from the [documentation](https://docs.spring.io/spring-cloud-gateway/docs/2.2.5.RELEASE/reference/html/#the-setrequesthost-gatewayfilter-factory)

<details>

```
spring:
  cloud:
    gateway:
      routes:
      - id: set_request_host_header_route
        uri: http://localhost:8080/headers
        predicates:
        - Path=/headers
        filters:
        - name: SetRequestHost
          args:
            host: example.org
```
</details>


following exception is happening:

<details>

```
2020-10-16 19:13:20.663 ERROR 43117 --- [           main] o.s.c.gateway.route.CachingRouteLocator  : Refresh routes error !!!

reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalArgumentException: Unable to find GatewayFilterFactory with name SetRequestHost
Caused by: java.lang.IllegalArgumentException: Unable to find GatewayFilterFactory with name SetRequestHost
        at org.springframework.cloud.gateway.route.RouteDefinitionRouteLocator.loadGatewayFilters(RouteDefinitionRouteLocator.java:187) ~[spring-cloud-gateway-core-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.cloud.gateway.route.RouteDefinitionRouteLocator.getFilters(RouteDefinitionRouteLocator.java:233) ~[spring-cloud-gateway-core-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.cloud.gateway.route.RouteDefinitionRouteLocator.convertToRoute(RouteDefinitionRouteLocator.java:170) ~[spring-cloud-gateway-core-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at reactor.core.publisher.FluxMap$MapSubscriber.onNext(FluxMap.java:100) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxFlatMap$FlatMapMain.tryEmitScalar(FluxFlatMap.java:480) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxFlatMap$FlatMapMain.onNext(FluxFlatMap.java:413) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.drain(FluxMergeSequential.java:425) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.innerComplete(FluxMergeSequential.java:321) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxMergeSequential$MergeSequentialInner.onSubscribe(FluxMergeSequential.java:544) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:161) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:86) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.Flux.subscribe(Flux.java:8325) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.onNext(FluxMergeSequential.java:230) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable$IterableSubscription.slowPath(FluxIterable.java:267) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable$IterableSubscription.request(FluxIterable.java:225) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.onSubscribe(FluxMergeSequential.java:191) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:161) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:86) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.Flux.subscribe(Flux.java:8325) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.onNext(FluxMergeSequential.java:230) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable$IterableSubscription.slowPath(FluxIterable.java:267) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable$IterableSubscription.request(FluxIterable.java:225) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxMergeSequential$MergeSequentialMain.onSubscribe(FluxMergeSequential.java:191) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:161) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.FluxIterable.subscribe(FluxIterable.java:86) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.Mono.subscribe(Mono.java:4213) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.Mono.subscribeWith(Mono.java:4324) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.Mono.subscribe(Mono.java:4184) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.Mono.subscribe(Mono.java:4120) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at reactor.core.publisher.Mono.subscribe(Mono.java:4067) ~[reactor-core-3.3.10.RELEASE.jar:3.3.10.RELEASE]
        at org.springframework.cloud.gateway.route.CachingRouteLocator.onApplicationEvent(CachingRouteLocator.java:82) ~[spring-cloud-gateway-core-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.cloud.gateway.route.CachingRouteLocator.onApplicationEvent(CachingRouteLocator.java:40) ~[spring-cloud-gateway-core-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:404) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:361) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.cloud.gateway.route.RouteRefreshListener.reset(RouteRefreshListener.java:68) ~[spring-cloud-gateway-core-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.cloud.gateway.route.RouteRefreshListener.onApplicationEvent(RouteRefreshListener.java:49) ~[spring-cloud-gateway-core-2.2.5.RELEASE.jar:2.2.5.RELEASE]
        at org.springframework.context.event.SimpleApplicationEventMulticaster.doInvokeListener(SimpleApplicationEventMulticaster.java:172) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.event.SimpleApplicationEventMulticaster.invokeListener(SimpleApplicationEventMulticaster.java:165) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.event.SimpleApplicationEventMulticaster.multicastEvent(SimpleApplicationEventMulticaster.java:139) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:404) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.publishEvent(AbstractApplicationContext.java:361) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.finishRefresh(AbstractApplicationContext.java:898) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:554) ~[spring-context-5.2.9.RELEASE.jar:5.2.9.RELEASE]
        at org.springframework.boot.web.reactive.context.ReactiveWebServerApplicationContext.refresh(ReactiveWebServerApplicationContext.java:62) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:758) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:750) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:397) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:315) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1237) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at org.springframework.boot.SpringApplication.run(SpringApplication.java:1226) ~[spring-boot-2.3.4.RELEASE.jar:2.3.4.RELEASE]
        at com.example.demo.DemoApplication.main(DemoApplication.java:10) ~[classes/:na]
```

</details>

Checking the source the filter is actually named [`SetRequestHostHeaderGatewayFilter`](https://github.com/RageZBla/spring-cloud-gateway/blob/master/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SetRequestHostHeaderGatewayFilterFactory.java#L36)