### PR TITLE
Refine doc on body rewrite filters for the case of missing body

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1605,6 +1605,9 @@ static class Hello {
     }
 }
 ----
+
+NOTE:  if the request has no body, the `RewriteFilter` will be passed `null`. `Mono.empty()` should be returned to assign a missing body in the request.
+
 ====
 
 === Modify a Response Body `GatewayFilter` Factory
@@ -1628,6 +1631,8 @@ public RouteLocator routes(RouteLocatorBuilder builder) {
         .build();
 }
 ----
+
+NOTE:  if the response has no body, the `RewriteFilter` will be passed `null`. `Mono.empty()` should be returned to assing a missing body in the response.
 ====
 
 === Token Relay `GatewayFilter` Factory


### PR DESCRIPTION
Null will be passed. Mono.empty() should be returned to assign an empty body.

However, I could not spot a related test in the codebase that officially documents/asserts this behavior. 

Hopefully, this can be a useful workaround to #1147 and #1762