### PR TITLE
Try to fix issue #2005:SecureHeadersGatewayFilterFactory support define value of header

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -32,7 +32,7 @@ import static org.springframework.cloud.gateway.support.GatewayToStringStyler.fi
  *
  * @author Spencer Gibb, Thirunavukkarasu Ravichandran
  */
-public class SecureHeadersGatewayFilterFactory extends AbstractGatewayFilterFactory {
+public class SecureHeadersGatewayFilterFactory extends AbstractGatewayFilterFactory<SecureHeadersGatewayFilterFactory.Config> {
 
 	/**
 	 * Xss-Protection header name.
@@ -77,50 +77,51 @@ public class SecureHeadersGatewayFilterFactory extends AbstractGatewayFilterFact
 	private final SecureHeadersProperties properties;
 
 	public SecureHeadersGatewayFilterFactory(SecureHeadersProperties properties) {
+		super(Config.class);
 		this.properties = properties;
 	}
 
 	@Override
-	public GatewayFilter apply(Object config) {
-		// TODO: allow args to override properties
-
+	public GatewayFilter apply(Config config) {
 		return new GatewayFilter() {
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 				HttpHeaders headers = exchange.getResponse().getHeaders();
 
 				List<String> disabled = properties.getDisable();
+				Config copyConfig = config.copy();
+				copyConfig.modifyConfig(properties);
 
 				if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
-					headers.add(X_XSS_PROTECTION_HEADER, properties.getXssProtectionHeader());
+					headers.add(X_XSS_PROTECTION_HEADER, copyConfig.getXssProtectionHeader());
 				}
 
 				if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
-					headers.add(STRICT_TRANSPORT_SECURITY_HEADER, properties.getStrictTransportSecurity());
+					headers.add(STRICT_TRANSPORT_SECURITY_HEADER, copyConfig.getStrictTransportSecurity());
 				}
 
 				if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
-					headers.add(X_FRAME_OPTIONS_HEADER, properties.getFrameOptions());
+					headers.add(X_FRAME_OPTIONS_HEADER, copyConfig.getFrameOptions());
 				}
 
 				if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
-					headers.add(X_CONTENT_TYPE_OPTIONS_HEADER, properties.getContentTypeOptions());
+					headers.add(X_CONTENT_TYPE_OPTIONS_HEADER, copyConfig.getContentTypeOptions());
 				}
 
 				if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
-					headers.add(REFERRER_POLICY_HEADER, properties.getReferrerPolicy());
+					headers.add(REFERRER_POLICY_HEADER, copyConfig.getReferrerPolicy());
 				}
 
 				if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
-					headers.add(CONTENT_SECURITY_POLICY_HEADER, properties.getContentSecurityPolicy());
+					headers.add(CONTENT_SECURITY_POLICY_HEADER, copyConfig.getContentSecurityPolicy());
 				}
 
 				if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
-					headers.add(X_DOWNLOAD_OPTIONS_HEADER, properties.getDownloadOptions());
+					headers.add(X_DOWNLOAD_OPTIONS_HEADER, copyConfig.getDownloadOptions());
 				}
 
 				if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
-					headers.add(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, properties.getPermittedCrossDomainPolicies());
+					headers.add(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, copyConfig.getPermittedCrossDomainPolicies());
 				}
 
 				return chain.filter(exchange);
@@ -137,4 +138,134 @@ public class SecureHeadersGatewayFilterFactory extends AbstractGatewayFilterFact
 		return !disabledHeaders.contains(header.toLowerCase());
 	}
 
+	public static class Config {
+
+		private String xssProtectionHeader;
+
+		private String strictTransportSecurity;
+
+		private String frameOptions;
+
+		private String contentTypeOptions;
+
+		private String referrerPolicy;
+
+		private String contentSecurityPolicy;
+
+		private String downloadOptions;
+
+		private String permittedCrossDomainPolicies;
+
+		public Config copy() {
+			Config config = new Config();
+			config.setXssProtectionHeader(xssProtectionHeader);
+			config.setStrictTransportSecurity(strictTransportSecurity);
+			config.setFrameOptions(frameOptions);
+			config.setContentTypeOptions(contentTypeOptions);
+			config.setReferrerPolicy(referrerPolicy);
+			config.setContentSecurityPolicy(contentSecurityPolicy);
+			config.setDownloadOptions(downloadOptions);
+			config.setPermittedCrossDomainPolicies(permittedCrossDomainPolicies);
+			return config;
+		}
+
+		public void modifyConfig(SecureHeadersProperties properties) {
+			if (xssProtectionHeader == null) {
+				this.xssProtectionHeader = properties.getXssProtectionHeader();
+			}
+
+			if (strictTransportSecurity == null) {
+				this.strictTransportSecurity = properties.getStrictTransportSecurity();
+			}
+
+			if (frameOptions == null) {
+				this.frameOptions = properties.getFrameOptions();
+			}
+
+			if (contentTypeOptions == null) {
+				this.contentTypeOptions = properties.getContentTypeOptions();
+			}
+
+			if (contentTypeOptions == null) {
+				this.referrerPolicy = properties.getReferrerPolicy();
+			}
+
+			if (contentSecurityPolicy == null) {
+				this.contentSecurityPolicy = properties.getContentSecurityPolicy();
+			}
+
+			if (downloadOptions == null) {
+				this.downloadOptions = properties.getDownloadOptions();
+			}
+
+			if (permittedCrossDomainPolicies == null) {
+				this.permittedCrossDomainPolicies = properties.getPermittedCrossDomainPolicies();
+			}
+		}
+
+		public String getXssProtectionHeader() {
+			return xssProtectionHeader;
+		}
+
+		public void setXssProtectionHeader(String xssProtectionHeader) {
+			this.xssProtectionHeader = xssProtectionHeader;
+		}
+
+		public String getStrictTransportSecurity() {
+			return strictTransportSecurity;
+		}
+
+		public void setStrictTransportSecurity(String strictTransportSecurity) {
+			this.strictTransportSecurity = strictTransportSecurity;
+		}
+
+		public String getFrameOptions() {
+			return frameOptions;
+		}
+
+		public void setFrameOptions(String frameOptions) {
+			this.frameOptions = frameOptions;
+		}
+
+		public String getContentTypeOptions() {
+			return contentTypeOptions;
+		}
+
+		public void setContentTypeOptions(String contentTypeOptions) {
+			this.contentTypeOptions = contentTypeOptions;
+		}
+
+		public String getReferrerPolicy() {
+			return referrerPolicy;
+		}
+
+		public void setReferrerPolicy(String referrerPolicy) {
+			this.referrerPolicy = referrerPolicy;
+		}
+
+		public String getContentSecurityPolicy() {
+			return contentSecurityPolicy;
+		}
+
+		public void setContentSecurityPolicy(String contentSecurityPolicy) {
+			this.contentSecurityPolicy = contentSecurityPolicy;
+		}
+
+		public String getDownloadOptions() {
+			return downloadOptions;
+		}
+
+		public void setDownloadOptions(String downloadOptions) {
+			this.downloadOptions = downloadOptions;
+		}
+
+		public String getPermittedCrossDomainPolicies() {
+			return permittedCrossDomainPolicies;
+		}
+
+		public void setPermittedCrossDomainPolicies(String permittedCrossDomainPolicies) {
+			this.permittedCrossDomainPolicies = permittedCrossDomainPolicies;
+		}
+
+	}
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -186,7 +186,7 @@ public class SecureHeadersGatewayFilterFactory extends AbstractGatewayFilterFact
 				this.contentTypeOptions = properties.getContentTypeOptions();
 			}
 
-			if (contentTypeOptions == null) {
+			if (referrerPolicy == null) {
 				this.referrerPolicy = properties.getReferrerPolicy();
 			}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -521,12 +521,11 @@ public class GatewayFilterSpec extends UriSpec {
 	 * A filter that adds a number of headers to the response at the reccomendation from
 	 * <a href="https://blog.appcanary.com/2017/http-security-headers.html">this blog
 	 * post</a>.
+	 * @param config self define headers
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
-	@SuppressWarnings("unchecked")
-	public GatewayFilterSpec secureHeaders() {
-		return filter(getBean(SecureHeadersGatewayFilterFactory.class).apply(c -> {
-		}));
+	public GatewayFilterSpec secureHeaders(SecureHeadersGatewayFilterFactory.Config config) {
+		return filter(getBean(SecureHeadersGatewayFilterFactory.class).apply(config));
 	}
 
 	/**

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
@@ -24,7 +24,6 @@ import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
-import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory.NameConfig;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -35,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.CONTENT_SECURITY_POLICY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.Config;
 import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.REFERRER_POLICY_HEADER;
 import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.STRICT_TRANSPORT_SECURITY_HEADER;
 import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_CONTENT_TYPE_OPTIONS_HEADER;
@@ -70,9 +70,7 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 	public void addAllHeadersIfNothingIsDisabled() {
 		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(
 				new SecureHeadersProperties());
-		NameConfig config = new NameConfig();
-		config.setName("SecureHeadersGatewayFilter");
-		filter = filterFactory.apply(config);
+		filter = filterFactory.apply(new Config());
 
 		filter.filter(exchange, filterChain);
 
@@ -90,9 +88,7 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 				"x-permitted-cross-domain-policies"));
 
 		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
-		NameConfig config = new NameConfig();
-		config.setName("SecureHeadersGatewayFilter");
-		filter = filterFactory.apply(config);
+		filter = filterFactory.apply(new Config());
 
 		filter.filter(exchange, filterChain);
 
@@ -104,8 +100,38 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 	}
 
 	@Test
+	public void overrideSomeHeaders() {
+		SecureHeadersProperties properties = new SecureHeadersProperties();
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(
+				new SecureHeadersProperties());
+		Config config = new Config();
+		config.setStrictTransportSecurity("max-age=65535");
+		config.setReferrerPolicy("referrer");
+		filter = filterFactory.apply(config);
+
+		filter.filter(exchange, filterChain);
+
+		ServerHttpResponse response = captor.getValue().getResponse();
+		assertThat(response.getHeaders()).containsKeys(X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER,
+				X_FRAME_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER,
+				CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER);
+
+		assertThat(response.getHeaders().get(STRICT_TRANSPORT_SECURITY_HEADER)).containsOnly("max-age=65535");
+		assertThat(response.getHeaders().get(REFERRER_POLICY_HEADER)).containsOnly("referrer");
+
+		assertThat(response.getHeaders().get(X_XSS_PROTECTION_HEADER)).containsOnly(properties.getXssProtectionHeader());
+		assertThat(response.getHeaders().get(X_FRAME_OPTIONS_HEADER)).containsOnly(properties.getFrameOptions());
+		assertThat(response.getHeaders().get(X_CONTENT_TYPE_OPTIONS_HEADER)).containsOnly(properties.getContentTypeOptions());
+		assertThat(response.getHeaders().get(CONTENT_SECURITY_POLICY_HEADER)).containsOnly(properties.getContentSecurityPolicy());
+		assertThat(response.getHeaders().get(X_DOWNLOAD_OPTIONS_HEADER)).containsOnly(properties.getDownloadOptions());
+		assertThat(response.getHeaders().get(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)).containsOnly(properties.getPermittedCrossDomainPolicies());
+
+
+	}
+
+	@Test
 	public void toStringFormat() {
-		GatewayFilter filter = new SecureHeadersGatewayFilterFactory(new SecureHeadersProperties()).apply("");
+		GatewayFilter filter = new SecureHeadersGatewayFilterFactory(new SecureHeadersProperties()).apply(new Config());
 		Assertions.assertThat(filter.toString()).contains("SecureHeaders");
 	}
 


### PR DESCRIPTION
**Configure data priority**

When define a header value for route,then use defined value or else use default value.

**Use Example:**

Define a route with SecureHeaders filter in application.yaml

~~~yaml
spring:
  cloud:
    gateway:
      routes:
        - id: sec-header
          uri: http://localhost:8080
          predicates:
            - Path=/upload/**
          filters:
            - name: SecureHeaders
              args:
                xssProtectionHeader: no header
~~~

Use java code to define a route:

~~~java
@Bean
public RouteLocator testRoute(RouteLocatorBuilder builder) {
	return builder.routes()
		.route("test", new Function<PredicateSpec, Route.AsyncBuilder>() {
			@Override
			public Route.AsyncBuilder apply(PredicateSpec predicateSpec) {
				return predicateSpec.path("/upload")
					.filters(new Function<GatewayFilterSpec, UriSpec>() {
						@Override
						public UriSpec apply(GatewayFilterSpec gatewayFilterSpec) {
							SecureHeadersGatewayFilterFactory.Config config = new SecureHeadersGatewayFilterFactory.Config();
							config.setReferrerPolicy("chentong");
							return gatewayFilterSpec.secureHeaders(config);
						}
					}).uri("http://localhost:8080");
			}
		}).build();
}
~~~

