### PR TITLE
Update RouteToRequestUrlFilter.java

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
@@ -86,10 +86,12 @@ public class RouteToRequestUrlFilter implements GlobalFilter, Ordered {
 			throw new IllegalStateException("Invalid host: " + routeUri.toString());
 		}
 
-		URI mergedUrl = UriComponentsBuilder.fromUri(uri)
+		//URI mergedUrl = UriComponentsBuilder.fromUri(uri)
 				// .uri(routeUri)
-				.scheme(routeUri.getScheme()).host(routeUri.getHost())
-				.port(routeUri.getPort()).build(encoded).toUri();
+		//		.scheme(routeUri.getScheme()).host(routeUri.getHost())
+		//		.port(routeUri.getPort()).build(encoded).toUri();
+		 URI mergedUrl = UriComponentsBuilder.fromUri(routeUri).port(routeUri.getPort())
+                .path(uri.getPath()).query(uri.getRawQuery()).build(encoded).toUri();
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, mergedUrl);
 		return chain.filter(exchange);
 	}


### PR DESCRIPTION
mergedUrl 优化建议，有个需求测试环境和正式环境route 配置中uri 地址不一样，例如
https://www.xxxx.com.cn/test/user/add
https://www.xxxx.com.cn/prod/user/add
如果  URI mergedUrl = UriComponentsBuilder.fromUri(routeUri).port(routeUri.getPort())
                .path(uri.getPath()).query(uri.getRawQuery()).build(encoded).toUri(); 改成这个，这样就能支持 uri 配置中带path地址
例如
- id: test
  uri: https://test.xxxx.com.cn/aa
  predicates:
    - Path=/sc/**
  filters:
    - StripPrefix=1