### PR TITLE
use DynamicPropertySource to set redis container addr

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.cloud.gateway.filter;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,16 +33,15 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
-@RunWith(SpringRunner.class)
 @SpringBootTest(properties = "spring.cloud.gateway.httpclient.response-timeout=3s", webEnvironment = RANDOM_PORT)
 @DirtiesContext
 public class NettyRoutingFilterIntegrationTests extends BaseWebClientTests {
@@ -92,6 +91,7 @@ public class NettyRoutingFilterIntegrationTests extends BaseWebClientTests {
 	}
 
 	@Test
+	@DisabledOnOs(WINDOWS)
 	public void shouldApplyConnectTimeoutPerRoute() {
 		long currentTimeMillisBeforeCall = System.currentTimeMillis();
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/BaseWebClientTests.java
@@ -21,6 +21,7 @@ import java.time.Duration;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import reactor.core.publisher.Mono;
 
 import org.springframework.boot.SpringBootConfiguration;
@@ -70,6 +71,11 @@ public class BaseWebClientTests {
 
 	@Before
 	public void setup() throws Exception {
+		setup(new ReactorClientHttpConnector(), "http://localhost:" + port);
+	}
+
+	@BeforeEach
+	public void setupJupiter() throws Exception {
 		setup(new ReactorClientHttpConnector(), "http://localhost:" + port);
 	}
 


### PR DESCRIPTION
1. set spring.redis.host & port
2. use DisabledOnOs to disable redis container test on windows
3. use DisabledOnOs to disable
NettyRoutingFilterIntegrationTests.shouldApplyConnectTimeoutPerRoute,
this test set connect timeout to be 5ms, and assume the os will report
connection refused within that period, but windows needs more time, and
windows also report a slightly different error even we increase the
connect timeout setting, as the target usage will be on linux, I think
disable on windows should be ok