### PR TITLE
#263 Java routes API support for default filters

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -137,6 +137,7 @@ import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.RouteRefreshListener;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.support.ConfigurationService;
+import org.springframework.cloud.gateway.support.GatewayFilterContext;
 import org.springframework.cloud.gateway.support.StringToZonedDateTimeConverter;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -218,12 +219,12 @@ public class GatewayAutoConfiguration {
 
 	@Bean
 	public RouteLocator routeDefinitionRouteLocator(GatewayProperties properties,
-			List<GatewayFilterFactory> gatewayFilters,
 			List<RoutePredicateFactory> predicates,
 			RouteDefinitionLocator routeDefinitionLocator,
-			ConfigurationService configurationService) {
+			ConfigurationService configurationService,
+			GatewayFilterContext gatewayFilterContext) {
 		return new RouteDefinitionRouteLocator(routeDefinitionLocator, predicates,
-				gatewayFilters, properties, configurationService);
+				properties, configurationService, gatewayFilterContext);
 	}
 
 	@Bean
@@ -264,6 +265,14 @@ public class GatewayAutoConfiguration {
 	@Bean
 	public GatewayProperties gatewayProperties() {
 		return new GatewayProperties();
+	}
+
+	@Bean
+	public GatewayFilterContext gatewayFilterContext(GatewayProperties gatewayProperties,
+			ConfigurationService configurationService,
+			List<GatewayFilterFactory> gatewayFilterFactories) {
+		return new GatewayFilterContext(gatewayProperties, configurationService,
+				gatewayFilterFactories);
 	}
 
 	// ConfigurationProperty beans

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/Route.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/Route.java
@@ -169,6 +169,8 @@ public class Route implements Ordered {
 
 		protected Map<String, Object> metadata = new HashMap<>();
 
+		protected boolean enableDefaultFilter = false;
+
 		protected AbstractBuilder() {
 		}
 
@@ -240,6 +242,23 @@ public class Route implements Ordered {
 
 		public B filters(GatewayFilter... gatewayFilters) {
 			return filters(Arrays.asList(gatewayFilters));
+		}
+
+		public B enableDefaultFilter(boolean enableDefaultFilter) {
+			this.enableDefaultFilter = enableDefaultFilter;
+			return getThis();
+		}
+
+		public boolean isEnableDefaultFilter() {
+			return enableDefaultFilter;
+		}
+
+		public List<GatewayFilter> getGatewayFilters() {
+			return gatewayFilters;
+		}
+
+		public void setGatewayFilters(List<GatewayFilter> gatewayFilters) {
+			this.gatewayFilters = gatewayFilters;
 		}
 
 		public Route build() {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/RouteDefinition.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/RouteDefinition.java
@@ -56,6 +56,8 @@ public class RouteDefinition {
 
 	private int order = 0;
 
+	private boolean enableDefaultFilter = true;
+
 	public RouteDefinition() {
 	}
 
@@ -123,6 +125,14 @@ public class RouteDefinition {
 
 	public void setMetadata(Map<String, Object> metadata) {
 		this.metadata = metadata;
+	}
+
+	boolean isEnableDefaultFilter() {
+		return enableDefaultFilter;
+	}
+
+	void setEnableDefaultFilter(boolean enableDefaultFilter) {
+		this.enableDefaultFilter = enableDefaultFilter;
 	}
 
 	@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/RouteLocatorBuilder.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/RouteLocatorBuilder.java
@@ -23,8 +23,11 @@ import java.util.function.Function;
 
 import reactor.core.publisher.Flux;
 
+import org.springframework.cloud.gateway.config.GatewayProperties;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.route.RouteLocator;
+import org.springframework.cloud.gateway.support.GatewayFilterContext;
 import org.springframework.context.ConfigurableApplicationContext;
 
 /**
@@ -98,6 +101,11 @@ public class RouteLocatorBuilder {
 		}
 
 		void add(Route.AsyncBuilder route) {
+			if (route.isEnableDefaultFilter()) {
+				route.filters(context.getBean(GatewayFilterContext.class)
+						.getDefaultGatewayFilters());
+			}
+
 			routes.add(route);
 		}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/GatewayFilterContext.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/GatewayFilterContext.java
@@ -1,0 +1,97 @@
+package org.springframework.cloud.gateway.support;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.cloud.gateway.config.GatewayProperties;
+import org.springframework.cloud.gateway.event.FilterArgsEvent;
+import org.springframework.cloud.gateway.filter.FilterDefinition;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.core.Ordered;
+
+/**
+ * @author chentong
+ */
+public class GatewayFilterContext {
+
+	private static final Logger logger = LoggerFactory
+			.getLogger(GatewayFilterContext.class);
+
+	public static final String DEFAULT_FILTERS = "defaultFilters";
+
+	private final GatewayProperties gatewayProperties;
+
+	private final ConfigurationService configurationService;
+
+	private final Map<String, GatewayFilterFactory> gatewayFilterFactories = new HashMap<>();
+
+	public GatewayFilterContext(GatewayProperties gatewayProperties,
+			ConfigurationService configurationService,
+			List<GatewayFilterFactory> gatewayFilterFactories) {
+		this.gatewayProperties = gatewayProperties;
+		this.configurationService = configurationService;
+		gatewayFilterFactories.forEach(
+				factory -> this.gatewayFilterFactories.put(factory.name(), factory));
+	}
+
+	public List<GatewayFilter> getDefaultGatewayFilters() {
+		if (gatewayProperties.getDefaultFilters().isEmpty()) {
+			return new ArrayList<>();
+		}
+
+		return loadGatewayFilters(DEFAULT_FILTERS,
+				new ArrayList<>(gatewayProperties.getDefaultFilters()));
+	}
+
+	public List<GatewayFilter> loadGatewayFilters(String id,
+			List<FilterDefinition> filterDefinitions) {
+		ArrayList<GatewayFilter> ordered = new ArrayList<>(filterDefinitions.size());
+		for (int i = 0; i < filterDefinitions.size(); i++) {
+			FilterDefinition definition = filterDefinitions.get(i);
+			GatewayFilterFactory factory = this.gatewayFilterFactories
+					.get(definition.getName());
+			if (factory == null) {
+				throw new IllegalArgumentException(
+						"Unable to find GatewayFilterFactory with name "
+								+ definition.getName());
+			}
+			if (logger.isDebugEnabled()) {
+				logger.debug("RouteDefinition " + id + " applying filter "
+						+ definition.getArgs() + " to " + definition.getName());
+			}
+
+			// @formatter:off
+			Object configuration = this.configurationService.with(factory)
+					.name(definition.getName())
+					.properties(definition.getArgs())
+					.eventFunction((bound, properties) -> new FilterArgsEvent(
+							// TODO: why explicit cast needed or java compile fails
+							GatewayFilterContext.this, id, (Map<String, Object>) properties))
+					.bind();
+			// @formatter:on
+
+			if (configuration instanceof HasRouteId) {
+				HasRouteId hasRouteId = (HasRouteId) configuration;
+				hasRouteId.setRouteId(id);
+			}
+
+			GatewayFilter gatewayFilter = factory.apply(configuration);
+			if (gatewayFilter instanceof Ordered) {
+				ordered.add(gatewayFilter);
+			}
+			else {
+				ordered.add(new OrderedGatewayFilter(gatewayFilter, i + 1));
+			}
+		}
+
+		return ordered;
+	}
+
+}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
@@ -111,6 +111,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 				.isOk().expectBody(String.class).isEqualTo("2");
 	}
 
+	// log level must be TRACE
 	@Test
 	public void retryFilterPost() {
 		testClient.post().uri("/retrypost?key=postconfig&expectedbody=HelloConfig")
@@ -128,6 +129,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 				.exchange().expectStatus().isOk().expectBody(String.class).isEqualTo("3");
 	}
 
+	// log level must be TRACE
 	@Test
 	public void retryFilterPostOneTime() {
 		testClient.post().uri(

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocatorTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocatorTests.java
@@ -37,6 +37,7 @@ import org.springframework.cloud.gateway.handler.predicate.HostRoutePredicateFac
 import org.springframework.cloud.gateway.handler.predicate.PredicateDefinition;
 import org.springframework.cloud.gateway.handler.predicate.RoutePredicateFactory;
 import org.springframework.cloud.gateway.support.ConfigurationService;
+import org.springframework.cloud.gateway.support.GatewayFilterContext;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,11 +71,14 @@ public class RouteDefinitionRouteLocatorTests {
 
 		PropertiesRouteDefinitionLocator routeDefinitionLocator = new PropertiesRouteDefinitionLocator(
 				gatewayProperties);
+
+		GatewayFilterContext gatewayFilterContext = new GatewayFilterContext(
+				gatewayProperties, new ConfigurationService(), gatewayFilterFactories);
 		@SuppressWarnings("deprecation")
 		RouteDefinitionRouteLocator routeDefinitionRouteLocator = new RouteDefinitionRouteLocator(
 				new CompositeRouteDefinitionLocator(Flux.just(routeDefinitionLocator)),
-				predicates, gatewayFilterFactories, gatewayProperties,
-				new ConfigurationService());
+				predicates, gatewayProperties, new ConfigurationService(),
+				gatewayFilterContext);
 
 		StepVerifier.create(routeDefinitionRouteLocator.getRoutes()).assertNext(route -> {
 			List<GatewayFilter> filters = route.getFilters();
@@ -101,11 +105,13 @@ public class RouteDefinitionRouteLocatorTests {
 
 		PropertiesRouteDefinitionLocator routeDefinitionLocator = new PropertiesRouteDefinitionLocator(
 				gatewayProperties);
+		GatewayFilterContext gatewayFilterContext = new GatewayFilterContext(
+				gatewayProperties, new ConfigurationService(), gatewayFilterFactories);
 		@SuppressWarnings("deprecation")
 		RouteDefinitionRouteLocator routeDefinitionRouteLocator = new RouteDefinitionRouteLocator(
 				new CompositeRouteDefinitionLocator(Flux.just(routeDefinitionLocator)),
-				predicates, gatewayFilterFactories, gatewayProperties,
-				new ConfigurationService());
+				predicates, gatewayProperties, new ConfigurationService(),
+				gatewayFilterContext);
 
 		StepVerifier.create(routeDefinitionRouteLocator.getRoutes()).assertNext(route -> {
 			List<GatewayFilter> filters = route.getFilters();

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/GatewayFilterContextTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/GatewayFilterContextTests.java
@@ -1,0 +1,83 @@
+package org.springframework.cloud.gateway.support;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+import org.springframework.cloud.gateway.config.GatewayProperties;
+import org.springframework.cloud.gateway.filter.FilterDefinition;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.factory.AddResponseHeaderGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.RemoveResponseHeaderGatewayFilterFactory;
+import org.springframework.cloud.gateway.handler.predicate.PredicateDefinition;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GatewayFilterContextTests {
+
+	@Test
+	public void getDefaultGatewayFiltersEmpty() {
+		GatewayFilterContext gatewayFilterContext = new GatewayFilterContext(
+				new GatewayProperties(), new ConfigurationService(),
+				Collections.emptyList());
+		List<GatewayFilter> filters = gatewayFilterContext.getDefaultGatewayFilters();
+
+		assertThat(filters).isEmpty();
+	}
+
+	@Test
+	public void getDefaultGatewayFiltersSuccess() {
+		List<GatewayFilterFactory> gatewayFilterFactories = Arrays.asList(
+				new RemoveResponseHeaderGatewayFilterFactory(),
+				new AddResponseHeaderGatewayFilterFactory());
+
+		GatewayProperties gatewayProperties = new GatewayProperties();
+		gatewayProperties.setDefaultFilters(defaultFilterDefinitions());
+
+		GatewayFilterContext gatewayFilterContext = new GatewayFilterContext(
+				gatewayProperties, new ConfigurationService(), gatewayFilterFactories);
+
+		List<GatewayFilter> filters = gatewayFilterContext.getDefaultGatewayFilters();
+		assertThat(filters.size()).isEqualTo(2);
+	}
+
+	@Test
+	public void getDefaultGatewayFiltersThrowException() {
+		List<GatewayFilterFactory> gatewayFilterFactories = Arrays
+				.asList(new RemoveResponseHeaderGatewayFilterFactory());
+
+		GatewayProperties gatewayProperties = new GatewayProperties();
+		gatewayProperties.setDefaultFilters(defaultFilterDefinitions());
+
+		GatewayFilterContext gatewayFilterContext = new GatewayFilterContext(
+				gatewayProperties, new ConfigurationService(), gatewayFilterFactories);
+
+		Assert.assertThrows(
+				"Unable to find GatewayFilterFactory with name AddResponseHeader",
+				IllegalArgumentException.class, new ThrowingRunnable() {
+					@Override
+					public void run() throws Throwable {
+						gatewayFilterContext.getDefaultGatewayFilters();
+					}
+				});
+	}
+
+	private List<FilterDefinition> defaultFilterDefinitions() {
+		FilterDefinition removeResponseHeaderDefinition = new FilterDefinition();
+		removeResponseHeaderDefinition.setName("RemoveResponseHeader");
+
+		FilterDefinition addResponseHeaderDefinition = new FilterDefinition();
+		addResponseHeaderDefinition.setName("AddResponseHeader");
+
+		return Arrays.asList(removeResponseHeaderDefinition, addResponseHeaderDefinition);
+
+	}
+
+}


### PR DESCRIPTION
1、Why support disable default filters for route created by `RouteLocatorBuilder`？
In the previous version,we not support this feature,if default open this feature for Route defined by `RouteLocatorBuilder` this may be an incompatible change,so support a switch about this feature,client decide open or close.

suppose we have a Route like this:
~~~
@Bean
public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
	return builder.routes()
			.route("test_route", r -> r.path("/filter")
					.uri("http://localhost:5556"))
			.build();
}
~~~

default filter in yaml is:
~~~
spring:
  cloud:
    gateway:
      default-filters:
        - PrefixPath=/mypath
~~~

before open switch about default filter feature(default behavior), spring cloud gateway will forward request to `http://localhost:5556/filter`,this works well. when open switch spring cloud gateway will forward to`http://localhost:5556/mypath/filter` and get a NOT FOUND error.
