### PR TITLE
Fix PrematureCloseException by adding check for connection and channel before dispose

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
@@ -121,7 +121,8 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 
 	private void cleanup(ServerWebExchange exchange) {
 		Connection connection = exchange.getAttribute(CLIENT_RESPONSE_CONN_ATTR);
-		if (connection != null) {
+		if (connection != null && connection.channel().isActive()
+				&& !connection.isPersistent()) {
 			connection.dispose();
 		}
 	}


### PR DESCRIPTION
Add channel check before dispose which may cause reactor-netty PrematureCloseException.

Test case:
1、We are doing a perfomance test using Spring Cloud Gateway **v2.2.5.RELEASE**
2、The request is HTTP POST which body size is less than 1k Bytes
3、The backend service return a response 200 OK as a result

Bug description:
Exception appears in spring cloud gateway in **Very Small Probability** as below:
reactor.netty.http.client.PrematureCloseException: Connection has been closed BEFORE response, while sending request body

In nearly 500,000 http post request tests, there will be dozens of errors.

When applied this fix, retested with nearly 3, 000,000 requests, No error occurred.

Related issue:

SCG:
[Connection prematurely closed BEFORE response](https://github.com/spring-cloud/spring-cloud-gateway/issues/2046)

