### PR TITLE
logger interface which enables sleuth to plugin implementation 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,12 +138,10 @@
 				<groupId>io.spring.javaformat</groupId>
 				<artifactId>spring-javaformat-maven-plugin</artifactId>
 			</plugin>
-<!--
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
--->
 		</plugins>
 	</build>
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -26,8 +26,10 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.logging.PassthroughLogger;
+import org.springframework.context.annotation.Scope;
 import reactor.core.publisher.Flux;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.WebsocketClientSpec;
@@ -240,8 +242,9 @@ public class GatewayAutoConfiguration {
 	}
 
 	@Bean
-	public FilteringWebHandler filteringWebHandler(List<GlobalFilter> globalFilters, AdaptableLogger adaptableLogger) {
-		return new FilteringWebHandler(globalFilters, adaptableLogger);
+	public FilteringWebHandler filteringWebHandler(List<GlobalFilter> globalFilters,
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new FilteringWebHandler(globalFilters, adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -252,9 +255,9 @@ public class GatewayAutoConfiguration {
 	@Bean
 	public RoutePredicateHandlerMapping routePredicateHandlerMapping(FilteringWebHandler webHandler,
 			RouteLocator routeLocator, GlobalCorsProperties globalCorsProperties, Environment environment,
-			AdaptableLogger adaptableLogger) {
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		return new RoutePredicateHandlerMapping(webHandler, routeLocator, globalCorsProperties, environment,
-				adaptableLogger);
+				adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -298,21 +301,23 @@ public class GatewayAutoConfiguration {
 
 	@Bean
 	@ConditionalOnEnabledGlobalFilter
-	public RemoveCachedBodyFilter removeCachedBodyFilter(AdaptableLogger adaptableLogger) {
-		return new RemoveCachedBodyFilter(adaptableLogger);
+	public RemoveCachedBodyFilter removeCachedBodyFilter(
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new RemoveCachedBodyFilter(adaptableLoggerObjectProvider);
 	}
 
 	@Bean
 	@ConditionalOnEnabledGlobalFilter
-	public RouteToRequestUrlFilter routeToRequestUrlFilter(AdaptableLogger adaptableLogger) {
-		return new RouteToRequestUrlFilter(adaptableLogger);
+	public RouteToRequestUrlFilter routeToRequestUrlFilter(
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new RouteToRequestUrlFilter(adaptableLoggerObjectProvider);
 	}
 
 	@Bean
 	@ConditionalOnEnabledGlobalFilter
 	public ForwardRoutingFilter forwardRoutingFilter(ObjectProvider<DispatcherHandler> dispatcherHandler,
-			AdaptableLogger adaptableLogger) {
-		return new ForwardRoutingFilter(dispatcherHandler, adaptableLogger);
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new ForwardRoutingFilter(dispatcherHandler, adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -331,8 +336,9 @@ public class GatewayAutoConfiguration {
 	@ConditionalOnEnabledGlobalFilter
 	public WebsocketRoutingFilter websocketRoutingFilter(WebSocketClient webSocketClient,
 			WebSocketService webSocketService, ObjectProvider<List<HttpHeadersFilter>> headersFilters,
-			AdaptableLogger adaptableLogger) {
-		return new WebsocketRoutingFilter(webSocketClient, webSocketService, headersFilters, adaptableLogger);
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new WebsocketRoutingFilter(webSocketClient, webSocketService, headersFilters,
+				adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -388,8 +394,9 @@ public class GatewayAutoConfiguration {
 
 	@Bean
 	@ConditionalOnEnabledPredicate
-	public PathRoutePredicateFactory pathRoutePredicateFactory(AdaptableLogger adaptableLogger) {
-		return new PathRoutePredicateFactory(adaptableLogger);
+	public PathRoutePredicateFactory pathRoutePredicateFactory(
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new PathRoutePredicateFactory(adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -401,21 +408,23 @@ public class GatewayAutoConfiguration {
 	@Bean
 	@ConditionalOnEnabledPredicate
 	public ReadBodyRoutePredicateFactory readBodyPredicateFactory(ServerCodecConfigurer codecConfigurer,
-			AdaptableLogger adaptableLogger) {
-		return new ReadBodyRoutePredicateFactory(codecConfigurer.getReaders(), adaptableLogger);
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new ReadBodyRoutePredicateFactory(codecConfigurer.getReaders(), adaptableLoggerObjectProvider);
 	}
 
 	@Bean
 	@ConditionalOnEnabledPredicate
-	public RemoteAddrRoutePredicateFactory remoteAddrRoutePredicateFactory(AdaptableLogger adaptableLogger) {
-		return new RemoteAddrRoutePredicateFactory(adaptableLogger);
+	public RemoteAddrRoutePredicateFactory remoteAddrRoutePredicateFactory(
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new RemoteAddrRoutePredicateFactory(adaptableLoggerObjectProvider);
 	}
 
 	@Bean
 	@DependsOn("weightCalculatorWebFilter")
 	@ConditionalOnEnabledPredicate
-	public WeightRoutePredicateFactory weightRoutePredicateFactory(AdaptableLogger adaptableLogger) {
-		return new WeightRoutePredicateFactory(adaptableLogger);
+	public WeightRoutePredicateFactory weightRoutePredicateFactory(
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new WeightRoutePredicateFactory(adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -473,8 +482,9 @@ public class GatewayAutoConfiguration {
 
 	@Bean
 	@ConditionalOnEnabledFilter
-	public PrefixPathGatewayFilterFactory prefixPathGatewayFilterFactory(AdaptableLogger adaptableLogger) {
-		return new PrefixPathGatewayFilterFactory(adaptableLogger);
+	public PrefixPathGatewayFilterFactory prefixPathGatewayFilterFactory(
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new PrefixPathGatewayFilterFactory(adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -531,8 +541,9 @@ public class GatewayAutoConfiguration {
 
 	@Bean
 	@ConditionalOnEnabledFilter
-	public RetryGatewayFilterFactory retryGatewayFilterFactory(AdaptableLogger adaptableLogger) {
-		return new RetryGatewayFilterFactory(adaptableLogger);
+	public RetryGatewayFilterFactory retryGatewayFilterFactory(
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new RetryGatewayFilterFactory(adaptableLoggerObjectProvider);
 	}
 
 	@Bean
@@ -616,6 +627,13 @@ public class GatewayAutoConfiguration {
 	@Bean
 	public GzipMessageBodyResolver gzipMessageBodyResolver() {
 		return new GzipMessageBodyResolver();
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+	public AdaptableLogger adaptableLogger(Log log) {
+		return new PassthroughLogger(log);
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -765,15 +783,15 @@ public class GatewayAutoConfiguration {
 		@ConditionalOnEnabledGlobalFilter
 		public NettyRoutingFilter routingFilter(HttpClient httpClient,
 				ObjectProvider<List<HttpHeadersFilter>> headersFilters, HttpClientProperties properties,
-				AdaptableLogger adaptableLogger) {
-			return new NettyRoutingFilter(httpClient, headersFilters, properties, adaptableLogger);
+				ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+			return new NettyRoutingFilter(httpClient, headersFilters, properties, adaptableLoggerObjectProvider);
 		}
 
 		@Bean
 		@ConditionalOnEnabledGlobalFilter(NettyRoutingFilter.class)
 		public NettyWriteResponseFilter nettyWriteResponseFilter(GatewayProperties properties,
-				AdaptableLogger adaptableLogger) {
-			return new NettyWriteResponseFilter(properties.getStreamingMediaTypes(), adaptableLogger);
+				ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+			return new NettyWriteResponseFilter(properties.getStreamingMediaTypes(), adaptableLoggerObjectProvider);
 		}
 
 		@Bean
@@ -800,12 +818,6 @@ public class GatewayAutoConfiguration {
 			map.from(websocket::isProxyPing).to(builder::handlePing);
 
 			return new ReactorNettyRequestUpgradeStrategy(builder);
-		}
-
-		@Bean
-		@ConditionalOnMissingBean
-		public AdaptableLogger adaptableLogger() {
-			return new PassthroughLogger();
 		}
 
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import io.micrometer.core.instrument.MeterRegistry;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -69,8 +70,9 @@ public class GatewayMetricsAutoConfiguration {
 	// encompass more than just the filter
 	public GatewayMetricsFilter gatewayMetricFilter(MeterRegistry meterRegistry,
 			List<GatewayTagsProvider> tagsProviders, GatewayMetricsProperties properties,
-			AdaptableLogger adaptableLogger) {
-		return new GatewayMetricsFilter(meterRegistry, tagsProviders, properties.getPrefix(), adaptableLogger);
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new GatewayMetricsFilter(meterRegistry, tagsProviders, properties.getPrefix(),
+				adaptableLoggerObjectProvider);
 	}
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.gateway.filter.GatewayMetricsFilter;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.support.tagsprovider.GatewayHttpTagsProvider;
 import org.springframework.cloud.gateway.support.tagsprovider.GatewayRouteTagsProvider;
 import org.springframework.cloud.gateway.support.tagsprovider.GatewayTagsProvider;
@@ -67,8 +68,9 @@ public class GatewayMetricsAutoConfiguration {
 	// don't use @ConditionalOnEnabledGlobalFilter as the above property may
 	// encompass more than just the filter
 	public GatewayMetricsFilter gatewayMetricFilter(MeterRegistry meterRegistry,
-			List<GatewayTagsProvider> tagsProviders, GatewayMetricsProperties properties) {
-		return new GatewayMetricsFilter(meterRegistry, tagsProviders, properties.getPrefix());
+			List<GatewayTagsProvider> tagsProviders, GatewayMetricsProperties properties,
+			AdaptableLogger adaptableLogger) {
+		return new GatewayMetricsFilter(meterRegistry, tagsProviders, properties.getPrefix(), adaptableLogger);
 	}
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayReactiveLoadBalancerClientAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayReactiveLoadBalancerClientAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancerProperties;
 import org.springframework.cloud.client.loadbalancer.reactive.ReactiveLoadBalancer;
 import org.springframework.cloud.gateway.config.conditional.ConditionalOnEnabledGlobalFilter;
 import org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.loadbalancer.config.LoadBalancerAutoConfiguration;
 import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 import org.springframework.context.annotation.Bean;
@@ -48,8 +49,9 @@ public class GatewayReactiveLoadBalancerClientAutoConfiguration {
 	@ConditionalOnMissingBean(ReactiveLoadBalancerClientFilter.class)
 	@ConditionalOnEnabledGlobalFilter
 	public ReactiveLoadBalancerClientFilter gatewayLoadBalancerClientFilter(LoadBalancerClientFactory clientFactory,
-			GatewayLoadBalancerProperties properties, LoadBalancerProperties loadBalancerProperties) {
-		return new ReactiveLoadBalancerClientFilter(clientFactory, properties, loadBalancerProperties);
+			GatewayLoadBalancerProperties properties, LoadBalancerProperties loadBalancerProperties,
+			AdaptableLogger adaptableLogger) {
+		return new ReactiveLoadBalancerClientFilter(clientFactory, properties, loadBalancerProperties, adaptableLogger);
 	}
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayReactiveLoadBalancerClientAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayReactiveLoadBalancerClientAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.config;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -50,8 +51,9 @@ public class GatewayReactiveLoadBalancerClientAutoConfiguration {
 	@ConditionalOnEnabledGlobalFilter
 	public ReactiveLoadBalancerClientFilter gatewayLoadBalancerClientFilter(LoadBalancerClientFactory clientFactory,
 			GatewayLoadBalancerProperties properties, LoadBalancerProperties loadBalancerProperties,
-			AdaptableLogger adaptableLogger) {
-		return new ReactiveLoadBalancerClientFilter(clientFactory, properties, loadBalancerProperties, adaptableLogger);
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		return new ReactiveLoadBalancerClientFilter(clientFactory, properties, loadBalancerProperties,
+				adaptableLoggerObjectProvider);
 	}
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
@@ -71,7 +71,7 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 		}
 
 		// TODO: translate url?
-		adaptableLogger.traceLog(log, exchange, "Forwarding to URI: " + requestUrl);
+		adaptableLogger.trace(log, exchange, "Forwarding to URI: " + requestUrl);
 
 		return this.getDispatcherHandler().handle(exchange);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
@@ -20,6 +20,7 @@ import java.net.URI;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.ObjectProvider;
@@ -36,11 +37,15 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 
 	private final ObjectProvider<DispatcherHandler> dispatcherHandlerProvider;
 
+	private final AdaptableLogger adaptableLogger;
+
 	// do not use this dispatcherHandler directly, use getDispatcherHandler() instead.
 	private volatile DispatcherHandler dispatcherHandler;
 
-	public ForwardRoutingFilter(ObjectProvider<DispatcherHandler> dispatcherHandlerProvider) {
+	public ForwardRoutingFilter(ObjectProvider<DispatcherHandler> dispatcherHandlerProvider,
+			AdaptableLogger adaptableLogger) {
 		this.dispatcherHandlerProvider = dispatcherHandlerProvider;
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	private DispatcherHandler getDispatcherHandler() {
@@ -66,10 +71,7 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 		}
 
 		// TODO: translate url?
-
-		if (log.isTraceEnabled()) {
-			log.trace("Forwarding to URI: " + requestUrl);
-		}
+		adaptableLogger.traceLog(log, exchange, "Forwarding to URI: " + requestUrl);
 
 		return this.getDispatcherHandler().handle(exchange);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
@@ -37,15 +37,15 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 
 	private final ObjectProvider<DispatcherHandler> dispatcherHandlerProvider;
 
-	private final AdaptableLogger adaptableLogger;
+	private AdaptableLogger adaptableLogger;
 
 	// do not use this dispatcherHandler directly, use getDispatcherHandler() instead.
 	private volatile DispatcherHandler dispatcherHandler;
 
 	public ForwardRoutingFilter(ObjectProvider<DispatcherHandler> dispatcherHandlerProvider,
-			AdaptableLogger adaptableLogger) {
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		this.dispatcherHandlerProvider = dispatcherHandlerProvider;
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	private DispatcherHandler getDispatcherHandler() {
@@ -71,7 +71,7 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 		}
 
 		// TODO: translate url?
-		adaptableLogger.trace(log, exchange, "Forwarding to URI: " + requestUrl);
+		adaptableLogger.trace(exchange, "Forwarding to URI: " + requestUrl);
 
 		return this.getDispatcherHandler().handle(exchange);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilter.java
@@ -97,7 +97,7 @@ public class GatewayMetricsFilter implements GlobalFilter, Ordered {
 	private void endTimerInner(ServerWebExchange exchange, Sample sample) {
 		Tags tags = compositeTagsProvider.apply(exchange);
 
-		adaptableLogger.traceLog(log, exchange, metricsPrefix + ".requests tags: " + tags);
+		adaptableLogger.trace(log, exchange, metricsPrefix + ".requests tags: " + tags);
 		sample.stop(meterRegistry.timer(metricsPrefix + ".requests", tags));
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -86,11 +86,11 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 	private final AdaptableLogger adaptableLogger;
 
 	public NettyRoutingFilter(HttpClient httpClient, ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider,
-			HttpClientProperties properties, AdaptableLogger adaptableLogger) {
+			HttpClientProperties properties, ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		this.httpClient = httpClient;
 		this.headersFiltersProvider = headersFiltersProvider;
 		this.properties = properties;
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	public List<HttpHeadersFilter> getHeadersFilters() {
@@ -139,7 +139,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 			}
 		}).request(method).uri(url).send((req, nettyOutbound) -> {
 			if (log.isTraceEnabled()) {
-				nettyOutbound.withConnection(connection -> adaptableLogger.trace(log, exchange, "outbound route: "
+				nettyOutbound.withConnection(connection -> adaptableLogger.trace(exchange, "outbound route: "
 						+ connection.channel().id().asShortText() + ", inbound: " + exchange.getLogPrefix()));
 			}
 			return nettyOutbound.send(request.getBody().map(this::getByteBuf));

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -139,7 +139,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 			}
 		}).request(method).uri(url).send((req, nettyOutbound) -> {
 			if (log.isTraceEnabled()) {
-				nettyOutbound.withConnection(connection -> adaptableLogger.traceLog(log, exchange, "outbound route: "
+				nettyOutbound.withConnection(connection -> adaptableLogger.trace(log, exchange, "outbound route: "
 						+ connection.channel().id().asShortText() + ", inbound: " + exchange.getLogPrefix()));
 			}
 			return nettyOutbound.send(request.getBody().map(this::getByteBuf));

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
@@ -82,11 +83,14 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 	// do not use this headersFilters directly, use getHeadersFilters() instead.
 	private volatile List<HttpHeadersFilter> headersFilters;
 
+	private final AdaptableLogger adaptableLogger;
+
 	public NettyRoutingFilter(HttpClient httpClient, ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider,
-			HttpClientProperties properties) {
+			HttpClientProperties properties, AdaptableLogger adaptableLogger) {
 		this.httpClient = httpClient;
 		this.headersFiltersProvider = headersFiltersProvider;
 		this.properties = properties;
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	public List<HttpHeadersFilter> getHeadersFilters() {
@@ -135,7 +139,7 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 			}
 		}).request(method).uri(url).send((req, nettyOutbound) -> {
 			if (log.isTraceEnabled()) {
-				nettyOutbound.withConnection(connection -> log.trace("outbound route: "
+				nettyOutbound.withConnection(connection -> adaptableLogger.traceLog(log, exchange, "outbound route: "
 						+ connection.channel().id().asShortText() + ", inbound: " + exchange.getLogPrefix()));
 			}
 			return nettyOutbound.send(request.getBody().map(this::getByteBuf));
@@ -232,7 +236,6 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 	 * timeout configuration.
 	 * @param route the current route.
 	 * @param exchange the current ServerWebExchange.
-	 * @param chain the current GatewayFilterChain.
 	 * @return
 	 */
 	protected HttpClient getHttpClient(Route route, ServerWebExchange exchange) {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
@@ -77,7 +77,7 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 					if (connection == null) {
 						return Mono.empty();
 					}
-					adaptableLogger.traceLog(log, exchange, "NettyWriteResponseFilter start inbound: "
+					adaptableLogger.trace(log, exchange, "NettyWriteResponseFilter start inbound: "
 							+ connection.channel().id().asShortText() + ", outbound: "
 							+ exchange.getLogPrefix());
 					ServerHttpResponse response = exchange.getResponse();
@@ -94,7 +94,7 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 						contentType = response.getHeaders().getContentType();
 					}
 					catch (Exception e) {
-						adaptableLogger.traceLog(log, exchange, "invalid media type", e);
+						adaptableLogger.trace(log, exchange, "invalid media type", e);
 					}
 					return (isStreamingMediaType(contentType)
 							? response.writeAndFlushWith(body.map(Flux::just))

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.client.ServiceInstance;
@@ -74,11 +75,15 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 
 	private final LoadBalancerProperties loadBalancerProperties;
 
+	private final AdaptableLogger adaptableLogger;
+
 	public ReactiveLoadBalancerClientFilter(LoadBalancerClientFactory clientFactory,
-			GatewayLoadBalancerProperties properties, LoadBalancerProperties loadBalancerProperties) {
+			GatewayLoadBalancerProperties properties, LoadBalancerProperties loadBalancerProperties,
+			AdaptableLogger adaptableLogger) {
 		this.clientFactory = clientFactory;
 		this.properties = properties;
 		this.loadBalancerProperties = loadBalancerProperties;
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	@Override
@@ -96,9 +101,8 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 		// preserve the original url
 		addOriginalRequestUrl(exchange, url);
 
-		if (log.isTraceEnabled()) {
-			log.trace(ReactiveLoadBalancerClientFilter.class.getSimpleName() + " url before: " + url);
-		}
+		adaptableLogger.traceLog(log, exchange,
+				ReactiveLoadBalancerClientFilter.class.getSimpleName() + " url before: " + url);
 
 		URI requestUri = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
 		String serviceId = requestUri.getHost();
@@ -131,9 +135,7 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 
 			URI requestUrl = reconstructURI(serviceInstance, uri);
 
-			if (log.isTraceEnabled()) {
-				log.trace("LoadBalancerClientFilter url chosen: " + requestUrl);
-			}
+			adaptableLogger.traceLog(log, exchange, "LoadBalancerClientFilter url chosen: " + requestUrl);
 			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
 			exchange.getAttributes().put(GATEWAY_LOADBALANCER_RESPONSE_ATTR, response);
 			supportedLifecycleProcessors.forEach(lifecycle -> lifecycle.onStartRequest(lbRequest, response));

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
@@ -79,11 +80,11 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 
 	public ReactiveLoadBalancerClientFilter(LoadBalancerClientFactory clientFactory,
 			GatewayLoadBalancerProperties properties, LoadBalancerProperties loadBalancerProperties,
-			AdaptableLogger adaptableLogger) {
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		this.clientFactory = clientFactory;
 		this.properties = properties;
 		this.loadBalancerProperties = loadBalancerProperties;
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	@Override
@@ -101,8 +102,7 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 		// preserve the original url
 		addOriginalRequestUrl(exchange, url);
 
-		adaptableLogger.trace(log, exchange,
-				ReactiveLoadBalancerClientFilter.class.getSimpleName() + " url before: " + url);
+		adaptableLogger.trace(exchange, ReactiveLoadBalancerClientFilter.class.getSimpleName() + " url before: " + url);
 
 		URI requestUri = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
 		String serviceId = requestUri.getHost();
@@ -135,7 +135,7 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 
 			URI requestUrl = reconstructURI(serviceInstance, uri);
 
-			adaptableLogger.trace(log, exchange, "LoadBalancerClientFilter url chosen: " + requestUrl);
+			adaptableLogger.trace(exchange, "LoadBalancerClientFilter url chosen: " + requestUrl);
 			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
 			exchange.getAttributes().put(GATEWAY_LOADBALANCER_RESPONSE_ATTR, response);
 			supportedLifecycleProcessors.forEach(lifecycle -> lifecycle.onStartRequest(lbRequest, response));

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilter.java
@@ -101,7 +101,7 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 		// preserve the original url
 		addOriginalRequestUrl(exchange, url);
 
-		adaptableLogger.traceLog(log, exchange,
+		adaptableLogger.trace(log, exchange,
 				ReactiveLoadBalancerClientFilter.class.getSimpleName() + " url before: " + url);
 
 		URI requestUri = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
@@ -135,7 +135,7 @@ public class ReactiveLoadBalancerClientFilter implements GlobalFilter, Ordered {
 
 			URI requestUrl = reconstructURI(serviceInstance, uri);
 
-			adaptableLogger.traceLog(log, exchange, "LoadBalancerClientFilter url chosen: " + requestUrl);
+			adaptableLogger.trace(log, exchange, "LoadBalancerClientFilter url chosen: " + requestUrl);
 			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
 			exchange.getAttributes().put(GATEWAY_LOADBALANCER_RESPONSE_ATTR, response);
 			supportedLifecycleProcessors.forEach(lifecycle -> lifecycle.onStartRequest(lbRequest, response));

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.filter;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
@@ -33,8 +34,8 @@ public class RemoveCachedBodyFilter implements GlobalFilter, Ordered {
 
 	private final AdaptableLogger adaptableLogger;
 
-	public RemoveCachedBodyFilter(AdaptableLogger adaptableLogger) {
-		this.adaptableLogger = adaptableLogger;
+	public RemoveCachedBodyFilter(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	@Override
@@ -44,7 +45,7 @@ public class RemoveCachedBodyFilter implements GlobalFilter, Ordered {
 			if (attribute != null && attribute instanceof PooledDataBuffer) {
 				PooledDataBuffer dataBuffer = (PooledDataBuffer) attribute;
 				if (dataBuffer.isAllocated()) {
-					adaptableLogger.trace(log, exchange, "releasing cached body in exchange attribute");
+					adaptableLogger.trace(exchange, "releasing cached body in exchange attribute");
 					dataBuffer.release();
 				}
 			}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
@@ -44,7 +44,7 @@ public class RemoveCachedBodyFilter implements GlobalFilter, Ordered {
 			if (attribute != null && attribute instanceof PooledDataBuffer) {
 				PooledDataBuffer dataBuffer = (PooledDataBuffer) attribute;
 				if (dataBuffer.isAllocated()) {
-					adaptableLogger.traceLog(log, exchange, "releasing cached body in exchange attribute");
+					adaptableLogger.trace(log, exchange, "releasing cached body in exchange attribute");
 					dataBuffer.release();
 				}
 			}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.filter;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.Ordered;
@@ -30,6 +31,12 @@ public class RemoveCachedBodyFilter implements GlobalFilter, Ordered {
 
 	private static final Log log = LogFactory.getLog(RemoveCachedBodyFilter.class);
 
+	private final AdaptableLogger adaptableLogger;
+
+	public RemoveCachedBodyFilter(AdaptableLogger adaptableLogger) {
+		this.adaptableLogger = adaptableLogger;
+	}
+
 	@Override
 	public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 		return chain.filter(exchange).doFinally(s -> {
@@ -37,9 +44,7 @@ public class RemoveCachedBodyFilter implements GlobalFilter, Ordered {
 			if (attribute != null && attribute instanceof PooledDataBuffer) {
 				PooledDataBuffer dataBuffer = (PooledDataBuffer) attribute;
 				if (dataBuffer.isAllocated()) {
-					if (log.isTraceEnabled()) {
-						log.trace("releasing cached body in exchange attribute");
-					}
+					adaptableLogger.traceLog(log, exchange, "releasing cached body in exchange attribute");
 					dataBuffer.release();
 				}
 			}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
@@ -51,8 +52,8 @@ public class RouteToRequestUrlFilter implements GlobalFilter, Ordered {
 
 	private final AdaptableLogger adaptableLogger;
 
-	public RouteToRequestUrlFilter(AdaptableLogger adaptableLogger) {
-		this.adaptableLogger = adaptableLogger;
+	public RouteToRequestUrlFilter(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	/* for testing */
@@ -72,7 +73,7 @@ public class RouteToRequestUrlFilter implements GlobalFilter, Ordered {
 		if (route == null) {
 			return chain.filter(exchange);
 		}
-		adaptableLogger.trace(log, exchange, "RouteToRequestUrlFilter start");
+		adaptableLogger.trace(exchange, "RouteToRequestUrlFilter start");
 		URI uri = exchange.getRequest().getURI();
 		boolean encoded = containsEncodedParts(uri);
 		URI routeUri = route.getUri();

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
@@ -72,7 +72,7 @@ public class RouteToRequestUrlFilter implements GlobalFilter, Ordered {
 		if (route == null) {
 			return chain.filter(exchange);
 		}
-		adaptableLogger.traceLog(log, exchange, "RouteToRequestUrlFilter start");
+		adaptableLogger.trace(log, exchange, "RouteToRequestUrlFilter start");
 		URI uri = exchange.getRequest().getURI();
 		boolean encoded = containsEncodedParts(uri);
 		URI routeUri = route.getUri();

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilter.java
@@ -21,6 +21,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.route.Route;
@@ -48,6 +49,12 @@ public class RouteToRequestUrlFilter implements GlobalFilter, Ordered {
 	private static final String SCHEME_REGEX = "[a-zA-Z]([a-zA-Z]|\\d|\\+|\\.|-)*:.*";
 	static final Pattern schemePattern = Pattern.compile(SCHEME_REGEX);
 
+	private final AdaptableLogger adaptableLogger;
+
+	public RouteToRequestUrlFilter(AdaptableLogger adaptableLogger) {
+		this.adaptableLogger = adaptableLogger;
+	}
+
 	/* for testing */
 	static boolean hasAnotherScheme(URI uri) {
 		return schemePattern.matcher(uri.getSchemeSpecificPart()).matches() && uri.getHost() == null
@@ -65,7 +72,7 @@ public class RouteToRequestUrlFilter implements GlobalFilter, Ordered {
 		if (route == null) {
 			return chain.filter(exchange);
 		}
-		log.trace("RouteToRequestUrlFilter start");
+		adaptableLogger.traceLog(log, exchange, "RouteToRequestUrlFilter start");
 		URI uri = exchange.getRequest().getURI();
 		boolean encoded = containsEncodedParts(uri);
 		URI routeUri = route.getUri();

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
@@ -73,11 +73,12 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 	private final AdaptableLogger adaptableLogger;
 
 	public WebsocketRoutingFilter(WebSocketClient webSocketClient, WebSocketService webSocketService,
-			ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider, AdaptableLogger adaptableLogger) {
+			ObjectProvider<List<HttpHeadersFilter>> headersFiltersProvider,
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		this.webSocketClient = webSocketClient;
 		this.webSocketService = webSocketService;
 		this.headersFiltersProvider = headersFiltersProvider;
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	/* for testing */
@@ -157,7 +158,7 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 			boolean encoded = containsEncodedParts(requestUrl);
 			URI wsRequestUrl = UriComponentsBuilder.fromUri(requestUrl).scheme(wsScheme).build(encoded).toUri();
 			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, wsRequestUrl);
-			adaptableLogger.trace(log, exchange, "changeSchemeTo:[" + wsRequestUrl + "]");
+			adaptableLogger.trace(exchange, "changeSchemeTo:[" + wsRequestUrl + "]");
 		}
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
@@ -157,7 +157,7 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 			boolean encoded = containsEncodedParts(requestUrl);
 			URI wsRequestUrl = UriComponentsBuilder.fromUri(requestUrl).scheme(wsScheme).build(encoded).toUri();
 			exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, wsRequestUrl);
-			adaptableLogger.traceLog(log, exchange, "changeSchemeTo:[" + wsRequestUrl + "]");
+			adaptableLogger.trace(log, exchange, "changeSchemeTo:[" + wsRequestUrl + "]");
 		}
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
@@ -49,9 +50,9 @@ public class PrefixPathGatewayFilterFactory
 
 	private final AdaptableLogger adaptableLogger;
 
-	public PrefixPathGatewayFilterFactory(AdaptableLogger adaptableLogger) {
+	public PrefixPathGatewayFilterFactory(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		super(Config.class);
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	@Override
@@ -78,7 +79,7 @@ public class PrefixPathGatewayFilterFactory
 
 				exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, request.getURI());
 
-				adaptableLogger.trace(log, exchange, "Prefixed URI with: " + config.prefix + " -> " + request.getURI());
+				adaptableLogger.trace(exchange, "Prefixed URI with: " + config.prefix + " -> " + request.getURI());
 
 				return chain.filter(exchange.mutate().request(request).build());
 			}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -46,8 +47,11 @@ public class PrefixPathGatewayFilterFactory
 
 	private static final Log log = LogFactory.getLog(PrefixPathGatewayFilterFactory.class);
 
-	public PrefixPathGatewayFilterFactory() {
+	private final AdaptableLogger adaptableLogger;
+
+	public PrefixPathGatewayFilterFactory(AdaptableLogger adaptableLogger) {
 		super(Config.class);
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	@Override
@@ -74,9 +78,8 @@ public class PrefixPathGatewayFilterFactory
 
 				exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, request.getURI());
 
-				if (log.isTraceEnabled()) {
-					log.trace("Prefixed URI with: " + config.prefix + " -> " + request.getURI());
-				}
+				adaptableLogger.traceLog(log, exchange,
+						"Prefixed URI with: " + config.prefix + " -> " + request.getURI());
 
 				return chain.filter(exchange.mutate().request(request).build());
 			}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
@@ -78,8 +78,7 @@ public class PrefixPathGatewayFilterFactory
 
 				exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, request.getURI());
 
-				adaptableLogger.traceLog(log, exchange,
-						"Prefixed URI with: " + config.prefix + " -> " + request.getURI());
+				adaptableLogger.trace(log, exchange, "Prefixed URI with: " + config.prefix + " -> " + request.getURI());
 
 				return chain.filter(exchange.mutate().request(request).build());
 			}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -258,7 +258,7 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 				args[i] = a.get();
 				++i;
 			}
-			adaptableLogger.traceLog(log, exchange, String.format(message, args));
+			adaptableLogger.trace(log, exchange, String.format(message, args));
 		}
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -27,6 +27,7 @@ import java.util.function.Supplier;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 import reactor.netty.Connection;
@@ -61,9 +62,9 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 
 	private AdaptableLogger adaptableLogger;
 
-	public RetryGatewayFilterFactory(AdaptableLogger adaptableLogger) {
+	public RetryGatewayFilterFactory(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		super(RetryConfig.class);
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	private static <T> List<T> toList(T... items) {
@@ -258,7 +259,7 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 				args[i] = a.get();
 				++i;
 			}
-			adaptableLogger.trace(log, exchange, String.format(message, args));
+			adaptableLogger.trace(exchange, String.format(message, args));
 		}
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/FilteringWebHandler.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/FilteringWebHandler.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
@@ -54,9 +55,10 @@ public class FilteringWebHandler implements WebHandler {
 
 	private final AdaptableLogger adaptableLogger;
 
-	public FilteringWebHandler(List<GlobalFilter> globalFilters, AdaptableLogger adaptableLogger) {
+	public FilteringWebHandler(List<GlobalFilter> globalFilters,
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		this.globalFilters = loadFilters(globalFilters);
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(logger);
 	}
 
 	private static List<GatewayFilter> loadFilters(List<GlobalFilter> filters) {
@@ -84,7 +86,7 @@ public class FilteringWebHandler implements WebHandler {
 		combined.addAll(gatewayFilters);
 		// TODO: needed or cached?
 		AnnotationAwareOrderComparator.sort(combined);
-		adaptableLogger.debug(logger, exchange, "Sorted gatewayFilterFactories: " + combined);
+		adaptableLogger.debug(exchange, "Sorted gatewayFilterFactories: " + combined);
 
 		return new DefaultGatewayFilterChain(combined).filter(exchange);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/FilteringWebHandler.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/FilteringWebHandler.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -51,8 +52,11 @@ public class FilteringWebHandler implements WebHandler {
 
 	private final List<GatewayFilter> globalFilters;
 
-	public FilteringWebHandler(List<GlobalFilter> globalFilters) {
+	private final AdaptableLogger adaptableLogger;
+
+	public FilteringWebHandler(List<GlobalFilter> globalFilters, AdaptableLogger adaptableLogger) {
 		this.globalFilters = loadFilters(globalFilters);
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	private static List<GatewayFilter> loadFilters(List<GlobalFilter> filters) {
@@ -80,10 +84,7 @@ public class FilteringWebHandler implements WebHandler {
 		combined.addAll(gatewayFilters);
 		// TODO: needed or cached?
 		AnnotationAwareOrderComparator.sort(combined);
-
-		if (logger.isDebugEnabled()) {
-			logger.debug("Sorted gatewayFilterFactories: " + combined);
-		}
+		adaptableLogger.debugLog(logger, exchange, "Sorted gatewayFilterFactories: " + combined);
 
 		return new DefaultGatewayFilterChain(combined).filter(exchange);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/FilteringWebHandler.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/FilteringWebHandler.java
@@ -84,7 +84,7 @@ public class FilteringWebHandler implements WebHandler {
 		combined.addAll(gatewayFilters);
 		// TODO: needed or cached?
 		AnnotationAwareOrderComparator.sort(combined);
-		adaptableLogger.debugLog(logger, exchange, "Sorted gatewayFilterFactories: " + combined);
+		adaptableLogger.debug(logger, exchange, "Sorted gatewayFilterFactories: " + combined);
 
 		return new DefaultGatewayFilterChain(combined).filter(exchange);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.handler;
 
 import java.util.function.Function;
 
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.config.GlobalCorsProperties;
@@ -48,13 +49,16 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 
 	private final ManagementPortType managementPortType;
 
+	private final AdaptableLogger adaptableLogger;
+
 	public RoutePredicateHandlerMapping(FilteringWebHandler webHandler, RouteLocator routeLocator,
-			GlobalCorsProperties globalCorsProperties, Environment environment) {
+			GlobalCorsProperties globalCorsProperties, Environment environment, AdaptableLogger adaptableLogger) {
 		this.webHandler = webHandler;
 		this.routeLocator = routeLocator;
 
 		this.managementPort = getPortProperty(environment, "management.server.");
 		this.managementPortType = getManagementPortType(environment);
+		this.adaptableLogger = adaptableLogger;
 		setOrder(1);
 		setCorsConfigurations(globalCorsProperties.getCorsConfigurations());
 	}
@@ -85,17 +89,14 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 				// .log("route-predicate-handler-mapping", Level.FINER) //name this
 				.flatMap((Function<Route, Mono<?>>) r -> {
 					exchange.getAttributes().remove(GATEWAY_PREDICATE_ROUTE_ATTR);
-					if (logger.isDebugEnabled()) {
-						logger.debug("Mapping [" + getExchangeDesc(exchange) + "] to " + r);
-					}
+					adaptableLogger.debugLog(logger, exchange, "Mapping [" + getExchangeDesc(exchange) + "] to " + r);
 
 					exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, r);
 					return Mono.just(webHandler);
 				}).switchIfEmpty(Mono.empty().then(Mono.fromRunnable(() -> {
 					exchange.getAttributes().remove(GATEWAY_PREDICATE_ROUTE_ATTR);
-					if (logger.isTraceEnabled()) {
-						logger.trace("No RouteDefinition found for [" + getExchangeDesc(exchange) + "]");
-					}
+					adaptableLogger.traceLog(logger, exchange,
+							"No RouteDefinition found for [" + getExchangeDesc(exchange) + "]");
 				})));
 	}
 
@@ -137,9 +138,7 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 				.next()
 				// TODO: error handling
 				.map(route -> {
-					if (logger.isDebugEnabled()) {
-						logger.debug("Route matched: " + route.getId());
-					}
+					adaptableLogger.debugLog(logger, exchange, "Route matched: " + route.getId());
 					validateRoute(route, exchange);
 					return route;
 				});

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -89,13 +89,13 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 				// .log("route-predicate-handler-mapping", Level.FINER) //name this
 				.flatMap((Function<Route, Mono<?>>) r -> {
 					exchange.getAttributes().remove(GATEWAY_PREDICATE_ROUTE_ATTR);
-					adaptableLogger.debugLog(logger, exchange, "Mapping [" + getExchangeDesc(exchange) + "] to " + r);
+					adaptableLogger.debug(logger, exchange, "Mapping [" + getExchangeDesc(exchange) + "] to " + r);
 
 					exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, r);
 					return Mono.just(webHandler);
 				}).switchIfEmpty(Mono.empty().then(Mono.fromRunnable(() -> {
 					exchange.getAttributes().remove(GATEWAY_PREDICATE_ROUTE_ATTR);
-					adaptableLogger.traceLog(logger, exchange,
+					adaptableLogger.trace(logger, exchange,
 							"No RouteDefinition found for [" + getExchangeDesc(exchange) + "]");
 				})));
 	}
@@ -138,7 +138,7 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 				.next()
 				// TODO: error handling
 				.map(route -> {
-					adaptableLogger.debugLog(logger, exchange, "Route matched: " + route.getId());
+					adaptableLogger.debug(logger, exchange, "Route matched: " + route.getId());
 					validateRoute(route, exchange);
 					return route;
 				});

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
@@ -62,7 +62,7 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 		if (log.isTraceEnabled()) {
 			String message = String.format("%s \"%s\" %s against value \"%s\"", prefix, desired,
 					match ? "matches" : "does not match", actual);
-			adaptableLogger.traceLog(log, exchange, message);
+			adaptableLogger.trace(log, exchange, message);
 		}
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
@@ -25,6 +25,7 @@ import java.util.function.Predicate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.http.server.PathContainer;
@@ -51,9 +52,9 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 
 	private final AdaptableLogger adaptableLogger;
 
-	public PathRoutePredicateFactory(AdaptableLogger adaptableLogger) {
+	public PathRoutePredicateFactory(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		super(Config.class);
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	private static void traceMatch(String prefix, Object desired, Object actual, boolean match,
@@ -62,7 +63,7 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 		if (log.isTraceEnabled()) {
 			String message = String.format("%s \"%s\" %s against value \"%s\"", prefix, desired,
 					match ? "matches" : "does not match", actual);
-			adaptableLogger.trace(log, exchange, message);
+			adaptableLogger.trace(exchange, message);
 		}
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
@@ -50,16 +51,17 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 
 	private final AdaptableLogger adaptableLogger;
 
-	public ReadBodyRoutePredicateFactory(AdaptableLogger adaptableLogger) {
+	public ReadBodyRoutePredicateFactory(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		super(Config.class);
 		this.messageReaders = HandlerStrategies.withDefaults().messageReaders();
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
-	public ReadBodyRoutePredicateFactory(List<HttpMessageReader<?>> messageReaders, AdaptableLogger adaptableLogger) {
+	public ReadBodyRoutePredicateFactory(List<HttpMessageReader<?>> messageReaders,
+			ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		super(Config.class);
 		this.messageReaders = messageReaders;
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	@Override
@@ -85,7 +87,7 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 						return Mono.just(test);
 					}
 					catch (ClassCastException e) {
-						adaptableLogger.debug(log, exchange, "Predicate test failed because class in predicate "
+						adaptableLogger.debug(exchange, "Predicate test failed because class in predicate "
 								+ "does not match the cached body object", e);
 					}
 					return Mono.just(false);

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
@@ -85,7 +85,7 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 						return Mono.just(test);
 					}
 					catch (ClassCastException e) {
-						adaptableLogger.debugLog(log, exchange, "Predicate test failed because class in predicate "
+						adaptableLogger.debug(log, exchange, "Predicate test failed because class in predicate "
 								+ "does not match the cached body object", e);
 					}
 					return Mono.just(false);

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
@@ -23,6 +23,7 @@ import java.util.function.Predicate;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.reactivestreams.Publisher;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.handler.AsyncPredicate;
@@ -47,14 +48,18 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 
 	private final List<HttpMessageReader<?>> messageReaders;
 
-	public ReadBodyRoutePredicateFactory() {
+	private final AdaptableLogger adaptableLogger;
+
+	public ReadBodyRoutePredicateFactory(AdaptableLogger adaptableLogger) {
 		super(Config.class);
 		this.messageReaders = HandlerStrategies.withDefaults().messageReaders();
+		this.adaptableLogger = adaptableLogger;
 	}
 
-	public ReadBodyRoutePredicateFactory(List<HttpMessageReader<?>> messageReaders) {
+	public ReadBodyRoutePredicateFactory(List<HttpMessageReader<?>> messageReaders, AdaptableLogger adaptableLogger) {
 		super(Config.class);
 		this.messageReaders = messageReaders;
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	@Override
@@ -80,10 +85,8 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 						return Mono.just(test);
 					}
 					catch (ClassCastException e) {
-						if (log.isDebugEnabled()) {
-							log.debug("Predicate test failed because class in predicate "
-									+ "does not match the cached body object", e);
-						}
+						adaptableLogger.debugLog(log, exchange, "Predicate test failed because class in predicate "
+								+ "does not match the cached body object", e);
 					}
 					return Mono.just(false);
 				}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
@@ -85,7 +85,7 @@ public class RemoteAddrRoutePredicateFactory
 					String host = exchange.getRequest().getURI().getHost();
 
 					if (log.isDebugEnabled() && !hostAddress.equals(host)) {
-						adaptableLogger.debugLog(log, exchange,
+						adaptableLogger.debug(log, exchange,
 								"Remote addresses didn't match " + hostAddress + " != " + host);
 					}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
@@ -31,6 +31,7 @@ import io.netty.handler.ipfilter.IpSubnetFilterRule;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.support.ipresolver.RemoteAddressResolver;
 import org.springframework.validation.annotation.Validated;
@@ -48,9 +49,9 @@ public class RemoteAddrRoutePredicateFactory
 
 	private final AdaptableLogger adaptableLogger;
 
-	public RemoteAddrRoutePredicateFactory(AdaptableLogger adaptableLogger) {
+	public RemoteAddrRoutePredicateFactory(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		super(Config.class);
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	@Override
@@ -85,8 +86,7 @@ public class RemoteAddrRoutePredicateFactory
 					String host = exchange.getRequest().getURI().getHost();
 
 					if (log.isDebugEnabled() && !hostAddress.equals(host)) {
-						adaptableLogger.debug(log, exchange,
-								"Remote addresses didn't match " + hostAddress + " != " + host);
+						adaptableLogger.debug(exchange, "Remote addresses didn't match " + hostAddress + " != " + host);
 					}
 
 					for (IpSubnetFilterRule source : sources) {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
@@ -31,6 +31,7 @@ import io.netty.handler.ipfilter.IpSubnetFilterRule;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.support.ipresolver.RemoteAddressResolver;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
@@ -45,8 +46,11 @@ public class RemoteAddrRoutePredicateFactory
 
 	private static final Log log = LogFactory.getLog(RemoteAddrRoutePredicateFactory.class);
 
-	public RemoteAddrRoutePredicateFactory() {
+	private final AdaptableLogger adaptableLogger;
+
+	public RemoteAddrRoutePredicateFactory(AdaptableLogger adaptableLogger) {
 		super(Config.class);
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	@Override
@@ -81,7 +85,8 @@ public class RemoteAddrRoutePredicateFactory
 					String host = exchange.getRequest().getURI().getHost();
 
 					if (log.isDebugEnabled() && !hostAddress.equals(host)) {
-						log.debug("Remote addresses didn't match " + hostAddress + " != " + host);
+						adaptableLogger.debugLog(log, exchange,
+								"Remote addresses didn't match " + hostAddress + " != " + host);
 					}
 
 					for (IpSubnetFilterRule source : sources) {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
@@ -16,20 +16,20 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.cloud.gateway.event.WeightDefinedEvent;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
+import org.springframework.cloud.gateway.support.WeightConfig;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.web.server.ServerWebExchange;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-import org.springframework.cloud.gateway.event.WeightDefinedEvent;
-import org.springframework.cloud.gateway.support.WeightConfig;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.context.ApplicationEventPublisherAware;
-import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_PREDICATE_ROUTE_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.WEIGHT_ATTR;
@@ -55,8 +55,11 @@ public class WeightRoutePredicateFactory extends AbstractRoutePredicateFactory<W
 
 	private ApplicationEventPublisher publisher;
 
-	public WeightRoutePredicateFactory() {
+	private AdaptableLogger adaptableLogger;
+
+	public WeightRoutePredicateFactory(AdaptableLogger adaptableLogger) {
 		super(WeightConfig.class);
+		this.adaptableLogger = adaptableLogger;
 	}
 
 	@Override
@@ -96,15 +99,14 @@ public class WeightRoutePredicateFactory extends AbstractRoutePredicateFactory<W
 				if (weights.containsKey(group)) {
 
 					String chosenRoute = weights.get(group);
-					if (log.isTraceEnabled()) {
-						log.trace("in group weight: " + group + ", current route: " + routeId + ", chosen route: "
-								+ chosenRoute);
-					}
+					adaptableLogger.traceLog(log, exchange, "in group weight: " + group + ", current route: " + routeId
+							+ "chosen route: " + chosenRoute);
 
 					return routeId.equals(chosenRoute);
 				}
-				else if (log.isTraceEnabled()) {
-					log.trace("no weights found for group: " + group + ", current route: " + routeId);
+				else {
+					adaptableLogger.traceLog(log, exchange,
+							"no weights found for group: " + group + ", current route: " + routeId);
 				}
 
 				return false;

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.handler.predicate;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.event.WeightDefinedEvent;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.support.WeightConfig;
@@ -57,9 +58,9 @@ public class WeightRoutePredicateFactory extends AbstractRoutePredicateFactory<W
 
 	private AdaptableLogger adaptableLogger;
 
-	public WeightRoutePredicateFactory(AdaptableLogger adaptableLogger) {
+	public WeightRoutePredicateFactory(ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider) {
 		super(WeightConfig.class);
-		this.adaptableLogger = adaptableLogger;
+		this.adaptableLogger = adaptableLoggerObjectProvider.getObject(log);
 	}
 
 	@Override
@@ -99,13 +100,13 @@ public class WeightRoutePredicateFactory extends AbstractRoutePredicateFactory<W
 				if (weights.containsKey(group)) {
 
 					String chosenRoute = weights.get(group);
-					adaptableLogger.trace(log, exchange, "in group weight: " + group + ", current route: " + routeId
+					adaptableLogger.trace(exchange, "in group weight: " + group + ", current route: " + routeId
 							+ "chosen route: " + chosenRoute);
 
 					return routeId.equals(chosenRoute);
 				}
 				else {
-					adaptableLogger.trace(log, exchange,
+					adaptableLogger.trace(exchange,
 							"no weights found for group: " + group + ", current route: " + routeId);
 				}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactory.java
@@ -99,13 +99,13 @@ public class WeightRoutePredicateFactory extends AbstractRoutePredicateFactory<W
 				if (weights.containsKey(group)) {
 
 					String chosenRoute = weights.get(group);
-					adaptableLogger.traceLog(log, exchange, "in group weight: " + group + ", current route: " + routeId
+					adaptableLogger.trace(log, exchange, "in group weight: " + group + ", current route: " + routeId
 							+ "chosen route: " + chosenRoute);
 
 					return routeId.equals(chosenRoute);
 				}
 				else {
-					adaptableLogger.traceLog(log, exchange,
+					adaptableLogger.trace(log, exchange,
 							"no weights found for group: " + group + ", current route: " + routeId);
 				}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
@@ -11,24 +11,24 @@ import org.springframework.web.server.ServerWebExchange;
  */
 public interface AdaptableLogger {
 
-	void traceLog(Log log, ServerWebExchange exchange, Object message);
+	void trace(Log log, ServerWebExchange exchange, Object message);
 
-	void traceLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void trace(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void debugLog(Log log, ServerWebExchange exchange, Object message);
+	void debug(Log log, ServerWebExchange exchange, Object message);
 
-	void debugLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void debug(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void infoLog(Log log, ServerWebExchange exchange, Object message);
+	void info(Log log, ServerWebExchange exchange, Object message);
 
-	void infoLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void info(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void warnLog(Log log, ServerWebExchange exchange, Object message);
+	void warn(Log log, ServerWebExchange exchange, Object message);
 
-	void warnLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void warn(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void errorLog(Log log, ServerWebExchange exchange, Object message);
+	void error(Log log, ServerWebExchange exchange, Object message);
 
-	void errorLog(Log log, ServerWebExchange exchange, Object message, Throwable t);
+	void error(Log log, ServerWebExchange exchange, Object message, Throwable t);
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.gateway.logging;
 
 import org.springframework.web.server.ServerWebExchange;

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
@@ -1,34 +1,31 @@
 package org.springframework.cloud.gateway.logging;
 
-import org.apache.commons.logging.Log;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
- * An abstraction over logging to all alternative implementations. For example, to
- * maintain proper trace context when using manual sleuth instrumentation the log call
- * needs to be wrapped inside a special WebFlux operator. Presently, it assumes apache
- * commons logging as the logging interface (dominant in Spring)
+ * An abstraction over logging. For example, to maintain proper trace context when using manual sleuth
+ * instrumentation the log call needs to be wrapped inside a special WebFlux operator.
  */
 public interface AdaptableLogger {
 
-	void trace(Log log, ServerWebExchange exchange, Object message);
+	void trace(ServerWebExchange exchange, Object message);
 
-	void trace(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void trace(ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void debug(Log log, ServerWebExchange exchange, Object message);
+	void debug(ServerWebExchange exchange, Object message);
 
-	void debug(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void debug(ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void info(Log log, ServerWebExchange exchange, Object message);
+	void info(ServerWebExchange exchange, Object message);
 
-	void info(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void info(ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void warn(Log log, ServerWebExchange exchange, Object message);
+	void warn(ServerWebExchange exchange, Object message);
 
-	void warn(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+	void warn(ServerWebExchange exchange, Object message, Throwable throwable);
 
-	void error(Log log, ServerWebExchange exchange, Object message);
+	void error(ServerWebExchange exchange, Object message);
 
-	void error(Log log, ServerWebExchange exchange, Object message, Throwable t);
+	void error(ServerWebExchange exchange, Object message, Throwable t);
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/AdaptableLogger.java
@@ -1,0 +1,34 @@
+package org.springframework.cloud.gateway.logging;
+
+import org.apache.commons.logging.Log;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * An abstraction over logging to all alternative implementations. For example, to
+ * maintain proper trace context when using manual sleuth instrumentation the log call
+ * needs to be wrapped inside a special WebFlux operator. Presently, it assumes apache
+ * commons logging as the logging interface (dominant in Spring)
+ */
+public interface AdaptableLogger {
+
+	void traceLog(Log log, ServerWebExchange exchange, Object message);
+
+	void traceLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+
+	void debugLog(Log log, ServerWebExchange exchange, Object message);
+
+	void debugLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+
+	void infoLog(Log log, ServerWebExchange exchange, Object message);
+
+	void infoLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+
+	void warnLog(Log log, ServerWebExchange exchange, Object message);
+
+	void warnLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable);
+
+	void errorLog(Log log, ServerWebExchange exchange, Object message);
+
+	void errorLog(Log log, ServerWebExchange exchange, Object message, Throwable t);
+
+}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
@@ -6,21 +6,21 @@ import org.springframework.web.server.ServerWebExchange;
 public class PassthroughLogger implements AdaptableLogger {
 
 	@Override
-	public void traceLog(Log log, ServerWebExchange exchange, Object message) {
+	public void trace(Log log, ServerWebExchange exchange, Object message) {
 		if (log.isTraceEnabled()) {
 			log.trace(message);
 		}
 	}
 
 	@Override
-	public void traceLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void trace(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isTraceEnabled()) {
 			log.trace(message, throwable);
 		}
 	}
 
 	@Override
-	public void debugLog(Log log, ServerWebExchange exchange, Object message) {
+	public void debug(Log log, ServerWebExchange exchange, Object message) {
 		if (log.isDebugEnabled()) {
 			log.debug(message);
 		}
@@ -28,7 +28,7 @@ public class PassthroughLogger implements AdaptableLogger {
 	}
 
 	@Override
-	public void debugLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void debug(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isDebugEnabled()) {
 			log.debug(message, throwable);
 		}
@@ -36,42 +36,42 @@ public class PassthroughLogger implements AdaptableLogger {
 	}
 
 	@Override
-	public void infoLog(Log log, ServerWebExchange exchange, Object message) {
+	public void info(Log log, ServerWebExchange exchange, Object message) {
 		if (log.isInfoEnabled()) {
 			log.info(message);
 		}
 	}
 
 	@Override
-	public void infoLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void info(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isInfoEnabled()) {
 			log.info(message, throwable);
 		}
 	}
 
 	@Override
-	public void warnLog(Log log, ServerWebExchange exchange, Object message) {
+	public void warn(Log log, ServerWebExchange exchange, Object message) {
 		if (log.isWarnEnabled()) {
 			log.warn(message);
 		}
 	}
 
 	@Override
-	public void warnLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void warn(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isWarnEnabled()) {
 			log.warn(message, throwable);
 		}
 	}
 
 	@Override
-	public void errorLog(Log log, ServerWebExchange exchange, Object message) {
+	public void error(Log log, ServerWebExchange exchange, Object message) {
 		if (log.isErrorEnabled()) {
 			log.error(message);
 		}
 	}
 
 	@Override
-	public void errorLog(Log log, ServerWebExchange exchange, Object message, Throwable t) {
+	public void error(Log log, ServerWebExchange exchange, Object message, Throwable t) {
 		if (log.isErrorEnabled()) {
 			log.error(message, t);
 		}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
@@ -1,0 +1,80 @@
+package org.springframework.cloud.gateway.logging;
+
+import org.apache.commons.logging.Log;
+import org.springframework.web.server.ServerWebExchange;
+
+public class PassthroughLogger implements AdaptableLogger {
+
+	@Override
+	public void traceLog(Log log, ServerWebExchange exchange, Object message) {
+		if (log.isTraceEnabled()) {
+			log.trace(message);
+		}
+	}
+
+	@Override
+	public void traceLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+		if (log.isTraceEnabled()) {
+			log.trace(message, throwable);
+		}
+	}
+
+	@Override
+	public void debugLog(Log log, ServerWebExchange exchange, Object message) {
+		if (log.isDebugEnabled()) {
+			log.debug(message);
+		}
+
+	}
+
+	@Override
+	public void debugLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+		if (log.isDebugEnabled()) {
+			log.debug(message, throwable);
+		}
+
+	}
+
+	@Override
+	public void infoLog(Log log, ServerWebExchange exchange, Object message) {
+		if (log.isInfoEnabled()) {
+			log.info(message);
+		}
+	}
+
+	@Override
+	public void infoLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+		if (log.isInfoEnabled()) {
+			log.info(message, throwable);
+		}
+	}
+
+	@Override
+	public void warnLog(Log log, ServerWebExchange exchange, Object message) {
+		if (log.isWarnEnabled()) {
+			log.warn(message);
+		}
+	}
+
+	@Override
+	public void warnLog(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+		if (log.isWarnEnabled()) {
+			log.warn(message, throwable);
+		}
+	}
+
+	@Override
+	public void errorLog(Log log, ServerWebExchange exchange, Object message) {
+		if (log.isErrorEnabled()) {
+			log.error(message);
+		}
+	}
+
+	@Override
+	public void errorLog(Log log, ServerWebExchange exchange, Object message, Throwable t) {
+		if (log.isErrorEnabled()) {
+			log.error(message, t);
+		}
+	}
+
+}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
@@ -5,22 +5,28 @@ import org.springframework.web.server.ServerWebExchange;
 
 public class PassthroughLogger implements AdaptableLogger {
 
+	private Log log;
+
+	public PassthroughLogger(Log log) {
+		this.log = log;
+	}
+
 	@Override
-	public void trace(Log log, ServerWebExchange exchange, Object message) {
+	public void trace(ServerWebExchange exchange, Object message) {
 		if (log.isTraceEnabled()) {
 			log.trace(message);
 		}
 	}
 
 	@Override
-	public void trace(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void trace(ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isTraceEnabled()) {
 			log.trace(message, throwable);
 		}
 	}
 
 	@Override
-	public void debug(Log log, ServerWebExchange exchange, Object message) {
+	public void debug(ServerWebExchange exchange, Object message) {
 		if (log.isDebugEnabled()) {
 			log.debug(message);
 		}
@@ -28,7 +34,7 @@ public class PassthroughLogger implements AdaptableLogger {
 	}
 
 	@Override
-	public void debug(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void debug(ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isDebugEnabled()) {
 			log.debug(message, throwable);
 		}
@@ -36,42 +42,42 @@ public class PassthroughLogger implements AdaptableLogger {
 	}
 
 	@Override
-	public void info(Log log, ServerWebExchange exchange, Object message) {
+	public void info(ServerWebExchange exchange, Object message) {
 		if (log.isInfoEnabled()) {
 			log.info(message);
 		}
 	}
 
 	@Override
-	public void info(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void info(ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isInfoEnabled()) {
 			log.info(message, throwable);
 		}
 	}
 
 	@Override
-	public void warn(Log log, ServerWebExchange exchange, Object message) {
+	public void warn(ServerWebExchange exchange, Object message) {
 		if (log.isWarnEnabled()) {
 			log.warn(message);
 		}
 	}
 
 	@Override
-	public void warn(Log log, ServerWebExchange exchange, Object message, Throwable throwable) {
+	public void warn(ServerWebExchange exchange, Object message, Throwable throwable) {
 		if (log.isWarnEnabled()) {
 			log.warn(message, throwable);
 		}
 	}
 
 	@Override
-	public void error(Log log, ServerWebExchange exchange, Object message) {
+	public void error(ServerWebExchange exchange, Object message) {
 		if (log.isErrorEnabled()) {
 			log.error(message);
 		}
 	}
 
 	@Override
-	public void error(Log log, ServerWebExchange exchange, Object message, Throwable t) {
+	public void error(ServerWebExchange exchange, Object message, Throwable t) {
 		if (log.isErrorEnabled()) {
 			log.error(message, t);
 		}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/logging/PassthroughLogger.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.cloud.gateway.logging;
 
 import org.apache.commons.logging.Log;

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
@@ -27,6 +27,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.core.Ordered;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -59,6 +60,9 @@ public class ForwardRoutingFilterTests {
 
 	@Mock
 	private DispatcherHandler dispatcherHandler;
+
+	@Mock
+	private AdaptableLogger adaptableLogger;
 
 	@InjectMocks
 	private ForwardRoutingFilter forwardRoutingFilter;

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
@@ -18,16 +18,24 @@ package org.springframework.cloud.gateway.filter;
 
 import java.net.URI;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.internal.matchers.Any;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.logging.AdaptableLogger;
+import org.springframework.cloud.gateway.logging.TestAdaptableLoggerObjectProvider;
 import org.springframework.core.Ordered;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -52,23 +60,24 @@ public class ForwardRoutingFilterTests {
 
 	private ServerWebExchange exchange;
 
+	private Log log = LogFactory.getLog(ForwardRoutingFilterTests.class);
+
 	@Mock
 	private GatewayFilterChain chain;
 
 	@Mock
 	private ObjectProvider<DispatcherHandler> objectProvider;
 
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider = new TestAdaptableLoggerObjectProvider(log);
+
 	@Mock
 	private DispatcherHandler dispatcherHandler;
 
-	@Mock
-	private AdaptableLogger adaptableLogger;
-
-	@InjectMocks
 	private ForwardRoutingFilter forwardRoutingFilter;
 
 	@Before
 	public void setup() {
+		forwardRoutingFilter = new ForwardRoutingFilter(objectProvider, adaptableLoggerObjectProvider);
 		exchange = MockServerWebExchange.from(MockServerHttpRequest.get("localendpoint").build());
 		when(objectProvider.getIfAvailable()).thenReturn(this.dispatcherHandler);
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilterTests.java
@@ -16,17 +16,17 @@
 
 package org.springframework.cloud.gateway.filter;
 
-import java.nio.charset.Charset;
-import java.util.ArrayList;
-
 import io.netty.buffer.ByteBuf;
+import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
-
-import org.springframework.cloud.gateway.logging.PassthroughLogger;
+import org.springframework.cloud.gateway.logging.TestAdaptableLoggerObjectProvider;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.core.io.buffer.PooledDataBuffer;
 import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
 
 import static io.netty.buffer.PooledByteBufAllocator.DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +47,8 @@ public class NettyWriteResponseFilterTests {
 	}
 
 	private void doTestWrap(MockServerHttpResponse response) {
-		NettyWriteResponseFilter filter = new NettyWriteResponseFilter(new ArrayList<>(), new PassthroughLogger());
+		NettyWriteResponseFilter filter = new NettyWriteResponseFilter(new ArrayList<>(),
+				new TestAdaptableLoggerObjectProvider(LogFactory.getLog(NettyWriteResponseFilterTests.class)));
 
 		ByteBuf buffer = DEFAULT.buffer();
 		buffer.writeCharSequence("test", Charset.defaultCharset());

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilterTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import io.netty.buffer.ByteBuf;
 import org.junit.Test;
 
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.core.io.buffer.PooledDataBuffer;
@@ -46,7 +47,7 @@ public class NettyWriteResponseFilterTests {
 	}
 
 	private void doTestWrap(MockServerHttpResponse response) {
-		NettyWriteResponseFilter filter = new NettyWriteResponseFilter(new ArrayList<>());
+		NettyWriteResponseFilter filter = new NettyWriteResponseFilter(new ArrayList<>(), new PassthroughLogger());
 
 		ByteBuf buffer = DEFAULT.buffer();
 		buffer.writeCharSequence("test", Charset.defaultCharset());

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ReactiveLoadBalancerClientFilterTests.java
@@ -29,6 +29,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.client.DefaultServiceInstance;
@@ -91,6 +93,9 @@ class ReactiveLoadBalancerClientFilterTests {
 
 	@Mock
 	private LoadBalancerProperties loadBalancerProperties;
+
+	@Mock
+	private AdaptableLogger adaptableLogger;
 
 	@InjectMocks
 	private ReactiveLoadBalancerClientFilter filter;
@@ -261,7 +266,7 @@ class ReactiveLoadBalancerClientFilterTests {
 		when(clientFactory.getInstance("service1", ReactorServiceInstanceLoadBalancer.class)).thenReturn(loadBalancer);
 		properties.setUse404(true);
 		ReactiveLoadBalancerClientFilter filter = new ReactiveLoadBalancerClientFilter(clientFactory, properties,
-				loadBalancerProperties);
+				loadBalancerProperties, new PassthroughLogger());
 		when(chain.filter(exchange)).thenReturn(Mono.empty());
 		try {
 			filter.filter(exchange, chain).block();
@@ -429,7 +434,7 @@ class ReactiveLoadBalancerClientFilterTests {
 		when(clientFactory.getInstance("service1", ReactorServiceInstanceLoadBalancer.class)).thenReturn(loadBalancer);
 
 		ReactiveLoadBalancerClientFilter filter = new ReactiveLoadBalancerClientFilter(clientFactory, properties,
-				loadBalancerProperties);
+				loadBalancerProperties, new PassthroughLogger());
 		filter.filter(exchange, chain).block();
 
 		return captor.getValue();

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
@@ -18,9 +18,13 @@ package org.springframework.cloud.gateway.filter;
 
 import java.net.URI;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.cloud.gateway.logging.PassthroughLogger;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
+import org.springframework.cloud.gateway.logging.TestAdaptableLoggerObjectProvider;
 import reactor.core.publisher.Mono;
 
 import org.springframework.boot.SpringBootVersion;
@@ -43,6 +47,10 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.G
  * @author Spencer Gibb
  */
 public class RouteToRequestUrlFilterTests {
+
+	private Log log = LogFactory.getLog(RouteToRequestUrlFilterTests.class);
+
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider = new TestAdaptableLoggerObjectProvider(log);
 
 	@Test
 	public void happyPath() {
@@ -197,7 +205,7 @@ public class RouteToRequestUrlFilterTests {
 		ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
 		when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
 
-		RouteToRequestUrlFilter filter = new RouteToRequestUrlFilter(new PassthroughLogger());
+		RouteToRequestUrlFilter filter = new RouteToRequestUrlFilter(adaptableLoggerObjectProvider);
 		filter.filter(exchange, filterChain);
 
 		return captor.getValue();

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
@@ -20,6 +20,7 @@ import java.net.URI;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.boot.SpringBootVersion;
@@ -196,7 +197,7 @@ public class RouteToRequestUrlFilterTests {
 		ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
 		when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
 
-		RouteToRequestUrlFilter filter = new RouteToRequestUrlFilter();
+		RouteToRequestUrlFilter filter = new RouteToRequestUrlFilter(new PassthroughLogger());
 		filter.filter(exchange, filterChain);
 
 		return captor.getValue();

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilterTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.filter.headers.HttpHeadersFilter;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
@@ -60,7 +61,7 @@ public class WebsocketRoutingFilterTests {
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
 		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR,
 				URI.create("http://microservice/my-service/websocket%20upgrade"));
-		changeSchemeIfIsWebSocketUpgrade(exchange);
+		changeSchemeIfIsWebSocketUpgrade(exchange, new PassthroughLogger());
 		URI wsRequestUrl = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
 		assertThat(wsRequestUrl).isEqualTo(URI.create("ws://microservice/my-service/websocket%20upgrade"));
 	}
@@ -80,7 +81,7 @@ public class WebsocketRoutingFilterTests {
 		ObjectProvider<List<HttpHeadersFilter>> headersFilters = mock(ObjectProvider.class);
 		when(headersFilters.getIfAvailable(any())).thenReturn(new ArrayList<>());
 		WebsocketRoutingFilter filter = new WebsocketRoutingFilter(mock(WebSocketClient.class),
-				mock(WebSocketService.class), headersFilters);
+				mock(WebSocketService.class), headersFilters, new PassthroughLogger());
 		List<HttpHeadersFilter> filters = filter.getHeadersFilters();
 		MockServerHttpRequest request = MockServerHttpRequest.get("ws://not-matters-that").header(HOST, "MyHost")
 				.header("Sec-Websocket-Something", "someval").header("x-foo", "bar").build();

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
@@ -19,9 +19,13 @@ package org.springframework.cloud.gateway.filter.factory;
 import java.net.URI;
 import java.util.LinkedHashSet;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.cloud.gateway.logging.PassthroughLogger;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
+import org.springframework.cloud.gateway.logging.TestAdaptableLoggerObjectProvider;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -41,6 +45,10 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.G
  */
 public class PrefixPathGatewayFilterFactoryTest {
 
+	private Log log = LogFactory.getLog(PrefixPathGatewayFilterFactoryTest.class);
+
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider = new TestAdaptableLoggerObjectProvider(log);
+
 	@Test
 	public void testPrefixPath() {
 		testPrefixPathFilter("/foo", "/bar", "/foo/bar");
@@ -48,7 +56,7 @@ public class PrefixPathGatewayFilterFactoryTest {
 	}
 
 	private void testPrefixPathFilter(String prefix, String path, String expectedPath) {
-		GatewayFilter filter = new PrefixPathGatewayFilterFactory(new PassthroughLogger())
+		GatewayFilter filter = new PrefixPathGatewayFilterFactory(adaptableLoggerObjectProvider)
 				.apply(c -> c.setPrefix(prefix));
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost" + path).build();
 
@@ -72,7 +80,7 @@ public class PrefixPathGatewayFilterFactoryTest {
 	public void toStringFormat() {
 		Config config = new Config();
 		config.setPrefix("myprefix");
-		GatewayFilter filter = new PrefixPathGatewayFilterFactory(new PassthroughLogger()).apply(config);
+		GatewayFilter filter = new PrefixPathGatewayFilterFactory(adaptableLoggerObjectProvider).apply(config);
 		assertThat(filter.toString()).contains("myprefix");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
@@ -47,7 +48,8 @@ public class PrefixPathGatewayFilterFactoryTest {
 	}
 
 	private void testPrefixPathFilter(String prefix, String path, String expectedPath) {
-		GatewayFilter filter = new PrefixPathGatewayFilterFactory().apply(c -> c.setPrefix(prefix));
+		GatewayFilter filter = new PrefixPathGatewayFilterFactory(new PassthroughLogger())
+				.apply(c -> c.setPrefix(prefix));
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost" + path).build();
 
 		ServerWebExchange exchange = MockServerWebExchange.from(request);
@@ -70,7 +72,7 @@ public class PrefixPathGatewayFilterFactoryTest {
 	public void toStringFormat() {
 		Config config = new Config();
 		config.setPrefix("myprefix");
-		GatewayFilter filter = new PrefixPathGatewayFilterFactory().apply(config);
+		GatewayFilter filter = new PrefixPathGatewayFilterFactory(new PassthroughLogger()).apply(config);
 		assertThat(filter.toString()).contains("myprefix");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
@@ -28,6 +28,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -190,7 +191,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 		config.setMethods(HttpMethod.GET);
 		config.setSeries(HttpStatus.Series.SERVER_ERROR);
 		config.setExceptions(IOException.class);
-		GatewayFilter filter = new RetryGatewayFilterFactory().apply(config);
+		GatewayFilter filter = new RetryGatewayFilterFactory(new PassthroughLogger()).apply(config);
 		assertThat(filter.toString()).contains("4").contains("[GET]").contains("[SERVER_ERROR]")
 				.contains("[IOException]");
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
@@ -28,7 +28,9 @@ import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.cloud.gateway.logging.PassthroughLogger;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -74,6 +76,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 // so we use only PrefixPath filter
 @ActiveProfiles("retrytests")
 public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTests {
+
+	@Autowired
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider;
 
 	@Rule
 	public final OutputCaptureRule capture = new OutputCaptureRule();
@@ -191,7 +196,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 		config.setMethods(HttpMethod.GET);
 		config.setSeries(HttpStatus.Series.SERVER_ERROR);
 		config.setExceptions(IOException.class);
-		GatewayFilter filter = new RetryGatewayFilterFactory(new PassthroughLogger()).apply(config);
+		GatewayFilter filter = new RetryGatewayFilterFactory(adaptableLoggerObjectProvider).apply(config);
 		assertThat(filter.toString()).contains("4").contains("[GET]").contains("[SERVER_ERROR]")
 				.contains("[IOException]");
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gateway.handler;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -49,7 +50,7 @@ public class RoutePredicateHandlerMappingTests {
 		Route routeTrue = Route.async().id("routeTrue").uri("http://localhost").predicate(swe -> true).build();
 		RouteLocator routeLocator = () -> Flux.just(routeFalse, routeFail, routeTrue).hide();
 		RoutePredicateHandlerMapping mapping = new RoutePredicateHandlerMapping(null, routeLocator,
-				new GlobalCorsProperties(), new MockEnvironment());
+				new GlobalCorsProperties(), new MockEnvironment(), new PassthroughLogger());
 
 		final Mono<Route> routeMono = mapping.lookupRoute(Mockito.mock(ServerWebExchange.class));
 
@@ -72,7 +73,7 @@ public class RoutePredicateHandlerMappingTests {
 				.build();
 		RouteLocator routeLocator = () -> Flux.just(routeFalse, routeError, routeFail, routeTrue).hide();
 		RoutePredicateHandlerMapping mapping = new RoutePredicateHandlerMapping(null, routeLocator,
-				new GlobalCorsProperties(), new MockEnvironment());
+				new GlobalCorsProperties(), new MockEnvironment(), new PassthroughLogger());
 
 		final Mono<Route> routeMono = mapping.lookupRoute(Mockito.mock(ServerWebExchange.class));
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
@@ -16,10 +16,14 @@
 
 package org.springframework.cloud.gateway.handler;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mockito;
-import org.springframework.cloud.gateway.logging.PassthroughLogger;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
+import org.springframework.cloud.gateway.logging.TestAdaptableLoggerObjectProvider;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -38,6 +42,10 @@ import static org.hamcrest.Matchers.containsString;
  */
 public class RoutePredicateHandlerMappingTests {
 
+	private Log log = LogFactory.getLog(RoutePredicateHandlerMappingTests.class);
+
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider = new TestAdaptableLoggerObjectProvider(log);
+
 	@Rule
 	public OutputCaptureRule outputCapture = new OutputCaptureRule();
 
@@ -50,7 +58,7 @@ public class RoutePredicateHandlerMappingTests {
 		Route routeTrue = Route.async().id("routeTrue").uri("http://localhost").predicate(swe -> true).build();
 		RouteLocator routeLocator = () -> Flux.just(routeFalse, routeFail, routeTrue).hide();
 		RoutePredicateHandlerMapping mapping = new RoutePredicateHandlerMapping(null, routeLocator,
-				new GlobalCorsProperties(), new MockEnvironment(), new PassthroughLogger());
+				new GlobalCorsProperties(), new MockEnvironment(), adaptableLoggerObjectProvider);
 
 		final Mono<Route> routeMono = mapping.lookupRoute(Mockito.mock(ServerWebExchange.class));
 
@@ -73,7 +81,7 @@ public class RoutePredicateHandlerMappingTests {
 				.build();
 		RouteLocator routeLocator = () -> Flux.just(routeFalse, routeError, routeFail, routeTrue).hide();
 		RoutePredicateHandlerMapping mapping = new RoutePredicateHandlerMapping(null, routeLocator,
-				new GlobalCorsProperties(), new MockEnvironment(), new PassthroughLogger());
+				new GlobalCorsProperties(), new MockEnvironment(), adaptableLoggerObjectProvider);
 
 		final Mono<Route> routeMono = mapping.lookupRoute(Mockito.mock(ServerWebExchange.class));
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
@@ -28,6 +28,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
 import org.springframework.cloud.gateway.handler.predicate.PathRoutePredicateFactory.Config;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
@@ -102,14 +103,14 @@ public class PathRoutePredicateFactoryTests extends BaseWebClientTests {
 	public void toStringFormat() {
 		Config config = new Config().setPatterns(Arrays.asList("patternA", "patternB"))
 				.setMatchOptionalTrailingSeparator(false);
-		Predicate predicate = new PathRoutePredicateFactory().apply(config);
+		Predicate predicate = new PathRoutePredicateFactory(new PassthroughLogger()).apply(config);
 		assertThat(predicate.toString()).contains("patternA").contains("patternB").contains("false");
 	}
 
 	@Test
 	public void toStringFormatMatchTrailingSlashTrue() {
 		Config config = new Config().setPatterns(Arrays.asList("patternA", "patternB")).setMatchTrailingSlash(true);
-		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory().apply(config);
+		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new PassthroughLogger()).apply(config);
 		assertThat(predicate.toString()).contains("patternA").contains("patternB").contains("true");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
@@ -22,12 +22,15 @@ import java.util.function.Predicate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
 import org.springframework.cloud.gateway.handler.predicate.PathRoutePredicateFactory.Config;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
@@ -46,6 +49,9 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @DirtiesContext
 public class PathRoutePredicateFactoryTests extends BaseWebClientTests {
+
+	@Autowired
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider;
 
 	@Test
 	public void pathRouteWorks() {
@@ -103,14 +109,15 @@ public class PathRoutePredicateFactoryTests extends BaseWebClientTests {
 	public void toStringFormat() {
 		Config config = new Config().setPatterns(Arrays.asList("patternA", "patternB"))
 				.setMatchOptionalTrailingSeparator(false);
-		Predicate predicate = new PathRoutePredicateFactory(new PassthroughLogger()).apply(config);
+		Predicate predicate = new PathRoutePredicateFactory(adaptableLoggerObjectProvider).apply(config);
 		assertThat(predicate.toString()).contains("patternA").contains("patternB").contains("false");
 	}
 
 	@Test
 	public void toStringFormatMatchTrailingSlashTrue() {
 		Config config = new Config().setPatterns(Arrays.asList("patternA", "patternB")).setMatchTrailingSlash(true);
-		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new PassthroughLogger()).apply(config);
+		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(adaptableLoggerObjectProvider)
+				.apply(config);
 		assertThat(predicate.toString()).contains("patternA").contains("patternB").contains("true");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactoryTests.java
@@ -27,6 +27,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.AsyncPredicate;
 import org.springframework.cloud.gateway.handler.predicate.ReadBodyRoutePredicateFactory.Config;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests.TestLoadBalancerConfig;
@@ -78,7 +79,8 @@ public class ReadBodyRoutePredicateFactoryTests {
 	public void toStringFormat() {
 		Config config = new Config();
 		config.setInClass(String.class);
-		AsyncPredicate<ServerWebExchange> predicate = new ReadBodyRoutePredicateFactory().applyAsync(config);
+		AsyncPredicate<ServerWebExchange> predicate = new ReadBodyRoutePredicateFactory(new PassthroughLogger())
+				.applyAsync(config);
 		assertThat(predicate.toString()).contains("ReadBody: " + config.getInClass());
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactoryTests.java
@@ -21,12 +21,14 @@ import java.util.function.Predicate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.AsyncPredicate;
 import org.springframework.cloud.gateway.handler.predicate.ReadBodyRoutePredicateFactory.Config;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
@@ -61,6 +63,9 @@ public class ReadBodyRoutePredicateFactoryTests {
 	@Autowired
 	private WebTestClient webClient;
 
+	@Autowired
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider;
+
 	@Test
 	public void readBodyWorks() {
 
@@ -79,7 +84,7 @@ public class ReadBodyRoutePredicateFactoryTests {
 	public void toStringFormat() {
 		Config config = new Config();
 		config.setInClass(String.class);
-		AsyncPredicate<ServerWebExchange> predicate = new ReadBodyRoutePredicateFactory(new PassthroughLogger())
+		AsyncPredicate<ServerWebExchange> predicate = new ReadBodyRoutePredicateFactory(adaptableLoggerObjectProvider)
 				.applyAsync(config);
 		assertThat(predicate.toString()).contains("ReadBody: " + config.getInClass());
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
@@ -80,7 +81,7 @@ public class RemoteAddrRoutePredicateFactoryTests extends BaseWebClientTests {
 	public void toStringFormat() {
 		Config config = new Config();
 		config.setSources("1.2.3.4", "5.6.7.8");
-		Predicate predicate = new RemoteAddrRoutePredicateFactory().apply(config);
+		Predicate predicate = new RemoteAddrRoutePredicateFactory(new PassthroughLogger()).apply(config);
 		assertThat(predicate.toString()).contains("RemoteAddrs: [1.2.3.4, 5.6.7.8]");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
@@ -21,6 +21,9 @@ import java.util.function.Predicate;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.logging.PassthroughLogger;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -52,6 +55,9 @@ import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 @ActiveProfiles({ "remote-address" })
 public class RemoteAddrRoutePredicateFactoryTests extends BaseWebClientTests {
 
+	@Autowired
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider;
+
 	@Test
 	public void remoteAddrWorks() {
 		Mono<ClientResponse> result = webClient.get().uri("/ok/httpbin/").exchange();
@@ -81,7 +87,7 @@ public class RemoteAddrRoutePredicateFactoryTests extends BaseWebClientTests {
 	public void toStringFormat() {
 		Config config = new Config();
 		config.setSources("1.2.3.4", "5.6.7.8");
-		Predicate predicate = new RemoteAddrRoutePredicateFactory(new PassthroughLogger()).apply(config);
+		Predicate predicate = new RemoteAddrRoutePredicateFactory(adaptableLoggerObjectProvider).apply(config);
 		assertThat(predicate.toString()).contains("RemoteAddrs: [1.2.3.4, 5.6.7.8]");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactoryIntegrationTests.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
@@ -53,7 +54,7 @@ public class WeightRoutePredicateFactoryIntegrationTests extends BaseWebClientTe
 	private WeightCalculatorWebFilter filter;
 
 	@Autowired
-	private AdaptableLogger adaptableLogger;
+	private ObjectProvider<AdaptableLogger> adaptableLoggerObjectProvider;
 
 	private static Random getRandom(double value) {
 		Random random = mock(Random.class);
@@ -80,7 +81,7 @@ public class WeightRoutePredicateFactoryIntegrationTests extends BaseWebClientTe
 	@Test
 	public void toStringFormat() {
 		WeightConfig config = new WeightConfig("mygroup", "myroute", 5);
-		Predicate predicate = new WeightRoutePredicateFactory(adaptableLogger).apply(config);
+		Predicate predicate = new WeightRoutePredicateFactory(adaptableLoggerObjectProvider).apply(config);
 		assertThat(predicate.toString()).contains("Weight: mygroup 5");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/WeightRoutePredicateFactoryIntegrationTests.java
@@ -28,6 +28,7 @@ import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.filter.WeightCalculatorWebFilter;
+import org.springframework.cloud.gateway.logging.AdaptableLogger;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.support.WeightConfig;
@@ -50,6 +51,9 @@ public class WeightRoutePredicateFactoryIntegrationTests extends BaseWebClientTe
 
 	@Autowired
 	private WeightCalculatorWebFilter filter;
+
+	@Autowired
+	private AdaptableLogger adaptableLogger;
 
 	private static Random getRandom(double value) {
 		Random random = mock(Random.class);
@@ -76,7 +80,7 @@ public class WeightRoutePredicateFactoryIntegrationTests extends BaseWebClientTe
 	@Test
 	public void toStringFormat() {
 		WeightConfig config = new WeightConfig("mygroup", "myroute", 5);
-		Predicate predicate = new WeightRoutePredicateFactory().apply(config);
+		Predicate predicate = new WeightRoutePredicateFactory(adaptableLogger).apply(config);
 		assertThat(predicate.toString()).contains("Weight: mygroup 5");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/logging/TestAdaptableLoggerObjectProvider.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/logging/TestAdaptableLoggerObjectProvider.java
@@ -1,0 +1,35 @@
+package org.springframework.cloud.gateway.logging;
+
+import org.apache.commons.logging.Log;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.ObjectProvider;
+
+public class TestAdaptableLoggerObjectProvider implements ObjectProvider<AdaptableLogger> {
+
+	private Log log;
+
+	public TestAdaptableLoggerObjectProvider(Log log) {
+		this.log = log;
+	}
+
+	@Override
+	public AdaptableLogger getObject(Object... args) throws BeansException {
+		return new PassthroughLogger(log);
+	}
+
+	@Override
+	public AdaptableLogger getIfAvailable() throws BeansException {
+		return null;
+	}
+
+	@Override
+	public AdaptableLogger getIfUnique() throws BeansException {
+		return null;
+	}
+
+	@Override
+	public AdaptableLogger getObject() throws BeansException {
+		return null;
+	}
+
+}


### PR DESCRIPTION
See https://github.com/spring-cloud/spring-cloud-sleuth/issues/1815. I think something like this allows Sleuth to provide an implementation based on WebFluxSleuthOperators.withSpanInScope(). @marcingrzejszczak does this look the right kind of interface? If so, then I can create a PR in sleuth after it's merged here.