### PR TITLE
DedupeResponseHeaderGatewayFilter ReadOnlyHeader bug fix

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactory.java
@@ -125,8 +125,12 @@ public class DedupeResponseHeaderGatewayFilterFactory
 		if (headers == null || names == null || strategy == null) {
 			return;
 		}
-		for (String name : names.split(" ")) {
-			dedupe(headers, name.trim(), strategy);
+		try{
+			for (String name : names.split(" ")) {
+				dedupe(headers, name.trim(), strategy);
+			}
+		}catch (UnsupportedOperationException ex){
+
 		}
 	}
 


### PR DESCRIPTION
A bug in which exception occurs when set value when it is ReadOnlyHttpHeaders