### PR TITLE
feature-2140 `org.springframework.cloud.gateway.config.HttpClientProperties#proxy` consider specifying the proxy type?

### DIFF
--- a/docs/src/main/asciidoc/_configprops.adoc
+++ b/docs/src/main/asciidoc/_configprops.adoc
@@ -79,6 +79,7 @@
 |spring.cloud.gateway.httpclient.pool.max-life-time |  | Duration after which the channel will be closed. If NULL, there is no max life time.
 |spring.cloud.gateway.httpclient.pool.name | `proxy` | The channel pool map name, defaults to proxy.
 |spring.cloud.gateway.httpclient.pool.type |  | Type of pool for HttpClient to use, defaults to ELASTIC.
+|spring.cloud.gateway.httpclient.proxy.type | `HTTP` | proxyType for proxy configuration of Netty HttpClient.
 |spring.cloud.gateway.httpclient.proxy.host |  | Hostname for proxy configuration of Netty HttpClient.
 |spring.cloud.gateway.httpclient.proxy.non-proxy-hosts-pattern |  | Regular expression (Java) for a configured list of hosts. that should be reached directly, bypassing the proxy
 |spring.cloud.gateway.httpclient.proxy.password |  | Password for proxy configuration of Netty HttpClient.

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -691,8 +691,7 @@ public class GatewayAutoConfiguration {
 						if (StringUtils.hasText(proxy.getHost())) {
 
 							tcpClient = tcpClient.proxy(proxySpec -> {
-								ProxyProvider.Builder builder = proxySpec.type(ProxyProvider.Proxy.HTTP)
-										.host(proxy.getHost());
+								ProxyProvider.Builder builder = proxySpec.type(proxy.getType()).host(proxy.getHost());
 
 								PropertyMapper map = PropertyMapper.get();
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
@@ -35,6 +35,7 @@ import javax.validation.constraints.Max;
 
 import reactor.netty.resources.ConnectionProvider;
 import reactor.netty.tcp.SslProvider;
+import reactor.netty.transport.ProxyProvider;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.web.server.WebServerException;
@@ -276,6 +277,9 @@ public class HttpClientProperties {
 
 	public static class Proxy {
 
+		/** proxyType for proxy configuration of Netty HttpClient. */
+		private ProxyProvider.Proxy type = ProxyProvider.Proxy.HTTP;
+
 		/** Hostname for proxy configuration of Netty HttpClient. */
 		private String host;
 
@@ -293,6 +297,14 @@ public class HttpClientProperties {
 		 * reached directly, bypassing the proxy
 		 */
 		private String nonProxyHostsPattern;
+
+		public ProxyProvider.Proxy getType() {
+			return type;
+		}
+
+		public void setType(ProxyProvider.Proxy type) {
+			this.type = type;
+		}
 
 		public String getHost() {
 			return host;
@@ -336,8 +348,9 @@ public class HttpClientProperties {
 
 		@Override
 		public String toString() {
-			return "Proxy{" + "host='" + host + '\'' + ", port=" + port + ", username='" + username + '\''
-					+ ", password='" + password + '\'' + ", nonProxyHostsPattern='" + nonProxyHostsPattern + '\'' + '}';
+			return "Proxy{" + "type='" + type + '\'' + "host='" + host + '\'' + ", port=" + port + ", username='"
+					+ username + '\'' + ", password='" + password + '\'' + ", nonProxyHostsPattern='"
+					+ nonProxyHostsPattern + '\'' + '}';
 		}
 
 	}


### PR DESCRIPTION
See https://github.com/spring-cloud/spring-cloud-gateway/issues/2140
Hello, is org.springframework.cloud.gateway.config.HttpClientProperties#proxy considering specifying the proxy type? Currently, the code is fixed ProxyProvider.Proxy.HTTP, if configuration injection can be used to enable the gateway to support more complex network environments.

By adding the type field in org.springframework.cloud.gateway.config.HttpClientProperties.Proxy, it can be used in org.springframework.cloud.gateway.config.GatewayAutoConfiguration.