### PR TITLE
Use request.getLocalAddress() to test management port

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.handler;
 
 import java.util.function.Function;
 
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.config.GlobalCorsProperties;
@@ -72,11 +73,20 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 		return environment.getProperty(prefix + "port", Integer.class);
 	}
 
+	private int getPort(ServerWebExchange exchange) {
+		ServerHttpRequest request = exchange.getRequest();
+		if (request.getLocalAddress() != null) {
+			return request.getLocalAddress().getPort();
+		}
+		else {
+			return request.getURI().getPort();
+		}
+	}
 	@Override
 	protected Mono<?> getHandlerInternal(ServerWebExchange exchange) {
 		// don't handle requests on management port if set and different than server port
 		if (this.managementPortType == DIFFERENT && this.managementPort != null
-				&& exchange.getRequest().getURI().getPort() == this.managementPort) {
+				&& getPort(exchange) == this.managementPort) {
 			return Mono.empty();
 		}
 		exchange.getAttributes().put(GATEWAY_HANDLER_MAPPER_ATTR, getSimpleName());

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -18,13 +18,13 @@ package org.springframework.cloud.gateway.handler;
 
 import java.util.function.Function;
 
-import org.springframework.http.server.reactive.ServerHttpRequest;
 import reactor.core.publisher.Mono;
 
 import org.springframework.cloud.gateway.config.GlobalCorsProperties;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.core.env.Environment;
+import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.reactive.handler.AbstractHandlerMapping;
 import org.springframework.web.server.ServerWebExchange;


### PR DESCRIPTION
Spring Cloud Gateway uses `exchange.getRequest().getURI().getPort()` to determine if the current request port is the management port.
But `exchange.getRequest().getURI().getPort()` is created from Host header. So if, for example, you have a HaProxy in front of the gateway, the port in Host header might be different from the actual real port of the gateway.
Maybe it's better to use `exchange.getRequest().getLocalAddress().getPort()`.

(issue #2195)