### PR TITLE
Fix for ForwardedHeadersFilter: wrong mapping for IPv6 remote address

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gateway.filter.headers;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.ArrayList;
@@ -118,8 +120,16 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 		if (remoteAddress != null) {
 			// If remoteAddress is unresolved, calling getHostAddress() would cause a
 			// NullPointerException.
-			String forValue = remoteAddress.isUnresolved() ? remoteAddress.getHostName()
-					: remoteAddress.getAddress().getHostAddress();
+			String forValue;
+			if (remoteAddress.isUnresolved()) {
+				forValue = remoteAddress.getHostName();
+			} else {
+				InetAddress address = remoteAddress.getAddress();
+				forValue = remoteAddress.getAddress().getHostAddress();
+				if (address instanceof Inet6Address) {
+					forValue = "[" + forValue + "]";
+				}
+			}
 			int port = remoteAddress.getPort();
 			if (port >= 0) {
 				forValue = forValue + ":" + port;


### PR DESCRIPTION
fix problem with missing '[' and ']' around IPv6 address. See https://tools.ietf.org/html/rfc7239

