### PR TITLE
Fix secure headers duplication

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -92,39 +92,39 @@ public class SecureHeadersGatewayFilterFactory
 				List<String> disabled = properties.getDisable();
 				Config config = originalConfig.withDefaults(properties);
 
-				if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
-					headers.add(X_XSS_PROTECTION_HEADER, config.getXssProtectionHeader());
-				}
+				return chain.filter(exchange).then(Mono.fromRunnable(() -> {
+					if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
+						headers.addIfAbsent(X_XSS_PROTECTION_HEADER, config.getXssProtectionHeader());
+					}
 
-				if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
-					headers.add(STRICT_TRANSPORT_SECURITY_HEADER, config.getStrictTransportSecurity());
-				}
+					if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
+						headers.addIfAbsent(STRICT_TRANSPORT_SECURITY_HEADER, config.getStrictTransportSecurity());
+					}
 
-				if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
-					headers.add(X_FRAME_OPTIONS_HEADER, config.getFrameOptions());
-				}
+					if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
+						headers.addIfAbsent(X_FRAME_OPTIONS_HEADER, config.getFrameOptions());
+					}
 
-				if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
-					headers.add(X_CONTENT_TYPE_OPTIONS_HEADER, config.getContentTypeOptions());
-				}
+					if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
+						headers.addIfAbsent(X_CONTENT_TYPE_OPTIONS_HEADER, config.getContentTypeOptions());
+					}
 
-				if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
-					headers.add(REFERRER_POLICY_HEADER, config.getReferrerPolicy());
-				}
+					if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
+						headers.addIfAbsent(REFERRER_POLICY_HEADER, config.getReferrerPolicy());
+					}
 
-				if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
-					headers.add(CONTENT_SECURITY_POLICY_HEADER, config.getContentSecurityPolicy());
-				}
+					if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
+						headers.addIfAbsent(CONTENT_SECURITY_POLICY_HEADER, config.getContentSecurityPolicy());
+					}
 
-				if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
-					headers.add(X_DOWNLOAD_OPTIONS_HEADER, config.getDownloadOptions());
-				}
+					if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
+						headers.addIfAbsent(X_DOWNLOAD_OPTIONS_HEADER, config.getDownloadOptions());
+					}
 
-				if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
-					headers.add(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, config.getPermittedCrossDomainPolicies());
-				}
-
-				return chain.filter(exchange);
+					if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
+						headers.addIfAbsent(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, config.getPermittedCrossDomainPolicies());
+					}
+				}));
 			}
 
 			@Override

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
@@ -72,9 +72,9 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 				new SecureHeadersProperties());
 		filter = filterFactory.apply(new Config());
 
-		filter.filter(exchange, filterChain);
+		filter.filter(exchange, filterChain).block();
 
-		ServerHttpResponse response = captor.getValue().getResponse();
+		ServerHttpResponse response = exchange.getResponse();
 		assertThat(response.getHeaders()).containsKeys(X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER,
 				X_FRAME_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER,
 				CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER);
@@ -90,7 +90,7 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
 		filter = filterFactory.apply(new Config());
 
-		filter.filter(exchange, filterChain);
+		filter.filter(exchange, filterChain).block();
 
 		ServerHttpResponse response = captor.getValue().getResponse();
 		assertThat(response.getHeaders()).doesNotContainKeys(X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER,
@@ -109,9 +109,9 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 		config.setReferrerPolicy("referrer");
 		filter = filterFactory.apply(config);
 
-		filter.filter(exchange, filterChain);
+		filter.filter(exchange, filterChain).block();
 
-		ServerHttpResponse response = captor.getValue().getResponse();
+		ServerHttpResponse response = exchange.getResponse();
 		assertThat(response.getHeaders()).containsKeys(X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER,
 				X_FRAME_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER,
 				CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER);
@@ -130,6 +130,31 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 		assertThat(response.getHeaders().get(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER))
 				.containsOnly(properties.getPermittedCrossDomainPolicies());
 
+	}
+
+	@Test
+	public void doesNotDuplicateHeaders() {
+		String originalHeaderValue = "original-header-value";
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(
+				new SecureHeadersProperties());
+		Config config = new Config();
+
+		String[] headers = { X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER, X_FRAME_OPTIONS_HEADER,
+				X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER, CONTENT_SECURITY_POLICY_HEADER,
+				X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER };
+
+		for (String header : headers) {
+			filter = filterFactory.apply(config);
+
+			MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost").build();
+			exchange = MockServerWebExchange.from(request);
+			exchange.getResponse().getHeaders().set(header, originalHeaderValue);
+
+			filter.filter(exchange, filterChain).block();
+
+			ServerHttpResponse response = captor.getValue().getResponse();
+			assertThat(response.getHeaders().get(header)).containsOnly(originalHeaderValue);
+		}
 	}
 
 	@Test

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
@@ -73,6 +73,17 @@ public class HttpBinCompatibleController {
 		return result;
 	}
 
+	@RequestMapping(path = "/headers", method = RequestMethod.PATCH)
+	public ResponseEntity<Map<String, Object>> headersPatch(ServerWebExchange exchange,
+			@RequestBody Map<String, String> headersToAdd) {
+		Map<String, Object> result = new HashMap<>();
+		result.put("headers", getHeaders(exchange));
+		ResponseEntity.BodyBuilder responseEntity = ResponseEntity.status(HttpStatus.OK);
+		headersToAdd.forEach(responseEntity::header);
+
+		return responseEntity.body(result);
+	}
+
 	@RequestMapping(path = "/multivalueheaders", method = { RequestMethod.GET, RequestMethod.POST },
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	public Map<String, Object> multiValueHeaders(ServerWebExchange exchange) {


### PR DESCRIPTION
When response from the upstream already includes one of the secure headers, it is duplicated by SCG