### PR TITLE
Add an annotation and some notes to custom components description

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -2547,11 +2547,12 @@ These are basic guides to writing some custom components of the gateway.
 === Writing Custom Route Predicate Factories
 
 
-In order to write a Route Predicate you will need to implement `RoutePredicateFactory`.  There is an abstract class called `AbstractRoutePredicateFactory` which you can extend.
+In order to write a Route Predicate you will need to implement `RoutePredicateFactory` as a bean. There is an abstract class called `AbstractRoutePredicateFactory` which you can extend.
 
 .MyRoutePredicateFactory.java
 [source,java]
 ----
+@Component
 public class MyRoutePredicateFactory extends AbstractRoutePredicateFactory<HeaderRoutePredicateFactory.Config> {
 
     public MyRoutePredicateFactory() {
@@ -2578,7 +2579,7 @@ public class MyRoutePredicateFactory extends AbstractRoutePredicateFactory<Heade
 ----
 === Writing Custom GatewayFilter Factories
 
-To write a `GatewayFilter`, you must implement `GatewayFilterFactory`.
+To write a `GatewayFilter`, you must implement `GatewayFilterFactory` as a bean.
 You can extend an abstract class called `AbstractGatewayFilterFactory`.
 The following examples show how to do so:
 
@@ -2586,6 +2587,7 @@ The following examples show how to do so:
 ====
 [source,java]
 ----
+@Component
 public class PreGatewayFilterFactory extends AbstractGatewayFilterFactory<PreGatewayFilterFactory.Config> {
 
 	public PreGatewayFilterFactory() {
@@ -2614,6 +2616,7 @@ public class PreGatewayFilterFactory extends AbstractGatewayFilterFactory<PreGat
 .PostGatewayFilterFactory.java
 [source,java]
 ----
+@Component
 public class PostGatewayFilterFactory extends AbstractGatewayFilterFactory<PostGatewayFilterFactory.Config> {
 
 	public PostGatewayFilterFactory() {
@@ -2654,7 +2657,7 @@ name to be compliant.
 
 === Writing Custom Global Filters
 
-To write a custom global filter, you must implement `GlobalFilter` interface.
+To write a custom global filter, you must implement `GlobalFilter` interface as a bean.
 This applies the filter to all requests.
 
 The following examples show how to set up global pre and post filters, respectively:


### PR DESCRIPTION
The current text and the examples of [custom predicates and filters](https://docs.spring.io/spring-cloud-gateway/docs/current/reference/html/#writing-custom-route-predicate-factories) seem incomplete as they don't mention that the components must be registered as beans in Spring context because otherwise the components would not be found by [`routeDefinitionRouteLocator`](https://github.com/spring-cloud/spring-cloud-gateway/blob/79cf80be3e084dedc9d35e4f36c91a0363fcd0b8/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java#L221l) and it would end up with:
```
16:23:50.632 ERROR - [freshExecutor-0] sid: rid: - reactor.core.publisher.Operators         : Operator called default onErrorDropped

reactor.core.Exceptions$ErrorCallbackNotImplemented: java.lang.IllegalArgumentException: Unable to find GatewayFilterFactory with name CabinetAccess
Caused by: java.lang.IllegalArgumentException: Unable to find GatewayFilterFactory with name CabinetAccess
	at org.springframework.cloud.gateway.route.RouteDefinitionRouteLocator.loadGatewayFilters(RouteDefinitionRouteLocator.java:130)
	at org.springframework.cloud.gateway.route.RouteDefinitionRouteLocator.getFilters(RouteDefinitionRouteLocator.java:176)
	at org.springframework.cloud.gateway.route.RouteDefinitionRouteLocator.convertToRoute(RouteDefinitionRouteLocator.java:117)
...
```

The fix is aimed to clarify this point.