### PR TITLE
Reorder predicate documentation paragraphs

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -367,32 +367,6 @@ spring:
 
 This route matches if the remote address of the request was, for example, `192.168.1.10`.
 
-=== The Weight Route Predicate Factory
-
-The `Weight` route predicate factory takes two arguments: `group` and `weight` (an int). The weights are calculated per group.
-The following example configures a weight route predicate:
-
-.application.yml
-====
-[source,yaml]
-----
-spring:
-  cloud:
-    gateway:
-      routes:
-      - id: weight_high
-        uri: https://weighthigh.org
-        predicates:
-        - Weight=group1, 8
-      - id: weight_low
-        uri: https://weightlow.org
-        predicates:
-        - Weight=group1, 2
-----
-====
-
-This route would forward ~80% of traffic to https://weighthigh.org and ~20% of traffic to https://weighlow.org
-
 ==== Modifying the Way Remote Addresses Are Resolved
 
 By default, the RemoteAddr route predicate factory uses the remote address from the incoming request.
@@ -452,6 +426,32 @@ RemoteAddressResolver resolver = XForwardedRemoteAddressResolver
 )
 ----
 ====
+
+=== The Weight Route Predicate Factory
+
+The `Weight` route predicate factory takes two arguments: `group` and `weight` (an int). The weights are calculated per group.
+The following example configures a weight route predicate:
+
+.application.yml
+====
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: weight_high
+        uri: https://weighthigh.org
+        predicates:
+        - Weight=group1, 8
+      - id: weight_low
+        uri: https://weightlow.org
+        predicates:
+        - Weight=group1, 2
+----
+====
+
+This route would forward ~80% of traffic to https://weighthigh.org and ~20% of traffic to https://weighlow.org
 
 == `GatewayFilter` Factories
 


### PR DESCRIPTION
#### Problem

Currently the [Modifying the Way Remote Addresses Are Resolved](https://docs.spring.io/spring-cloud-gateway/docs/3.0.1/reference/html/#modifying-the-way-remote-addresses-are-resolved) paragraph is a subitem of unrelated [The Weight Route Predicate Factory](https://docs.spring.io/spring-cloud-gateway/docs/3.0.1/reference/html/#the-weight-route-predicate-factory) paragraph. It looks confusing:

![image](https://user-images.githubusercontent.com/12630412/122736106-daf92880-d2a9-11eb-8626-6ae14cc9d579.png)

#### Suggested solution
Exchange the positions of the aforementioned paragraphs so that the [Modifying the Way Remote Addresses Are Resolved](https://docs.spring.io/spring-cloud-gateway/docs/3.0.1/reference/html/#modifying-the-way-remote-addresses-are-resolved) becomes a subitem of logically connected [The RemoteAddr Route Predicate Factory](https://docs.spring.io/spring-cloud-gateway/docs/3.0.1/reference/html/#the-remoteaddr-route-predicate-factory).

No other changes were made.