### PR TITLE
Fix timer metric name in docs and test

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1856,7 +1856,9 @@ spring:
 
 === The Gateway Metrics Filter
 
-To enable gateway metrics, add spring-boot-starter-actuator as a project dependency. Then, by default, the gateway metrics filter runs as long as the property `spring.cloud.gateway.metrics.enabled` is not set to `false`. This filter adds a timer metric named `gateway.requests` with the following tags:
+To enable gateway metrics, add spring-boot-starter-actuator as a project dependency.
+Then, by default, the gateway metrics filter runs as long as the property `spring.cloud.gateway.metrics.enabled` is not set to `false`.
+This filter adds a timer metric named `spring.cloud.gateway.requests` with the following tags:
 
 * `routeId`: The route ID.
 * `routeUri`: The URI to which the API is routed.
@@ -1865,7 +1867,7 @@ To enable gateway metrics, add spring-boot-starter-actuator as a project depende
 * `httpStatusCode`: The HTTP Status of the request returned to the client.
 * `httpMethod`: The HTTP method used for the request.
 
-These metrics are then available to be scraped from `/actuator/metrics/gateway.requests` and can be easily integrated with Prometheus to create a link:images/gateway-grafana-dashboard.jpeg[Grafana] link:gateway-grafana-dashboard.json[dashboard].
+These metrics are then available to be scraped from `/actuator/metrics/spring.cloud.gateway.requests` and can be easily integrated with Prometheus to create a link:images/gateway-grafana-dashboard.jpeg[Grafana] link:gateway-grafana-dashboard.json[dashboard].
 
 NOTE: To enable the prometheus endpoint, add `micrometer-registry-prometheus` as a project dependency.
 

--- a/spring-cloud-gateway-sample/src/main/java/org/springframework/cloud/gateway/sample/GatewaySampleApplication.java
+++ b/spring-cloud-gateway-sample/src/main/java/org/springframework/cloud/gateway/sample/GatewaySampleApplication.java
@@ -44,7 +44,7 @@ import org.springframework.web.reactive.function.server.ServerResponse;
 @Import(AdditionalRoutesImportSelector.class)
 public class GatewaySampleApplication {
 
-	public static final String HELLO_FROM_FAKE_ACTUATOR_METRICS_GATEWAY_REQUESTS = "hello from fake /actuator/metrics/gateway.requests";
+	public static final String HELLO_FROM_FAKE_ACTUATOR_METRICS_GATEWAY_REQUESTS = "hello from fake /actuator/metrics/spring.cloud.gateway.requests";
 
 	@Value("${test.uri:http://httpbin.org:80}")
 	String uri;
@@ -165,7 +165,7 @@ public class GatewaySampleApplication {
 	@Bean
 	public RouterFunction<ServerResponse> testWhenMetricPathIsNotMeet() {
 		RouterFunction<ServerResponse> route = RouterFunctions
-				.route(RequestPredicates.path("/actuator/metrics/gateway.requests"), request -> ServerResponse.ok()
+				.route(RequestPredicates.path("/actuator/metrics/spring.cloud.gateway.requests"), request -> ServerResponse.ok()
 						.body(BodyInserters.fromValue(HELLO_FROM_FAKE_ACTUATOR_METRICS_GATEWAY_REQUESTS)));
 		return route;
 	}

--- a/spring-cloud-gateway-sample/src/test/java/org/springframework/cloud/gateway/sample/GatewaySampleApplicationWithoutMetricsTests.java
+++ b/spring-cloud-gateway-sample/src/test/java/org/springframework/cloud/gateway/sample/GatewaySampleApplicationWithoutMetricsTests.java
@@ -71,7 +71,7 @@ public class GatewaySampleApplicationWithoutMetricsTests {
 	public void actuatorMetrics() {
 		init(TestConfig.class);
 		webClient.get().uri("/get").exchange().expectStatus().isOk();
-		webClient.get().uri("http://localhost:" + port + "/actuator/metrics/gateway.requests").exchange().expectStatus()
+		webClient.get().uri("http://localhost:" + port + "/actuator/metrics/spring.cloud.gateway.requests").exchange().expectStatus()
 				.isOk().expectBody(String.class)
 				.isEqualTo(GatewaySampleApplication.HELLO_FROM_FAKE_ACTUATOR_METRICS_GATEWAY_REQUESTS);
 	}


### PR DESCRIPTION
I update also the reference in `GatewaySampleApplicationWithoutMetricsTests`, but I don't see much value on it since the url pattern is set in `GatewaySampleApplication` and is not actually calling the actuator metrics.

rel #2273