### PR TITLE
refactor: Polish `@RequestMapping` annotations

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilterTests.java
@@ -38,7 +38,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -122,7 +122,7 @@ public class GatewayMetricsFilterTests extends BaseWebClientTests {
 					.build();
 		}
 
-		@RequestMapping("/httpbin/badtargeturi")
+		@GetMapping("/httpbin/badtargeturi")
 		public String exception() {
 			throw new RuntimeException("an error");
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactoryIntegrationTests.java
@@ -54,8 +54,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -215,7 +215,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 		@Value("${test.uri}")
 		private String uri;
 
-		@RequestMapping("/httpbin/sleep")
+		@GetMapping("/httpbin/sleep")
 		public Mono<ResponseEntity<String>> sleep(@RequestParam("key") String key,
 				@RequestParam("millis") long millisToSleep) {
 			AtomicInteger num = getCount(key);
@@ -225,7 +225,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 					.header("X-Retry-Count", String.valueOf(retryCount)).body("slept " + millisToSleep + " ms"));
 		}
 
-		@RequestMapping("/httpbin/retryalwaysfail")
+		@GetMapping("/httpbin/retryalwaysfail")
 		public ResponseEntity<String> retryalwaysfail(@RequestParam("key") String key,
 				@RequestParam(name = "count", defaultValue = "3") int count) {
 			AtomicInteger num = getCount(key);
@@ -235,7 +235,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 					.body("permanently broken");
 		}
 
-		@RequestMapping("/httpbin/retrypost")
+		@GetMapping("/httpbin/retrypost")
 		public ResponseEntity<String> retrypost(@RequestParam("key") String key,
 				@RequestParam(name = "count", defaultValue = "3") int count,
 				@RequestParam("expectedbody") String expectedbody, @RequestBody String body) {
@@ -248,7 +248,7 @@ public class RetryGatewayFilterFactoryIntegrationTests extends BaseWebClientTest
 			return response;
 		}
 
-		@RequestMapping("/httpbin/retry")
+		@GetMapping("/httpbin/retry")
 		public ResponseEntity<String> retry(@RequestParam("key") String key,
 				@RequestParam(name = "count", defaultValue = "3") int count,
 				@RequestParam(name = "failStatus", required = false) Integer failStatus) {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.server.RouterFunction;
@@ -62,27 +62,27 @@ public class SpringCloudCircuitBreakerTestConfig {
 	@Value("${test.uri}")
 	private String uri;
 
-	@RequestMapping("/circuitbreakerFallbackController")
+	@GetMapping("/circuitbreakerFallbackController")
 	public Map<String, String> fallbackcontroller(@RequestParam("a") String a) {
 		return Collections.singletonMap("from", "circuitbreakerfallbackcontroller");
 	}
 
-	@RequestMapping("/circuitbreakerFallbackController2")
+	@GetMapping("/circuitbreakerFallbackController2")
 	public Map<String, String> fallbackcontroller2() {
 		return Collections.singletonMap("from", "circuitbreakerfallbackcontroller2");
 	}
 
-	@RequestMapping("/circuitbreakerFallbackController3")
+	@GetMapping("/circuitbreakerFallbackController3")
 	public Map<String, String> fallbackcontroller3() {
 		return Collections.singletonMap("from", "circuitbreakerfallbackcontroller3");
 	}
 
-	@RequestMapping("/statusCodeFallbackController")
+	@GetMapping("/statusCodeFallbackController")
 	public Map<String, String> statusCodeFallbackController(ServerWebExchange exchange) {
 		return Collections.singletonMap("from", "statusCodeFallbackController");
 	}
 
-	@RequestMapping("/resetExchangeFallbackController")
+	@GetMapping("/resetExchangeFallbackController")
 	public ResponseEntity<Map<String, String>> resetExchangeFallbackController(ServerWebExchange exchange) {
 		return ResponseEntity.status(HttpStatus.OK)
 				.headers((HttpHeaders) exchange.getRequest().getHeaders().entrySet().stream()

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/PrincipalNameKeyResolverIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/PrincipalNameKeyResolverIntegrationTests.java
@@ -46,6 +46,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.util.SocketUtils;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -96,7 +97,7 @@ public class PrincipalNameKeyResolverIntegrationTests {
 		@Value("${server.port}")
 		private int port;
 
-		@RequestMapping("/myapi/{id}")
+		@GetMapping("/myapi/{id}")
 		public Map<String, String> myapi(@PathVariable String id, Principal principal) {
 			return Collections.singletonMap(principal.getName(), id);
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/ForwardTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/ForwardTests.java
@@ -32,7 +32,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.reactive.server.WebTestClient;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -72,7 +72,7 @@ public class ForwardTests {
 	@Import(PermitAllSecurityConfiguration.class)
 	public static class TestConfig {
 
-		@RequestMapping("/httpbin/localcontroller")
+		@GetMapping("/httpbin/localcontroller")
 		public Map<String, String> localController() {
 			return Collections.singletonMap("from", "localcontroller");
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/GatewayIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/GatewayIntegrationTests.java
@@ -51,7 +51,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -177,7 +177,7 @@ public class GatewayIntegrationTests extends BaseWebClientTests {
 			return Mono.empty();
 		}
 
-		@RequestMapping("/httpbin/nocontenttype")
+		@GetMapping("/httpbin/nocontenttype")
 		public ResponseEntity<Void> nocontenttype() {
 			return ResponseEntity.status(204).build();
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
@@ -45,7 +45,10 @@ import org.springframework.http.codec.multipart.Part;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -60,7 +63,7 @@ public class HttpBinCompatibleController {
 
 	private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
-	@RequestMapping("/")
+	@GetMapping("/")
 	public String home() {
 		return "httpbin compatible home";
 	}
@@ -73,7 +76,7 @@ public class HttpBinCompatibleController {
 		return result;
 	}
 
-	@RequestMapping(path = "/headers", method = RequestMethod.PATCH)
+	@PatchMapping("/headers")
 	public ResponseEntity<Map<String, Object>> headersPatch(ServerWebExchange exchange,
 			@RequestBody Map<String, String> headersToAdd) {
 		Map<String, Object> result = new HashMap<>();
@@ -92,19 +95,19 @@ public class HttpBinCompatibleController {
 		return result;
 	}
 
-	@RequestMapping(path = "/delay/{sec}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = "/delay/{sec}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<Map<String, Object>> get(ServerWebExchange exchange, @PathVariable int sec)
 			throws InterruptedException {
 		int delay = Math.min(sec, 10);
 		return Mono.just(get(exchange)).delayElement(Duration.ofSeconds(delay));
 	}
 
-	@RequestMapping(path = "/anything/{anything}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = "/anything/{anything}", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Map<String, Object> anything(ServerWebExchange exchange, @PathVariable(required = false) String anything) {
 		return get(exchange);
 	}
 
-	@RequestMapping(path = "/get", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = "/get", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Map<String, Object> get(ServerWebExchange exchange) {
 		if (log.isDebugEnabled()) {
 			log.debug("httpbin /get");
@@ -119,7 +122,7 @@ public class HttpBinCompatibleController {
 		return result;
 	}
 
-	@RequestMapping(value = "/post", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+	@GetMapping(value = "/post", consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<Map<String, Object>> postFormData(@RequestBody Mono<MultiValueMap<String, Part>> parts) {
 		// StringDecoder decoder = StringDecoder.allMimeTypes(true);
@@ -133,13 +136,13 @@ public class HttpBinCompatibleController {
 				}).map(files -> Collections.singletonMap("files", files));
 	}
 
-	@RequestMapping(path = "/post", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+	@GetMapping(path = "/post", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<Map<String, Object>> postUrlEncoded(ServerWebExchange exchange) throws IOException {
 		return post(exchange, null);
 	}
 
-	@RequestMapping(path = "/post", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PostMapping(path = "/post", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<Map<String, Object>> post(ServerWebExchange exchange, @RequestBody(required = false) String body)
 			throws IOException {
 		HashMap<String, Object> ret = new HashMap<>();
@@ -158,7 +161,7 @@ public class HttpBinCompatibleController {
 		});
 	}
 
-	@RequestMapping("/status/{status}")
+	@GetMapping("/status/{status}")
 	public ResponseEntity<String> status(@PathVariable int status) {
 		return ResponseEntity.status(status).body("Failed with " + status);
 	}
@@ -174,12 +177,12 @@ public class HttpBinCompatibleController {
 		return ResponseEntity.status(status).headers(httpHeaders).body(Collections.singletonMap("status", status));
 	}
 
-	@RequestMapping(path = "/post/empty", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+	@PostMapping(path = "/post/empty", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<String> emptyResponse() {
 		return Mono.empty();
 	}
 
-	@RequestMapping(path = "/gzip", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = "/gzip", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<Void> gzip(ServerWebExchange exchange) throws IOException {
 		if (log.isDebugEnabled()) {
 			log.debug("httpbin /gzip");

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpStatusTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpStatusTests.java
@@ -31,7 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -85,7 +85,7 @@ public class HttpStatusTests extends BaseWebClientTests {
 	@Import(DefaultTestConfig.class)
 	public static class TestConfig {
 
-		@RequestMapping("/httpbin/exception")
+		@GetMapping("/httpbin/exception")
 		public String exception() {
 			throw new RuntimeException("an error");
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/sse/SseIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/sse/SseIntegrationTests.java
@@ -44,7 +44,7 @@ import org.springframework.core.ResolvableType;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.http.server.reactive.HttpHandler;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.web.reactive.config.EnableWebFlux;
@@ -189,17 +189,17 @@ public class SseIntegrationTests {
 
 		private static final Flux<Long> INTERVAL = interval(Duration.ofMillis(100), 50);
 
-		@RequestMapping("/sse/string")
+		@GetMapping("/sse/string")
 		Flux<String> string() {
 			return INTERVAL.map(l -> "foo " + l);
 		}
 
-		@RequestMapping("/sse/person")
+		@GetMapping("/sse/person")
 		Flux<Person> person() {
 			return INTERVAL.map(l -> new Person("foo " + l));
 		}
 
-		@RequestMapping("/sse/event")
+		@GetMapping("/sse/event")
 		Flux<ServerSentEvent<String>> sse() {
 			return INTERVAL.map(l -> ServerSentEvent.builder("foo").id(Long.toString(l)).comment("bar").build());
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/ssl/SingleCertSSLTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/ssl/SingleCertSSLTests.java
@@ -36,7 +36,7 @@ import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
@@ -71,7 +71,7 @@ public class SingleCertSSLTests extends BaseWebClientTests {
 	@RestController
 	public static class TestConfig {
 
-		@RequestMapping("/httpbin/ssltrust")
+		@GetMapping("/httpbin/ssltrust")
 		public ResponseEntity<Void> nocontenttype() {
 			return ResponseEntity.status(204).build();
 		}


### PR DESCRIPTION
Co-authored-by: Moderne <team@moderne.io>

Polish the use of `@RequestMapping` to use the more specific HTTP verb.