### PR TITLE
Fix ConcurrentModificationException

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepository.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepository.java
@@ -58,7 +58,8 @@ public class InMemoryRouteDefinitionRepository implements RouteDefinitionReposit
 
 	@Override
 	public Flux<RouteDefinition> getRouteDefinitions() {
-		return Flux.fromIterable(routes.values());
+		Map<String, RouteDefinition> routesSafeCopy = new LinkedHashMap<>(routes);
+		return Flux.fromIterable(routesSafeCopy.values());
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
@@ -47,17 +47,14 @@ public class InMemoryRouteDefinitionRepositoryTests {
 
 		Mono<Void> createAnotherRoute = repository.save(createRoute("bar"));
 
-		StepVerifier.withVirtualTime(() -> readRoutesWithDelay)
-				.expectSubscription().expectNextCount(1)
-				.then(createAnotherRoute::subscribe)
-				.thenAwait().expectNextCount(2).verifyComplete();
+		StepVerifier.withVirtualTime(() -> readRoutesWithDelay).expectSubscription().expectNextCount(1)
+				.then(createAnotherRoute::subscribe).thenAwait().expectNextCount(2).verifyComplete();
 	}
 
 	@Test
 	public void shouldCreateRoute() {
 		Mono<RouteDefinition> emptyRoute = Mono.just(new RouteDefinition());
-		StepVerifier.create(repository.save(emptyRoute))
-				.verifyError(IllegalArgumentException.class);
+		StepVerifier.create(repository.save(emptyRoute)).verifyError(IllegalArgumentException.class);
 	}
 
 	@Test

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
@@ -59,7 +59,7 @@ public class InMemoryRouteDefinitionRepositoryTests {
 
 	@Test
 	public void shouldCreateRoute() {
-		StepVerifier.create(repository.save(createRoute("foo"))).expectComplete().verify();
+		StepVerifier.create(repository.save(createRoute("foo"))).verifyComplete();
 
 		StepVerifier.create(repository.getRouteDefinitions()).expectNextCount(1).verifyComplete();
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
@@ -52,13 +52,13 @@ public class InMemoryRouteDefinitionRepositoryTests {
 	}
 
 	@Test
-	public void shouldCreateRoute() {
+	public void shouldValidateRouteIdOnCreate() {
 		Mono<RouteDefinition> emptyRoute = Mono.just(new RouteDefinition());
 		StepVerifier.create(repository.save(emptyRoute)).verifyError(IllegalArgumentException.class);
 	}
 
 	@Test
-	public void shouldValidateRouteIdOnCreate() {
+	public void shouldCreateRoute() {
 		StepVerifier.create(repository.save(createRoute("foo"))).expectComplete().verify();
 
 		StepVerifier.create(repository.getRouteDefinitions()).expectNextCount(1).verifyComplete();

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/InMemoryRouteDefinitionRepositoryTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.route;
+
+import java.time.Duration;
+
+import org.junit.Before;
+import org.junit.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class InMemoryRouteDefinitionRepositoryTests {
+
+	private InMemoryRouteDefinitionRepository repository;
+
+	@Before
+	public void setUp() throws Exception {
+		repository = new InMemoryRouteDefinitionRepository();
+	}
+
+	@Test
+	public void shouldProtectRoutesAgainstConcurrentModificationException() {
+		Flux<Void> createRoutes = Flux.just(createRoute("foo1"), createRoute("foo2"), createRoute("foo3"))
+				.flatMap(repository::save);
+
+		StepVerifier.create(createRoutes).verifyComplete();
+
+		Flux<RouteDefinition> readRoutesWithDelay = repository.getRouteDefinitions()
+				.delayElements(Duration.ofMillis(100));
+
+		Mono<Void> createAnotherRoute = repository.save(createRoute("bar"));
+
+		StepVerifier.withVirtualTime(() -> readRoutesWithDelay).expectSubscription().expectNextCount(1)
+				.then(createAnotherRoute::subscribe).thenAwait().expectNextCount(2).verifyComplete();
+	}
+
+	private Mono<RouteDefinition> createRoute(String id) {
+		RouteDefinition routeDefinition = new RouteDefinition();
+		routeDefinition.setId(id);
+		return Mono.just(routeDefinition);
+	}
+
+}


### PR DESCRIPTION
Fix ConcurrentModificationException in routes from InMemoryRouteDefinitionRepository.

With `routesSafeCopy` the iterators in progress are not affected by routes changes. And the map insertion order is preserved.

Fixes gh-2120