### PR TITLE
Fix typo in document

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -2607,7 +2607,7 @@ In order to write a Route Predicate you will need to implement `RoutePredicateFa
 .MyRoutePredicateFactory.java
 [source,java]
 ----
-public class MyRoutePredicateFactory extends AbstractRoutePredicateFactory<HeaderRoutePredicateFactory.Config> {
+public class MyRoutePredicateFactory extends AbstractRoutePredicateFactory<MyRoutePredicateFactory.Config> {
 
     public MyRoutePredicateFactory() {
         super(Config.class);


### PR DESCRIPTION
Using `HeaderRoutePredicateFactory.Config` type in `MyRoutePredicateFactory.java` maybe typo.
`MyRoutePredicateFactory.Config` is right?