### PR TITLE
Redis Test Container fix for GH_2314

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayRedisAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayRedisAutoConfigurationTests.java
@@ -18,8 +18,6 @@ package org.springframework.cloud.gateway.config;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -109,28 +107,6 @@ public class GatewayRedisAutoConfigurationTests {
 		@Test
 		public void redisRouteDefinitionRepository() {
 			assertThat(redisRouteDefinitionRepository).isNull();
-		}
-
-	}
-
-	/**
-	 * @author Dennis Menge
-	 */
-	@Nested
-	@SpringBootTest(classes = GatewayRedisAutoConfigurationTests.Config.class,
-			properties = "spring.cloud.gateway.redis-route-definition-repository.enabled=true")
-	@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
-	class RedisRouteDefinitionRepositoryEnabledByProperty {
-
-		@Container
-		public GenericContainer redis = new GenericContainer<>("redis:5.0.9-alpine").withExposedPorts(6379);
-
-		@Autowired(required = false)
-		private RedisRouteDefinitionRepository redisRouteDefinitionRepository;
-
-		@Test
-		public void redisRouteDefinitionRepository() {
-			assertThat(redisRouteDefinitionRepository).isNotNull();
 		}
 
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayRedisRouteDefinitionRepositoryEnabledByPropertyTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayRedisRouteDefinitionRepositoryEnabledByPropertyTests.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.config;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.cloud.gateway.route.RedisRouteDefinitionRepository;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = GatewayRedisAutoConfigurationTests.Config.class,
+		properties = "spring.cloud.gateway.redis-route-definition-repository.enabled=true")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@Testcontainers
+@ContextConfiguration(
+		initializers = GatewayRedisRouteDefinitionRepositoryEnabledByPropertyTests.RedisDbInitializer.class)
+public class GatewayRedisRouteDefinitionRepositoryEnabledByPropertyTests {
+
+	@Container
+	public static GenericContainer redis = new GenericContainer<>("redis:5.0.9-alpine").withExposedPorts(6379);
+
+	@Autowired(required = false)
+	private RedisRouteDefinitionRepository redisRouteDefinitionRepository;
+
+	@BeforeAll
+	public static void startRedisContainer() {
+		redis.start();
+	}
+
+	@Test
+	public void redisRouteDefinitionRepository() {
+		assertThat(redisRouteDefinitionRepository).isNotNull();
+	}
+
+	public static class RedisDbInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
+		@Override
+		public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+			TestPropertyValues values = TestPropertyValues.of("spring.redis.port=" + redis.getFirstMappedPort());
+			values.applyTo(configurableApplicationContext);
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
@@ -177,8 +177,7 @@ public class RedisRouteDefinitionRepositoryTests {
 
 		@Override
 		public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-			TestPropertyValues values = TestPropertyValues.of("spring.redis.host=" + redis.getHost(),
-					"spring.redis.port=" + redis.getFirstMappedPort());
+			TestPropertyValues values = TestPropertyValues.of("spring.redis.port=" + redis.getFirstMappedPort());
 			values.applyTo(configurableApplicationContext);
 		}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
@@ -52,7 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Dennis Menge
  */
-@SpringBootTest(properties = { "debug=true", "logging.level.org.springframework.cloud.gateway=trace" })
+@SpringBootTest(properties = {"debug=true", "logging.level.org.springframework.cloud.gateway=trace"})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @ActiveProfiles("redis-route-repository")
 @Testcontainers

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -175,13 +174,14 @@ public class RedisRouteDefinitionRepositoryTests {
 	}
 
 	public static class RedisDbInitializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+
 		@Override
 		public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
-			TestPropertyValues values = TestPropertyValues.of(
-					"spring.redis.host="+redis.getHost(),
-					"spring.redis.port="+redis.getFirstMappedPort()
-			);
+			TestPropertyValues values = TestPropertyValues.of("spring.redis.host=" + redis.getHost(),
+					"spring.redis.port=" + redis.getFirstMappedPort());
 			values.applyTo(configurableApplicationContext);
 		}
+
 	}
+
 }


### PR DESCRIPTION
Added a new ApplicationContextInitializer to set the mapped port exposed by the test container.

Fixes gh-2314