### PR TITLE
Fix the inaccurate rate limit when the node time is different in the multi-node scenario

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gateway.filter.ratelimit;
 
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -250,8 +249,7 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 			List<String> keys = getKeys(id);
 
 			// The arguments to the LUA script. time() returns unixtime in seconds.
-			List<String> scriptArgs = Arrays.asList(replenishRate + "", burstCapacity + "",
-					Instant.now().getEpochSecond() + "", requestedTokens + "");
+			List<String> scriptArgs = Arrays.asList(replenishRate + "", burstCapacity + "", "", requestedTokens + "");
 			// allowed, tokens_left = redis.eval(SCRIPT, keys, args)
 			Flux<List<Long>> flux = this.redisTemplate.execute(this.script, keys, scriptArgs);
 			// .log("redisratelimiter", Level.FINER);

--- a/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
+++ b/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
@@ -4,7 +4,7 @@ local timestamp_key = KEYS[2]
 
 local rate = tonumber(ARGV[1])
 local capacity = tonumber(ARGV[2])
-local now = tonumber(ARGV[3])
+local now = redis.call('TIME')[1]
 local requested = tonumber(ARGV[4])
 
 local fill_time = capacity/rate
@@ -12,7 +12,7 @@ local ttl = math.floor(fill_time*2)
 
 --redis.log(redis.LOG_WARNING, "rate " .. ARGV[1])
 --redis.log(redis.LOG_WARNING, "capacity " .. ARGV[2])
---redis.log(redis.LOG_WARNING, "now " .. ARGV[3])
+--redis.log(redis.LOG_WARNING, "now " .. now)
 --redis.log(redis.LOG_WARNING, "requested " .. ARGV[4])
 --redis.log(redis.LOG_WARNING, "filltime " .. fill_time)
 --redis.log(redis.LOG_WARNING, "ttl " .. ttl)

--- a/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
+++ b/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
@@ -1,3 +1,5 @@
+redis.replicate_commands()
+
 local tokens_key = KEYS[1]
 local timestamp_key = KEYS[2]
 --redis.log(redis.LOG_WARNING, "tokens_key " .. tokens_key)


### PR DESCRIPTION
We deployed 10 gateway nodes in production, and the rate limit tokens was inaccurate during the recent stress test.

Through tcp packet capture and reading lua script, it is found that when redis receives an old time command, it will fill the token unexpectedly, which often occurs in our production environment.

Under multiple gateway nodes , the time of all nodes cannot be guaranteed to be consistent, and the redis connection line cannot be guaranteed to be smooth. I think the refresh token time of script should be based on redis time.

refer issue #2412
