### PR TITLE
Fix RedisRateLimiter replenishRate and burstCapacity when using incorrect configuration 

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
@@ -315,8 +315,6 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		@Min(1)
 		private int replenishRate;
 
-		private int originalReplenishRate;
-
 		@Min(0)
 		private int burstCapacity = 1;
 
@@ -328,13 +326,7 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		}
 
 		public Config setReplenishRate(int replenishRate) {
-			if (replenishRate <= 2) {
-				this.replenishRate = replenishRate;
-			}
-			else {
-				this.originalReplenishRate = replenishRate;
-				this.replenishRate = Math.min(this.burstCapacity, replenishRate);
-			}
+			this.replenishRate = replenishRate;
 			return this;
 		}
 
@@ -343,8 +335,8 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		}
 
 		public Config setBurstCapacity(int burstCapacity) {
-			if (this.originalReplenishRate > 2) {
-				this.replenishRate = Math.min(this.originalReplenishRate, burstCapacity);
+			if (this.replenishRate > 2 && this.replenishRate > burstCapacity) {
+				throw new IllegalStateException("BurstCapacity must be higher or equal than replenishRate");
 			}
 			this.burstCapacity = burstCapacity;
 			return this;

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
@@ -315,6 +315,8 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		@Min(1)
 		private int replenishRate;
 
+		private int originalReplenishRate;
+
 		@Min(0)
 		private int burstCapacity = 1;
 
@@ -326,7 +328,13 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		}
 
 		public Config setReplenishRate(int replenishRate) {
-			this.replenishRate = replenishRate;
+			if (replenishRate <= 2) {
+				this.replenishRate = replenishRate;
+			}
+			else {
+				this.originalReplenishRate = replenishRate;
+				this.replenishRate = Math.min(this.burstCapacity, replenishRate);
+			}
 			return this;
 		}
 
@@ -335,6 +343,9 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 		}
 
 		public Config setBurstCapacity(int burstCapacity) {
+			if (this.originalReplenishRate > 2) {
+				this.replenishRate = Math.min(this.originalReplenishRate, burstCapacity);
+			}
 			this.burstCapacity = burstCapacity;
 			return this;
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.ratelimit;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,6 +54,15 @@ public class RedisRateLimiterConfigTests {
 	public void init() {
 		// prime routes since getRoutes() no longer blocks
 		routeLocator.getRoutes().collectList().block();
+	}
+
+	@Test
+	public void replenishRateShouldBeEqualToBurstCapacityWhenReplenishRateIsHigherThanBurstCapacity() {
+		RedisRateLimiter redisRateLimiter = new RedisRateLimiter(10, 5);
+		int replenishRate = redisRateLimiter.getDefaultConfig().getReplenishRate();
+		int burstCapacity = redisRateLimiter.getDefaultConfig().getBurstCapacity();
+		Assert.assertEquals(5, burstCapacity);
+		Assert.assertEquals(5, replenishRate);
 	}
 
 	@Test

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
@@ -57,12 +57,10 @@ public class RedisRateLimiterConfigTests {
 	}
 
 	@Test
-	public void replenishRateShouldBeEqualToBurstCapacityWhenReplenishRateIsHigherThanBurstCapacity() {
-		RedisRateLimiter redisRateLimiter = new RedisRateLimiter(10, 5);
-		int replenishRate = redisRateLimiter.getDefaultConfig().getReplenishRate();
-		int burstCapacity = redisRateLimiter.getDefaultConfig().getBurstCapacity();
-		Assert.assertEquals(5, burstCapacity);
-		Assert.assertEquals(5, replenishRate);
+	public void shouldThrowAnErrorWhenReplenishRateIsHigherThanBurstCapacity() {
+		Assert.assertThrows(IllegalStateException.class, () -> {
+			new RedisRateLimiter(10, 5);
+		});
 	}
 
 	@Test


### PR DESCRIPTION
When using RedisRateLimiter with the following configuration:
 - ReplenishRate > 2
 - BurstCapacity < ReplenishRate 

So for example (3, 1), the Lua script will not save anything on Redis and therefore there won't be any rate limit, i.e. all request will succeed.

This problem is caused because of the following lines on the Lua script:

local fill_time = capacity/rate
local ttl = math.floor(fill_time*2)

For instance, if we have rate = 3 and capacity = 1:
	fill_time would be 0.333
	ttl would be 0

And at the end of the script, these are the lines that actually save something in Redis:

if ttl > 0 then
  redis.call("setex", tokens_key, ttl, new_tokens)
  redis.call("setex", timestamp_key, ttl, now)
end

One simple fix could be making replenishRate = burstCapacity when replenishRate > burstCapacity (and replenishRate > 2 as the minimal viable config could be 2 and 1).
Normally a user would always use burstCapacity >= replenishRate but if by mistake they set it as replenishRate > burstCapacity then what they would have is a rate limiter that actually does not limit anything.