### PR TITLE
Replace keys with scan when get routeDefinitions and fix null pointer exception when filters are null

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepository.java
@@ -24,10 +24,12 @@ import reactor.core.publisher.Mono;
 import org.springframework.cloud.gateway.support.NotFoundException;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.data.redis.core.ReactiveValueOperations;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.stereotype.Repository;
 
 /**
  * @author Dennis Menge
+ * @author lzhpo
  */
 @Repository
 public class RedisRouteDefinitionRepository implements RouteDefinitionRepository {
@@ -50,7 +52,8 @@ public class RedisRouteDefinitionRepository implements RouteDefinitionRepository
 
 	@Override
 	public Flux<RouteDefinition> getRouteDefinitions() {
-		return reactiveRedisTemplate.keys(createKey("*")).flatMap(key -> reactiveRedisTemplate.opsForValue().get(key))
+		return reactiveRedisTemplate.scan(ScanOptions.scanOptions().match(createKey("*")).build())
+				.flatMap(key -> reactiveRedisTemplate.opsForValue().get(key))
 				.onErrorContinue((throwable, routeDefinition) -> {
 					if (log.isErrorEnabled()) {
 						log.error("get routes from redis error cause : {}", throwable.toString(), throwable);

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/RouteDefinitionRouteLocator.java
@@ -40,6 +40,7 @@ import org.springframework.cloud.gateway.support.ConfigurationService;
 import org.springframework.cloud.gateway.support.HasRouteId;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -172,8 +173,9 @@ public class RouteDefinitionRouteLocator implements RouteLocator {
 					new ArrayList<>(this.gatewayProperties.getDefaultFilters())));
 		}
 
-		if (!routeDefinition.getFilters().isEmpty()) {
-			filters.addAll(loadGatewayFilters(routeDefinition.getId(), new ArrayList<>(routeDefinition.getFilters())));
+		final List<FilterDefinition> definitionFilters = routeDefinition.getFilters();
+		if (!CollectionUtils.isEmpty(definitionFilters)) {
+			filters.addAll(loadGatewayFilters(routeDefinition.getId(), definitionFilters));
 		}
 
 		AnnotationAwareOrderComparator.sort(filters);


### PR DESCRIPTION
## 1. Replace keys with scan when get routeDefinitions.
[Warnings in the official Redis documentation](https://redis.io/commands/keys#:~:text=Warning%3A%20consider%20KEYS,SCAN%20or%20sets.)
<img width="777" alt="Redis官方文档警告keys命令危险" src="https://user-images.githubusercontent.com/42663571/147869066-b221ad6f-8509-47f9-b0e8-fa6ee6309b7b.png">

`ReactiveKeyCommands`'s recommend
<img width="1194" alt="ReactiveKeyCommands建议使用scan代替keys" src="https://user-images.githubusercontent.com/42663571/147869077-1d0709af-6fff-4979-9847-44295cfc8bf3.png">

## 2. Fix null pointer exception when filters are null
<img width="1425" alt="routeDefinition getFilters() isEmpty()" src="https://user-images.githubusercontent.com/42663571/147869109-dd221e83-8366-4226-937d-a0cea55e5aee.png">
