### PR TITLE
SecureHeadersGatewayFilterFactory not populating headers to response correctly after v3.0.4

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -92,40 +92,40 @@ public class SecureHeadersGatewayFilterFactory
 				List<String> disabled = properties.getDisable();
 				Config config = originalConfig.withDefaults(properties);
 
-				return chain.filter(exchange).then(Mono.fromRunnable(() -> {
-					if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
-						headers.addIfAbsent(X_XSS_PROTECTION_HEADER, config.getXssProtectionHeader());
-					}
+				if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
+					headers.addIfAbsent(X_XSS_PROTECTION_HEADER, config.getXssProtectionHeader());
+				}
 
-					if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
-						headers.addIfAbsent(STRICT_TRANSPORT_SECURITY_HEADER, config.getStrictTransportSecurity());
-					}
+				if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
+					headers.addIfAbsent(STRICT_TRANSPORT_SECURITY_HEADER, config.getStrictTransportSecurity());
+				}
 
-					if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
-						headers.addIfAbsent(X_FRAME_OPTIONS_HEADER, config.getFrameOptions());
-					}
+				if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
+					headers.addIfAbsent(X_FRAME_OPTIONS_HEADER, config.getFrameOptions());
+				}
 
-					if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
-						headers.addIfAbsent(X_CONTENT_TYPE_OPTIONS_HEADER, config.getContentTypeOptions());
-					}
+				if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
+					headers.addIfAbsent(X_CONTENT_TYPE_OPTIONS_HEADER, config.getContentTypeOptions());
+				}
 
-					if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
-						headers.addIfAbsent(REFERRER_POLICY_HEADER, config.getReferrerPolicy());
-					}
+				if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
+					headers.addIfAbsent(REFERRER_POLICY_HEADER, config.getReferrerPolicy());
+				}
 
-					if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
-						headers.addIfAbsent(CONTENT_SECURITY_POLICY_HEADER, config.getContentSecurityPolicy());
-					}
+				if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
+					headers.addIfAbsent(CONTENT_SECURITY_POLICY_HEADER, config.getContentSecurityPolicy());
+				}
 
-					if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
-						headers.addIfAbsent(X_DOWNLOAD_OPTIONS_HEADER, config.getDownloadOptions());
-					}
+				if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
+					headers.addIfAbsent(X_DOWNLOAD_OPTIONS_HEADER, config.getDownloadOptions());
+				}
 
-					if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
-						headers.addIfAbsent(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
-								config.getPermittedCrossDomainPolicies());
-					}
-				}));
+				if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
+					headers.addIfAbsent(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
+							config.getPermittedCrossDomainPolicies());
+				}
+
+				return chain.filter(exchange);
 			}
 
 			@Override


### PR DESCRIPTION
## Issue
https://github.com/spring-cloud/spring-cloud-gateway/issues/2499

## Description
- In spring-cloud-gateway v3.0.4, after commit <a href="https://github.com/spring-cloud/spring-cloud-gateway/commit/8044bb1d24a1f27667fd6a721d682304fa610673">8044bb1</a>, `SecureHeadersGatewayFilterFactory.apply(SecureHeadersGatewayFilterFactory.Config originalConfig) ` return a GatewayFilter which populate secure headers from configuration properties (i.e. application.yml) into `ServerHttpResponse.headers` in a asynchronous manner instead of populating secure headers synchronously (at v3.0.3).
```java
    public GatewayFilter apply(SecureHeadersGatewayFilterFactory.Config originalConfig) {
        return new GatewayFilter() {
            public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
                HttpHeaders headers = exchange.getResponse().getHeaders();
                List<String> disabled = SecureHeadersGatewayFilterFactory.this.properties.getDisable();
                SecureHeadersGatewayFilterFactory.Config config = originalConfig.withDefaults(SecureHeadersGatewayFilterFactory.this.properties);
                return chain.filter(exchange).then(Mono.fromRunnable(() -> {
                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "X-Xss-Protection")) {
                        headers.addIfAbsent("X-Xss-Protection", config.getXssProtectionHeader());
                    }

                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "Strict-Transport-Security")) {
                        headers.addIfAbsent("Strict-Transport-Security", config.getStrictTransportSecurity());
                    }

                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "X-Frame-Options")) {
                        headers.addIfAbsent("X-Frame-Options", config.getFrameOptions());
                    }

                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "X-Content-Type-Options")) {
                        headers.addIfAbsent("X-Content-Type-Options", config.getContentTypeOptions());
                    }

                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "Referrer-Policy")) {
                        headers.addIfAbsent("Referrer-Policy", config.getReferrerPolicy());
                    }

                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "Content-Security-Policy")) {
                        headers.addIfAbsent("Content-Security-Policy", config.getContentSecurityPolicy());
                    }

                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "X-Download-Options")) {
                        headers.addIfAbsent("X-Download-Options", config.getDownloadOptions());
                    }

                    if (SecureHeadersGatewayFilterFactory.this.isEnabled(disabled, "X-Permitted-Cross-Domain-Policies")) {
                        headers.addIfAbsent("X-Permitted-Cross-Domain-Policies", config.getPermittedCrossDomainPolicies());
                    }

                }));
            }

            public String toString() {
                return GatewayToStringStyler.filterToStringCreator(SecureHeadersGatewayFilterFactory.this).toString();
            }
        };
    }

```
- `FilteringWebHandler.handle(ServerWebExchange exchange)` call `GatewayFilter.filter(ServerWebExchange exchange, GatewayFilterChain chain)` to apply all gateway filters on the server web exchange using reactive streams

- Before the secure headers is populated into the ServerHttpResponse object, the main stream may have terminated  already so that secure headers are missing from the response returned by server.

## Suggestion to fix
Moving the headers operation outside the Mono:
```java
	@Override
	public GatewayFilter apply(Config originalConfig) {
		return new GatewayFilter() {
			@Override
			public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
				HttpHeaders headers = exchange.getResponse().getHeaders();

				List<String> disabled = properties.getDisable();
				Config config = originalConfig.withDefaults(properties);

				if (isEnabled(disabled, X_XSS_PROTECTION_HEADER)) {
					headers.addIfAbsent(X_XSS_PROTECTION_HEADER, config.getXssProtectionHeader());
				}

				if (isEnabled(disabled, STRICT_TRANSPORT_SECURITY_HEADER)) {
					headers.addIfAbsent(STRICT_TRANSPORT_SECURITY_HEADER, config.getStrictTransportSecurity());
				}

				if (isEnabled(disabled, X_FRAME_OPTIONS_HEADER)) {
					headers.addIfAbsent(X_FRAME_OPTIONS_HEADER, config.getFrameOptions());
				}

				if (isEnabled(disabled, X_CONTENT_TYPE_OPTIONS_HEADER)) {
					headers.addIfAbsent(X_CONTENT_TYPE_OPTIONS_HEADER, config.getContentTypeOptions());
				}

				if (isEnabled(disabled, REFERRER_POLICY_HEADER)) {
					headers.addIfAbsent(REFERRER_POLICY_HEADER, config.getReferrerPolicy());
				}

				if (isEnabled(disabled, CONTENT_SECURITY_POLICY_HEADER)) {
					headers.addIfAbsent(CONTENT_SECURITY_POLICY_HEADER, config.getContentSecurityPolicy());
				}

				if (isEnabled(disabled, X_DOWNLOAD_OPTIONS_HEADER)) {
					headers.addIfAbsent(X_DOWNLOAD_OPTIONS_HEADER, config.getDownloadOptions());
				}

				if (isEnabled(disabled, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)) {
					headers.addIfAbsent(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
							config.getPermittedCrossDomainPolicies());
				}

				return chain.filter(exchange);
			}

			@Override
			public String toString() {
				return filterToStringCreator(SecureHeadersGatewayFilterFactory.this).toString();
			}
		};
	}
```

