### PR TITLE
Fix example in SetStatusGatewayFilterFactory docs

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -1395,7 +1395,7 @@ spring:
       - id: setstatusstring_route
         uri: https://example.org
         filters:
-        - SetStatus=BAD_REQUEST
+        - SetStatus=UNAUTHORIZED
       - id: setstatusint_route
         uri: https://example.org
         filters:


### PR DESCRIPTION
Based on the line below the example `In either case, the HTTP status of the response is set to 401.`, I understand the text option should be `UNAUTHORIZED`....right? 🙄 