### PR TITLE
fix: Ignore the Upgrade Websocket request

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactory.java
@@ -89,6 +89,10 @@ public class DedupeResponseHeaderGatewayFilterFactory
 		return new GatewayFilter() {
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+				final List<String> connection = exchange.getRequest().getHeaders().getConnection();
+				if (!connection.isEmpty() && connection.contains("Upgrade")) {
+					return chain.filter(exchange);
+				}
 				return chain.filter(exchange)
 						.then(Mono.fromRunnable(() -> dedupe(exchange.getResponse().getHeaders(), config)));
 			}


### PR DESCRIPTION
```yaml
spring:
  cloud:
    gateway:
      globalcors:
        cors-configurations:
          '[/**]':
            allowedOriginPatterns: "*"
            allowedHeaders: "*"
            allowedMethods: "*"
            allowCredentials: true
      routes:
        - id: test-stomp-info
          uri: lb://test
          predicates:
            - Path=/test/ws/stomp/info/**
        - id: rbac-stomp
          uri: lb:ws://test
          predicates:
            - Path=/test/ws/stomp/**
        - id: rbac
          uri: lb://test
          predicates:
            - Path=/**
      default-filters:
        - AddResponseHeader=Access-Control-Allow-Origin, *
        - AddResponseHeader=Access-Control-Allow-Methods, *
        - AddResponseHeader=Access-Control-Allow-Headers, *
        - AddResponseHeader=Access-Control-Allow-Credentials, true
        - DedupeResponseHeader=Vary Access-Control-Allow-Origin Access-Control-Allow-Credentials, RETAIN_FIRST
```
When forwarding the Websocket request in the above configuration, the forwarding may fail due to the modification of the Header. In this case, the DedupeResponseHeader needs to ignore the processing of the Upgrade request