### PR TITLE
Add a method to nest boolean predicates

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/BooleanSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/BooleanSpec.java
@@ -115,6 +115,10 @@ public class BooleanSpec extends UriSpec {
 			return fn.apply(new NotOpSpec(this.routeBuilder, this.builder, this.operator));
 		}
 
+		public BooleanSpec nested(Function<PredicateSpec, BooleanSpec> fn) {
+			return fn.apply(new NestedOpSpec(this.routeBuilder, this.builder, this.operator));
+		}
+
 	}
 
 	public static class NotOpSpec extends BooleanOpSpec {
@@ -127,6 +131,19 @@ public class BooleanSpec extends UriSpec {
 		public BooleanSpec asyncPredicate(AsyncPredicate<ServerWebExchange> predicate) {
 			AsyncPredicate<ServerWebExchange> negated = this.routeBuilder.getPredicate().not(predicate);
 			return super.asyncPredicate(negated);
+		}
+
+	}
+
+	public static class NestedOpSpec extends BooleanOpSpec {
+
+		NestedOpSpec(Route.AsyncBuilder routeBuilder, RouteLocatorBuilder.Builder builder, Operator operator) {
+			super(routeBuilder, builder, operator);
+		}
+
+		@Override
+		public BooleanSpec asyncPredicate(AsyncPredicate<ServerWebExchange> predicate) {
+			return super.asyncPredicate(predicate);
 		}
 
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingIntegrationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingIntegrationTests.java
@@ -71,6 +71,18 @@ public class RoutePredicateHandlerMappingIntegrationTests extends BaseWebClientT
 				.isEqualTo("hasquery");
 	}
 
+	@Test
+	public void andNestedOrQuery1() {
+		testClient.get().uri("/andnestedquery?query1=hasquery1").exchange().expectBody(String.class)
+				.isEqualTo("hasquery1,notsupplied");
+	}
+
+	@Test
+	public void andNestedOrQuery2() {
+		testClient.get().uri("/andnestedquery?query2=hasquery2").exchange().expectBody(String.class)
+				.isEqualTo("notsupplied,hasquery2");
+	}
+
 	@EnableAutoConfiguration
 	@SpringBootConfiguration
 	@Import(DefaultTestConfig.class)
@@ -83,6 +95,12 @@ public class RoutePredicateHandlerMappingIntegrationTests extends BaseWebClientT
 		@GetMapping("/httpbin/andnotquery")
 		String andnotquery(@RequestParam(name = "myquery", defaultValue = "notsupplied") String myquery) {
 			return myquery;
+		}
+
+		@GetMapping("/httpbin/andnestedquery")
+		String andnotquery(@RequestParam(name = "query1", defaultValue = "notsupplied") String query1,
+				@RequestParam(name = "query2", defaultValue = "notsupplied") String query2) {
+			return query1 + "," + query2;
 		}
 
 		@GetMapping("/httpbin/hasquery")
@@ -98,6 +116,8 @@ public class RoutePredicateHandlerMappingIntegrationTests extends BaseWebClientT
 									.filters(f -> f.prefixPath("/httpbin")).uri(uri))
 					.route("and_not_has_myquery", r -> r.path("/andnotquery").and().query("myquery")
 							.filters(f -> f.setPath("/httpbin/hasquery")).uri(uri))
+					.route("and_nested_query1_or_query2", r -> r.path("/andnestedquery").and().nested(p -> p.query("query1").or().query("query2"))
+							.filters(f -> f.prefixPath("/httpbin")).uri(uri))
 					.build();
 		}
 


### PR DESCRIPTION
Spring Cloud Gateway supports complicated boolean predicates like:

    (query("a") || query("b")) && (host("x") || host("y))

But lacked a Java API to express this. This new method allows the above:

    r.query("a").or().query("b").and().nested(p ->
      p.host("x").or().host("y")
    )