### PR TITLE
Updating RemoveHopByHopHeadersFilter precedence

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/GRPCRequestHeadersFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/GRPCRequestHeadersFilter.java
@@ -55,7 +55,7 @@ public class GRPCRequestHeadersFilter implements HttpHeadersFilter, Ordered {
 
 	@Override
 	public int getOrder() {
-		return 0;
+		return Ordered.LOWEST_PRECEDENCE;
 	}
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
@@ -42,7 +42,7 @@ public class RemoveHopByHopHeadersFilter implements HttpHeadersFilter, Ordered {
 			// "content-length",
 			));
 
-	private int order = Ordered.LOWEST_PRECEDENCE;
+	private int order = Ordered.LOWEST_PRECEDENCE - 1;
 
 	private Set<String> headers = HEADERS_REMOVED_ON_REQUEST;
 


### PR DESCRIPTION
Even though for HTTP/1 the `RemoveHopByHopHeadersFilter` implementation is correct, there is a new exception in HTTP/2.
As per https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.2 the TE header must now be kept if we are in HTTP/2 and the value must be trailers for us.

Fixes #2602