### PR TITLE
Update documentation for path route predicate

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -301,7 +301,7 @@ The following example shows how to use the `get` method:
 ====
 [source,java]
 ----
-Map<String, String> uriVariables = ServerWebExchangeUtils.getPathPredicateVariables(exchange);
+Map<String, String> uriVariables = ServerWebExchangeUtils.getUriTemplateVariables(exchange);
 
 String segment = uriVariables.get("segment");
 ----


### PR DESCRIPTION
The documentation states that, in order to access path predicate variables, one should use the `getPathPredicateVariables` method of `ServerWebExchangeUtils`. However, this method seems to be non existent (see [java-doc](https://javadoc.io/doc/org.springframework.cloud/spring-cloud-gateway-core/2.2.0.RELEASE/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.html)).

I replaced the method name with the method `getUriTemplateVariables` which seems to be the correct one to get easy access to the path predicate variables.