### PR TITLE
Replace getContainerIpAddress by getHost

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayRedisRouteDefinitionRepositoryEnabledByPropertyTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayRedisRouteDefinitionRepositoryEnabledByPropertyTests.java
@@ -52,7 +52,7 @@ public class GatewayRedisRouteDefinitionRepositoryEnabledByPropertyTests {
 
 	@DynamicPropertySource
 	static void containerProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redis::getContainerIpAddress);
+		registry.add("spring.redis.host", redis::getHost);
 		registry.add("spring.redis.port", redis::getFirstMappedPort);
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -66,7 +66,7 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 
 	@DynamicPropertySource
 	static void containerProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redis::getContainerIpAddress);
+		registry.add("spring.redis.host", redis::getHost);
 		registry.add("spring.redis.port", redis::getFirstMappedPort);
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/RedisRouteDefinitionRepositoryTests.java
@@ -71,7 +71,7 @@ public class RedisRouteDefinitionRepositoryTests {
 
 	@DynamicPropertySource
 	static void containerProperties(DynamicPropertyRegistry registry) {
-		registry.add("spring.redis.host", redis::getContainerIpAddress);
+		registry.add("spring.redis.host", redis::getHost);
 		registry.add("spring.redis.port", redis::getFirstMappedPort);
 	}
 


### PR DESCRIPTION
`getContainerIpAddress` is deprecated.
