### PR TITLE
Fix for ModifyResponseBodyGatewayFilter not setting up response content-type

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
@@ -40,6 +40,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.BodyInserter;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.ClientResponse;
@@ -233,6 +234,11 @@ public class ModifyResponseBodyGatewayFilterFactory
 						|| headers.containsKey(HttpHeaders.CONTENT_LENGTH)) {
 					messageBody = messageBody.doOnNext(data -> headers.setContentLength(data.readableByteCount()));
 				}
+
+				if (StringUtils.hasText(config.newContentType)) {
+					headers.set(HttpHeaders.CONTENT_TYPE, config.newContentType);
+				}
+
 				// TODO: fail if isStreamingMediaType?
 				return getDelegate().writeWith(messageBody);
 			}));


### PR DESCRIPTION
Fix bug for ModifyResponseBodyGatewayFilter not setting up response content-type if newContentType is present in config. 

Fixes gh-2647