### PR TITLE
Fixed XForwardedRemoteAddressResolver not supporting parsing comma-separated(without whitespace) header value

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ipresolver/XForwardedRemoteAddressResolver.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ipresolver/XForwardedRemoteAddressResolver.java
@@ -20,6 +20,7 @@ import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,6 +49,11 @@ public class XForwardedRemoteAddressResolver implements RemoteAddressResolver {
 	public static final String X_FORWARDED_FOR = "X-Forwarded-For";
 
 	private static final Logger log = LoggerFactory.getLogger(XForwardedRemoteAddressResolver.class);
+
+	/**
+	 * {@link Pattern} for a comma delimited string that support whitespace characters
+	 */
+	private static final Pattern commaSeparatedValuesPattern = Pattern.compile(", ?");
 
 	private final RemoteAddressResolver defaultRemoteIpResolver = new RemoteAddressResolver() {
 	};
@@ -126,7 +132,7 @@ public class XForwardedRemoteAddressResolver implements RemoteAddressResolver {
 			log.warn("Multiple X-Forwarded-For headers found, discarding all");
 			return Collections.emptyList();
 		}
-		List<String> values = Arrays.asList(xForwardedValues.get(0).split(", "));
+		List<String> values = Arrays.asList(commaSeparatedValuesPattern.split(xForwardedValues.get(0)));
 		if (values.size() == 1 && !StringUtils.hasText(values.get(0))) {
 			return Collections.emptyList();
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/ipresolver/XForwardedRemoteAddressResolverTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/ipresolver/XForwardedRemoteAddressResolverTest.java
@@ -68,7 +68,6 @@ public class XForwardedRemoteAddressResolverTest {
 		InetSocketAddress address = trustOne.resolve(exchange);
 
 		assertThat(address.getHostName()).isEqualTo("0.0.0.0");
-
 	}
 
 	@Test
@@ -115,7 +114,6 @@ public class XForwardedRemoteAddressResolverTest {
 		InetSocketAddress address = trustAll.resolve(exchange);
 
 		assertThat(address.getHostName()).isEqualTo("0.0.0.0");
-
 	}
 
 	@Test
@@ -126,6 +124,15 @@ public class XForwardedRemoteAddressResolverTest {
 		InetSocketAddress address = trustAll.resolve(exchange);
 
 		assertThat(address.getHostName()).isEqualTo("0.0.0.0");
+	}
+
+	@Test
+    public void onlyCommaSeparatedHeaders() {
+        ServerWebExchange exchange = buildExchange(onlyCommaSeparatedBuilder());
+
+		InetSocketAddress address = trustAll.resolve(exchange);
+
+		assertThat(address.getHostName()).isEqualTo("0.0.0.1");
 	}
 
 	private MockServerHttpRequest.BaseBuilder emptyBuilder() {
@@ -139,6 +146,11 @@ public class XForwardedRemoteAddressResolverTest {
 	private MockServerHttpRequest.BaseBuilder oneTwoThreeBuilder() {
 		return MockServerHttpRequest.get("someUrl").remoteAddress(remote0000Address).header("X-Forwarded-For",
 				"0.0.0.1, 0.0.0.2, 0.0.0.3");
+	}
+
+	private MockServerHttpRequest.BaseBuilder onlyCommaSeparatedBuilder() {
+		return MockServerHttpRequest.get("someUrl").remoteAddress(remote0000Address)
+				.header("X-Forwarded-For", "0.0.0.1,0.0.0.2,0.0.0.3");
 	}
 
 	private ServerWebExchange buildExchange(MockServerHttpRequest.BaseBuilder requestBuilder) {


### PR DESCRIPTION
This PR fixes a bug where `XForwardedRemoteAddressResolver` did not split IP addresses as expected when `X-Forwarded-For` was only separated by commas(without whitespace).

eg: 
```text
X-Forwarded-For: 0.0.0.1,0.0.0.2,0.0.0.3
```

The current implementation only supports comma-space separation:
```text
X-Forwarded-For: 0.0.0.1, 0.0.0.2, 0.0.0.3
```

#### Doc
> Elements are comma-separated, with optional whitespace surrounding the commas.

Reference: [X-Forwarded-For - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#syntax)