### PR TITLE
Add uri variables support for circuit breaker

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -719,6 +719,31 @@ public RouteLocator routes(RouteLocatorBuilder builder) {
 This example forwards to the `/inCaseofFailureUseThis` URI when the circuit breaker fallback is called.
 Note that this example also demonstrates the (optional) Spring Cloud LoadBalancer load-balancing (defined by the `lb` prefix on the destination URI).
 
+CircuitBreaker also supports URI variables in the `fallbackUri`.
+This allows more complex routing options, like forwarding sections of the original host or url path using  https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/util/pattern/PathPattern.html[PathPattern expression].
+
+In the example below the call `consumingServiceEndpoint/users/1` will be redirected to `inCaseOfFailureUseThis/users/1`.
+
+.application.yml
+====
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: circuitbreaker_route
+        uri: lb://backing-service:8088
+        predicates:
+        - Path=/consumingServiceEndpoint/{*segments}
+        filters:
+        - name: CircuitBreaker
+          args:
+            name: myCircuitBreaker
+            fallbackUri: forward:/inCaseOfFailureUseThis/{segments}
+----
+====
+
 The primary scenario is to use the `fallbackUri` to define an internal controller or handler within the gateway application.
 However, you can also reroute the request to a controller or handler in an external application, as follows:
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
@@ -48,7 +48,6 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.C
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.containsEncodedParts;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.reset;
-import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.setResponseStatus;
 
 /**
  * @author Ryan Baxter

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.support.HasRouteId;
 import org.springframework.cloud.gateway.support.HttpStatusHolder;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.server.reactive.ServerHttpRequest;
@@ -47,6 +48,7 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.C
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.containsEncodedParts;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.reset;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.setResponseStatus;
 
 /**
  * @author Ryan Baxter
@@ -113,8 +115,12 @@ public abstract class SpringCloudCircuitBreakerFilterFactory
 					URI uri = exchange.getRequest().getURI();
 					// TODO: assume always?
 					boolean encoded = containsEncodedParts(uri);
-					URI requestUrl = UriComponentsBuilder.fromUri(uri).host(null).port(null)
-							.uri(config.getFallbackUri()).scheme(null).build(encoded).toUri();
+
+					final String expandedFallbackUri = ServerWebExchangeUtils.expand(exchange, config.getFallbackUri().getPath());
+					final String fullFallbackUri = String.format("%s:%s", config.getFallbackUri().getScheme(), expandedFallbackUri);
+					final URI requestUrl = UriComponentsBuilder.fromUri(uri).host(null).port(null)
+							.uri(URI.create(fullFallbackUri)).scheme(null).build(encoded).toUri();
+
 					exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUrl);
 					addExceptionDetails(t, exchange);
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
@@ -61,6 +61,12 @@ public abstract class SpringCloudCircuitBreakerFilterFactoryTests extends BaseWe
 	}
 
 	@Test
+	public void filterWithVariables() {
+		testClient.get().uri("/delay/3/extra?a=b").header("Host", "www.circuitbreakervariables.org").exchange().expectStatus()
+				.isOk().expectBody().json("{\"uri\":\"/circuitbreakerUriFallbackController/3/extra/www?a=b\"}");
+	}
+
+	@Test
 	public void filterWorksJavaDsl() {
 		testClient.get().uri("/get").header("Host", "www.circuitbreakerjava.org").exchange().expectStatus().isOk()
 				.expectHeader().valueEquals(ROUTE_ID_HEADER, "circuitbreaker_java");

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
@@ -68,6 +68,11 @@ public class SpringCloudCircuitBreakerTestConfig {
 		return Collections.singletonMap("from", "circuitbreakerfallbackcontroller");
 	}
 
+	@GetMapping("/circuitbreakerUriFallbackController/**")
+	public Map<String, String> uriFallbackcontroller(ServerWebExchange exchange, @RequestParam("a") String a) {
+		return Collections.singletonMap("uri", exchange.getRequest().getURI().toString());
+	}
+
 	@GetMapping("/circuitbreakerFallbackController2")
 	public Map<String, String> fallbackcontroller2() {
 		return Collections.singletonMap("from", "circuitbreakerfallbackcontroller2");

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
@@ -95,7 +95,7 @@ public class HttpBinCompatibleController {
 		return result;
 	}
 
-	@GetMapping(path = "/delay/{sec}", produces = MediaType.APPLICATION_JSON_VALUE)
+	@GetMapping(path = "/delay/{sec}/**", produces = MediaType.APPLICATION_JSON_VALUE)
 	public Mono<Map<String, Object>> delay(ServerWebExchange exchange, @PathVariable int sec)
 			throws InterruptedException {
 		int delay = Math.min(sec, 10);

--- a/spring-cloud-gateway-server/src/test/resources/application.yml
+++ b/spring-cloud-gateway-server/src/test/resources/application.yml
@@ -104,6 +104,18 @@ spring:
               name: fallbackcmd
               fallbackUri: forward:/circuitbreakerFallbackController
 
+        # =====================================
+      - id: circuitbreaker_fallback_test_variables
+        uri: ${test.uri}
+        predicates:
+          - Path=/delay/{*segments}
+          - Host={host}.circuitbreakervariables.org
+        filters:
+          - name: CircuitBreaker
+            args:
+              name: fallbackvarscmd
+              fallbackUri: forward:/circuitbreakerUriFallbackController/{segments}/{host}
+
       # =====================================
       - id: circuitbreaker_fallback_test_statuscode
         uri: ${test.uri}


### PR DESCRIPTION
Adds support for Uri variables for fallbackUri in CircuitBreaker.

Similarly to `AddRequestHeaderGatewayFilterFactory`, uses `ServerWebExchangeUtils.expand` to process the original value and replace any variable present.