### PR TITLE
[#2756]Cache gateway filters to avoid sorting in every single request

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -118,6 +118,7 @@ import org.springframework.cloud.gateway.filter.ratelimit.KeyResolver;
 import org.springframework.cloud.gateway.filter.ratelimit.PrincipalNameKeyResolver;
 import org.springframework.cloud.gateway.filter.ratelimit.RateLimiter;
 import org.springframework.cloud.gateway.handler.FilteringWebHandler;
+import org.springframework.cloud.gateway.handler.GatewayFiltersCache;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
 import org.springframework.cloud.gateway.handler.predicate.AfterRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.BeforeRoutePredicateFactory;
@@ -249,8 +250,13 @@ public class GatewayAutoConfiguration {
 	}
 
 	@Bean
-	public FilteringWebHandler filteringWebHandler(List<GlobalFilter> globalFilters) {
-		return new FilteringWebHandler(globalFilters);
+	public FilteringWebHandler filteringWebHandler(GatewayFiltersCache gatewayFiltersCache) {
+		return new FilteringWebHandler(gatewayFiltersCache);
+	}
+
+	@Bean
+	public GatewayFiltersCache gatewayFiltersCache(List<GlobalFilter> globalFilters) {
+		return new GatewayFiltersCache(globalFilters);
 	}
 
 	@Bean

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/GatewayFiltersCache.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/GatewayFiltersCache.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.handler;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.cloud.gateway.event.RefreshRoutesResultEvent;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.route.Route;
+import org.springframework.cloud.gateway.support.FilterAdapter;
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.annotation.AnnotationAwareOrderComparator;
+
+/**
+ * Cache to avoid sorting all filters on each request.
+ *
+ * @author ziming liu
+ */
+public class GatewayFiltersCache implements ApplicationListener<RefreshRoutesResultEvent> {
+
+	private final List<GatewayFilter> globalFilters;
+
+	private final Map<Route, List<GatewayFilter>> cachedGatewayFilters = new ConcurrentHashMap<>();
+
+	public GatewayFiltersCache(List<GlobalFilter> globalFilters) {
+		this.globalFilters = FilterAdapter.loadFilters(globalFilters);
+	}
+
+	@Override
+	public void onApplicationEvent(RefreshRoutesResultEvent event) {
+		if (event.getThrowable() != null) {
+			return;
+		}
+		this.cachedGatewayFilters.clear();
+	}
+
+	public List<GatewayFilter> cacheGatewayFilters(Route route) {
+		if (cachedGatewayFilters.containsKey(route)) {
+			return cachedGatewayFilters.get(route);
+		}
+		List<GatewayFilter> combined = route.getFilters();
+		combined.addAll(this.globalFilters);
+		AnnotationAwareOrderComparator.sort(combined);
+		cachedGatewayFilters.put(route, combined);
+		return combined;
+	}
+
+}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/FilterAdapter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/FilterAdapter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.support;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
+import org.springframework.core.Ordered;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * An adapter to load global filters into gateway filters.
+ *
+ * @author ziming liu
+ */
+public final class FilterAdapter {
+
+	private FilterAdapter() {
+
+	}
+
+	public static List<GatewayFilter> loadFilters(List<GlobalFilter> filters) {
+		return filters.stream().map(filter -> {
+			GatewayFilterAdapter gatewayFilter = new GatewayFilterAdapter(filter);
+			if (filter instanceof Ordered) {
+				int order = ((Ordered) filter).getOrder();
+				return new OrderedGatewayFilter(gatewayFilter, order);
+			}
+			return gatewayFilter;
+		}).collect(Collectors.toList());
+	}
+
+	private static class GatewayFilterAdapter implements GatewayFilter {
+
+		private final GlobalFilter delegate;
+
+		GatewayFilterAdapter(GlobalFilter delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+			return this.delegate.filter(exchange, chain);
+		}
+
+		@Override
+		public String toString() {
+			final StringBuilder sb = new StringBuilder("GatewayFilterAdapter{");
+			sb.append("delegate=").append(delegate);
+			sb.append('}');
+			return sb.toString();
+		}
+
+	}
+
+}


### PR DESCRIPTION
This PR is to solve the issue [2756](https://github.com/spring-cloud/spring-cloud-gateway/issues/2756). It cache gateway filters to avoid sorting in every single request in order to improve performance of Spring Cloud Gateway!