### PR TITLE
Shouldn't remove remote fields from gateway propagation

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
@@ -135,7 +135,7 @@ public class GatewayMetricsAutoConfiguration {
 
 			@Bean
 			@ConditionalOnMissingBean
-			@ConditionalOnBean(Propagator.class)
+			@ConditionalOnBean({ Propagator.class, TracingProperties.class })
 			@Order(Ordered.HIGHEST_PRECEDENCE + 5)
 			GatewayPropagatingSenderTracingObservationHandler gatewayPropagatingSenderTracingObservationHandler(
 					Tracer tracer, Propagator propagator, TracingProperties tracingProperties) {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.actuate.autoconfigure.metrics.CompositeMeterRegistryAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.metrics.MetricsAutoConfiguration;
 import org.springframework.boot.actuate.autoconfigure.observation.ObservationAutoConfiguration;
+import org.springframework.boot.actuate.autoconfigure.tracing.TracingProperties;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -137,8 +138,9 @@ public class GatewayMetricsAutoConfiguration {
 			@ConditionalOnBean(Propagator.class)
 			@Order(Ordered.HIGHEST_PRECEDENCE + 5)
 			GatewayPropagatingSenderTracingObservationHandler gatewayPropagatingSenderTracingObservationHandler(
-					Tracer tracer, Propagator propagator) {
-				return new GatewayPropagatingSenderTracingObservationHandler(tracer, propagator);
+					Tracer tracer, Propagator propagator, TracingProperties tracingProperties) {
+				return new GatewayPropagatingSenderTracingObservationHandler(tracer, propagator,
+						tracingProperties.getBaggage().getRemoteFields());
 			}
 
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/GatewayMetricsAutoConfigurationTests.java
@@ -29,6 +29,7 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.actuate.autoconfigure.tracing.TracingProperties;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -176,6 +177,11 @@ public class GatewayMetricsAutoConfigurationTests {
 		@Bean
 		Propagator propagator() {
 			return Mockito.mock(Propagator.class);
+		}
+
+		@Bean
+		TracingProperties tracingProperties() {
+			return new TracingProperties();
 		}
 
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/B3BraveObservedHttpHeadersFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/B3BraveObservedHttpHeadersFilterTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.headers.observation;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -67,9 +68,11 @@ class B3BraveObservedHttpHeadersFilterTests {
 	void shouldWorkWithB3SingleHeader() {
 		TestObservationRegistry observationRegistry = TestObservationRegistry.create();
 		observationRegistry.observationConfig()
-				.observationHandler(new ObservationHandler.FirstMatchingCompositeObservationHandler(
-						new GatewayPropagatingSenderTracingObservationHandler(tracer, propagator),
-						new DefaultTracingObservationHandler(tracer)));
+				.observationHandler(
+						new ObservationHandler.FirstMatchingCompositeObservationHandler(
+								new GatewayPropagatingSenderTracingObservationHandler(tracer, propagator,
+										Collections.singletonList("X-A")),
+								new DefaultTracingObservationHandler(tracer)));
 
 		Observation.createNotStarted("parent", observationRegistry).observe(() -> {
 			// given

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/GatewayPropagatingSenderTracingObservationHandlerTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/GatewayPropagatingSenderTracingObservationHandlerTests.java
@@ -55,7 +55,7 @@ class GatewayPropagatingSenderTracingObservationHandlerTests {
 	};
 
 	GatewayPropagatingSenderTracingObservationHandler handler = new GatewayPropagatingSenderTracingObservationHandler(
-			tracer, propagator);
+			tracer, propagator, Collections.singletonList("remote"));
 
 	@Test
 	void shouldRemovePropagationFieldsFromTheRequestBeforePropagating() {
@@ -63,13 +63,15 @@ class GatewayPropagatingSenderTracingObservationHandlerTests {
 		headers.put("foo", Collections.singletonList("foo value"));
 		headers.put("bar", Collections.singletonList("bar value"));
 		headers.put("baz", Collections.singletonList("baz value"));
+		headers.put("remote", Collections.singletonList("remote value"));
 		MockServerHttpRequest request = MockServerHttpRequest.get("/get").build();
 		MockServerWebExchange serverWebExchange = MockServerWebExchange.from(request);
 		GatewayContext gatewayContext = new GatewayContext(headers, request, serverWebExchange);
 
 		handler.onStart(gatewayContext);
 
-		then(headers).doesNotContainKeys("foo", "bar").containsEntry("baz", Collections.singletonList("baz value"));
+		then(headers).doesNotContainKeys("foo", "bar").containsEntry("baz", Collections.singletonList("baz value"))
+				.containsEntry("remote", Collections.singletonList("remote value"));
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/ObservedHttpHeadersFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/ObservedHttpHeadersFilterTests.java
@@ -100,7 +100,8 @@ public class ObservedHttpHeadersFilterTests extends SampleTestRunner {
 	@Override
 	public BiConsumer<BuildingBlocks, Deque<ObservationHandler<? extends Observation.Context>>> customizeObservationHandlers() {
 		return (bb, observationHandlers) -> observationHandlers
-				.addFirst(new GatewayPropagatingSenderTracingObservationHandler(bb.getTracer(), bb.getPropagator()));
+				.addFirst(new GatewayPropagatingSenderTracingObservationHandler(bb.getTracer(), bb.getPropagator(),
+						Collections.emptyList()));
 	}
 
 }


### PR DESCRIPTION
without this change we removing all fields from an incoming request when propagating it further

with this change we're filtering out all remote fields cause they must be propagated