### PR TITLE
Adds the original Reactor Context to ServerWebExchange attributes

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/observation/ObservedRequestHttpHeadersFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/observation/ObservedRequestHttpHeadersFilter.java
@@ -21,6 +21,7 @@ import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import reactor.util.context.ContextView;
 
 import org.springframework.cloud.gateway.filter.headers.HttpHeadersFilter;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
@@ -90,7 +91,11 @@ public class ObservedRequestHttpHeadersFilter implements HttpHeadersFilter {
 	 * @return parent observation or {@code null} when there is none
 	 */
 	private Observation getParentObservation(ServerWebExchange exchange) {
-		return exchange.getAttribute("micrometer.observation");
+		ContextView contextView = exchange.getAttribute(ServerWebExchangeUtils.GATEWAY_REACTOR_CONTEXT_ATTR);
+		if (contextView == null) {
+			return null;
+		}
+		return contextView.getOrDefault("micrometer.observation", null);
 	}
 
 	@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -87,6 +87,11 @@ public final class ServerWebExchangeUtils {
 	public static final String GATEWAY_ROUTE_ATTR = qualify("gatewayRoute");
 
 	/**
+	 * Original Reactor Context corresponding to the processed request.
+	 */
+	public static final String GATEWAY_REACTOR_CONTEXT_ATTR = qualify("gatewayReactorContext");
+
+	/**
 	 * Gateway request URL attribute name.
 	 */
 	public static final String GATEWAY_REQUEST_URL_ATTR = qualify("gatewayRequestUrl");

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/B3BraveObservedHttpHeadersFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/B3BraveObservedHttpHeadersFilterTests.java
@@ -41,6 +41,7 @@ import io.micrometer.tracing.handler.DefaultTracingObservationHandler;
 import io.micrometer.tracing.propagation.Propagator;
 import io.micrometer.tracing.test.simple.SpansAssert;
 import org.junit.jupiter.api.Test;
+import reactor.util.context.Context;
 
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
@@ -90,8 +91,9 @@ class B3BraveObservedHttpHeadersFilterTests {
 					.predicate(serverWebExchange -> true).build();
 			exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR, route);
 			// Parent observation
-			exchange.getAttributes().put(ObservationThreadLocalAccessor.KEY,
-					observationRegistry.getCurrentObservation());
+			Context ctx = Context
+					.of(Map.of(ObservationThreadLocalAccessor.KEY, observationRegistry.getCurrentObservation()));
+			exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_REACTOR_CONTEXT_ATTR, ctx);
 
 			// and
 			ObservedRequestHttpHeadersFilter requestHttpHeadersFilter = new ObservedRequestHttpHeadersFilter(

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/ObservedHttpHeadersFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/observation/ObservedHttpHeadersFilterTests.java
@@ -30,6 +30,7 @@ import io.micrometer.tracing.TraceContext;
 import io.micrometer.tracing.test.SampleTestRunner;
 import io.micrometer.tracing.test.reporter.BuildingBlocks;
 import io.micrometer.tracing.test.simple.SpansAssert;
+import reactor.util.context.Context;
 
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
@@ -67,8 +68,9 @@ public class ObservedHttpHeadersFilterTests extends SampleTestRunner {
 					.predicate(serverWebExchange -> true).build();
 			exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR, route);
 			// Parent observation
-			exchange.getAttributes().put(ObservationThreadLocalAccessor.KEY,
-					getObservationRegistry().getCurrentObservation());
+			Context ctx = Context
+					.of(Map.of(ObservationThreadLocalAccessor.KEY, getObservationRegistry().getCurrentObservation()));
+			exchange.getAttributes().put(ServerWebExchangeUtils.GATEWAY_REACTOR_CONTEXT_ATTR, ctx);
 			exchange.getResponse().setStatusCode(HttpStatusCode.valueOf(200));
 
 			// when


### PR DESCRIPTION
Gateway uses WebFlux and WebFlux has native instrumentation using Micrometer Observations. WebFlux adds the Observation to the Reactor Context, but in the Headers filter inside the Gateway we no longer have access to the context.

With this change, when we process a route we attach the Reactor Context as a Gateway ServerWebExchange attribute, so that we can check for parent Observations later in the HttpHeadersFilter