### PR TITLE
Correct typo in CORS listener

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/cors/CorsGatewayFilterApplicationListener.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/cors/CorsGatewayFilterApplicationListener.java
@@ -86,7 +86,7 @@ public class CorsGatewayFilterApplicationListener implements ApplicationListener
 		if (corsMetadata != null) {
 			final CorsConfiguration corsConfiguration = new CorsConfiguration();
 
-			findValue(corsMetadata, "allowCredential")
+			findValue(corsMetadata, "allowCredentials")
 					.ifPresent(value -> corsConfiguration.setAllowCredentials((Boolean) value));
 			findValue(corsMetadata, "allowedHeaders")
 					.ifPresent(value -> corsConfiguration.setAllowedHeaders(asList(value)));

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/cors/CorsPerRouteTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/cors/CorsPerRouteTests.java
@@ -33,6 +33,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.HttpHeaders.ACCESS_CONTROL_ALLOW_CREDENTIALS;
 import static org.springframework.http.HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN;
 import static org.springframework.http.HttpHeaders.ACCESS_CONTROL_MAX_AGE;
 
@@ -50,12 +51,14 @@ public class CorsPerRouteTests extends BaseWebClientTests {
 
 					HttpHeaders responseHeaders = result.getResponseHeaders();
 					assertThat(responseHeaders.getAccessControlAllowOrigin())
-							.as(missingHeader(ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("*");
+							.as(missingHeader(ACCESS_CONTROL_ALLOW_ORIGIN)).isEqualTo("domain.com");
 					assertThat(responseHeaders.getAccessControlAllowMethods())
 							.as(missingHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
 							.containsExactlyInAnyOrder(HttpMethod.GET, HttpMethod.POST);
 					assertThat(responseHeaders.getAccessControlMaxAge()).as(missingHeader(ACCESS_CONTROL_MAX_AGE))
 							.isEqualTo(30L);
+				  assertThat(responseHeaders.getAccessControlAllowCredentials()).as(missingHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS))
+						    .isEqualTo(true);
 				});
 	}
 

--- a/spring-cloud-gateway-server/src/test/resources/application-cors-per-route-config.yml
+++ b/spring-cloud-gateway-server/src/test/resources/application-cors-per-route-config.yml
@@ -8,9 +8,10 @@ spring:
             - Path=/abc/**
           metadata:
             cors:
-              allowedOrigins: '*'
+              allowedOrigins: 'domain.com'
               allowedMethods: [ GET, POST ]
               allowedHeaders: '*'
+              allowCredentials: true
               maxAge: 30
         - id: cors_test
           uri: ${test.uri}


### PR DESCRIPTION
Typo: "allowCredential" should be `allowCredentials` - see [documentation](https://github.com/spring-projects/spring-framework/blob/d492086c76344e1b87d32e326d49d0844a8d2bcb/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc.xsd#L1345)

Also, it replaces `allowedOrigins` with a specific one because `allowCredentials` requires non "*" origin
