### PR TITLE
Fix Bug : Server sent event get blocked  ModifyResponseBodyGatewayFilterFactory is enable

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactoryTests.java
@@ -17,11 +17,14 @@
 package org.springframework.cloud.gateway.filter.factory.rewrite;
 
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
@@ -32,13 +35,17 @@ import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.reactive.server.FluxExchangeResult;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = "spring.codec.max-in-memory-size=40")
@@ -72,6 +79,58 @@ public class ModifyResponseBodyGatewayFilterFactoryTests extends BaseWebClientTe
 				.isEqualTo("Exceeded limit on max bytes to buffer : 40");
 	}
 
+	@Test
+	public void modifySseResponseBody() {
+		int events = 5;
+		long delay = 100L;
+
+		FluxExchangeResult<ServerSentEvent<String>> result = buildFluxExchangeResultForSse(events, delay);
+
+		StepVerifier.create(result.getResponseBody())
+				.consumeNextWith(event -> assertThat(event.data()).isEqualTo("MD - 0"))
+				.consumeNextWith(event -> assertThat(event.data()).isEqualTo("MD - 1")).expectNextCount(events - 2)
+				.thenCancel().verify();
+	}
+
+	@Test
+	public void sseResponseShouldNotBlockedDuringModification() {
+		int events = 10;
+		long delay = 100L;
+
+		FluxExchangeResult<ServerSentEvent<String>> result = buildFluxExchangeResultForSse(events, delay);
+		// Publisher should take sufficient time to emit all real time events. If response
+		// is blocked in between Publisher will emit all events immediately
+		StepVerifier.create(result.getResponseBody())
+				.consumeNextWith(event -> assertThat(event.data()).isEqualTo("MD - 0"))
+				.consumeNextWith(event -> assertThat(event.data()).isEqualTo("MD - 1")).expectNextCount(events - 2)
+				.thenCancel().verifyThenAssertThat().tookMoreThan(Duration.ofMillis((events / 2) * delay));
+	}
+
+	@Test
+	public void modifyLargeSseResponseBodyWithoutExcedingLimitOfBuffer() {
+		int events = 20;
+		long delay = 100L;
+
+		FluxExchangeResult<ServerSentEvent<String>> result = buildFluxExchangeResultForSse(events, delay);
+
+		StepVerifier.create(result.getResponseBody())
+				.consumeNextWith(event -> assertThat(event.data()).isEqualTo("MD - 0"))
+				.consumeNextWith(event -> assertThat(event.data()).isEqualTo("MD - 1")).expectNextCount(events - 2)
+				.thenCancel().verify();
+	}
+
+	private FluxExchangeResult<ServerSentEvent<String>> buildFluxExchangeResultForSse(int events, long delay) {
+		URI uri = UriComponentsBuilder.fromUriString(this.baseUri + "/sse?events=" + events + "&delay=" + delay)
+				.build(true).toUri();
+
+		FluxExchangeResult<ServerSentEvent<String>> result = testClient.get().uri(uri)
+				.header("Host", "www.modifyresponsebodyjavawithsse.org").accept(MediaType.TEXT_EVENT_STREAM).exchange()
+				.expectStatus().isOk().expectHeader().contentType("text/event-stream;charset=UTF-8")
+				.returnResult(new ParameterizedTypeReference<ServerSentEvent<String>>() {
+				});
+		return result;
+	}
+
 	@EnableAutoConfiguration
 	@SpringBootConfiguration
 	@Import(DefaultTestConfig.class)
@@ -97,6 +156,14 @@ public class ModifyResponseBodyGatewayFilterFactoryTests extends BaseWebClientTe
 												return Mono.just(toLarge);
 											}))
 									.uri(uri))
+					.route("modify_response_java_test_sse",
+							r -> r.host("www.modifyresponsebodyjavawithsse.org").filters(f -> f
+									.modifyResponseBody(byte[].class, String.class, (webExchange, originalResponse) -> {
+										String originalResponseStr = new String(originalResponse,
+												StandardCharsets.UTF_8);
+										String modifiedResponse = originalResponseStr.replace("D -", "MD -");
+										return Mono.just(modifiedResponse);
+									})).uri(uri))
 					.build();
 		}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/HttpBinCompatibleController.java
@@ -40,6 +40,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.http.codec.multipart.FilePart;
 import org.springframework.http.codec.multipart.Part;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -53,6 +54,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -219,6 +221,16 @@ public class HttpBinCompatibleController {
 			builder.varyBy(headerToVary);
 			return builder.body(headers(exchange));
 		}
+	}
+
+	@GetMapping(value = "/sse", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public Flux<ServerSentEvent<String>> sseEvents(
+			@RequestParam(value = "events", required = false, defaultValue = "5") int events,
+			@RequestParam(value = "delay", required = false, defaultValue = "500") long delay) {
+		return Flux.interval(Duration.ofMillis(delay)).take(events).map(e -> {
+			return ServerSentEvent.<String>builder().id(e.toString()).event("notice").data("D - " + e.toString())
+					.build();
+		});
 	}
 
 	public Map<String, String> getHeaders(ServerWebExchange exchange) {


### PR DESCRIPTION
`ModifyResponseBodyGatewayFilterFactory` is blocker for SSE based resources because `writeWith` method of `ModifiedServerHttpResponse` is responsible to modify response body for stream and non stream mime-type, `writeWith` convert response body to Mono, this behavior of `writeWith` is a blocker for stream type SSE.

Due to this issue consumer of SSE endpoint getting all events in one go instead of in form of stream. Without ModifyResponseBodyGatewayFilterFactory things works perfectly.

This PR contains fix for this issue and idea is to handle `writeAndFlushWith` method differently for stream mime type, as `writeAndFlushWith` being called by writer only when response content type is of Stream media type.

Please have a look at this PR, if looks ok please approve it.