### PR TITLE
Fix the Kotlin Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 		<spring-cloud-circuitbreaker.version>2.1.6-SNAPSHOT</spring-cloud-circuitbreaker.version>
 		<spring-cloud-commons.version>3.1.6-SNAPSHOT</spring-cloud-commons.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
+		<kotlin-maven-plugin.version>1.6.21</kotlin-maven-plugin.version>
 	</properties>
 
 	<dependencyManagement>

--- a/spring-cloud-gateway-sample/pom.xml
+++ b/spring-cloud-gateway-sample/pom.xml
@@ -146,6 +146,7 @@
 					<plugin>
 						<groupId>org.jetbrains.kotlin</groupId>
 						<artifactId>kotlin-maven-plugin</artifactId>
+						<version>${kotlin-maven-plugin.version}</version>
 						<configuration>
 							<args>
 								<arg>-Xjsr305=strict</arg>

--- a/spring-cloud-gateway-server/pom.xml
+++ b/spring-cloud-gateway-server/pom.xml
@@ -234,6 +234,7 @@
 						<!-- Based on instructions here - https://kotlinlang.org/docs/reference/using-maven.html -->
 						<artifactId>kotlin-maven-plugin</artifactId>
 						<groupId>org.jetbrains.kotlin</groupId>
+						<version>${kotlin-maven-plugin.version}</version>
 						<configuration>
 							<jvmTarget>1.8</jvmTarget>
 						</configuration>


### PR DESCRIPTION
Without this change I can't build Sleuth due to mismatch in Kotlin versions. We're compiling using 1.6.21 but using 1.8.0-RC Kotlin Maven plugin