### PR TITLE
Preventing potential native memory leak.

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -369,7 +369,12 @@ public final class ServerWebExchangeUtils {
 			if (log.isTraceEnabled()) {
 				log.trace("retaining body in exchange attribute");
 			}
-			exchange.getAttributes().put(CACHED_REQUEST_BODY_ATTR, dataBuffer);
+
+			Object cachedDataBuffer = exchange.getAttributeOrDefault(
+					CACHED_REQUEST_BODY_ATTR, null);
+			if (!(cachedDataBuffer instanceof DataBuffer)) {
+				exchange.getAttributes().put(CACHED_REQUEST_BODY_ATTR, dataBuffer);
+			}
 		}
 
 		ServerHttpRequest decorator = new ServerHttpRequestDecorator(exchange.getRequest()) {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtilsTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtilsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.support;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -23,7 +24,9 @@ import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DefaultDataBuffer;
+import org.springframework.http.HttpMethod;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.reactive.function.server.HandlerStrategies;
@@ -70,11 +73,48 @@ public class ServerWebExchangeUtilsTests {
 				.block();
 	}
 
+	@Test
+	public void duplicatedCachingDataBufferHandling() {
+		MockServerWebExchange exchange = mockExchange(HttpMethod.POST,
+				Collections.emptyMap());
+		DataBuffer dataBufferBeforeCaching = exchange.getResponse().bufferFactory()
+				.wrap("Cached buffer".getBytes(StandardCharsets.UTF_8));
+		exchange.getAttributes().put(CACHED_REQUEST_BODY_ATTR, dataBufferBeforeCaching);
+
+		ServerWebExchangeUtils.cacheRequestBodyAndRequest(exchange,
+				(serverHttpRequest) -> ServerRequest.create(
+								exchange.mutate().request(serverHttpRequest).build(),
+								HandlerStrategies.withDefaults().messageReaders())
+						.bodyToMono(DefaultDataBuffer.class)).block();
+
+		DataBuffer dataBufferAfterCached = exchange.getAttribute(
+				CACHED_REQUEST_BODY_ATTR);
+
+		Assertions.assertEquals(dataBufferBeforeCaching, dataBufferAfterCached);
+	}
+
 	private MockServerWebExchange mockExchange(Map<String, String> vars) {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/get").build();
 		MockServerWebExchange exchange = MockServerWebExchange.from(request);
 		ServerWebExchangeUtils.putUriTemplateVariables(exchange, vars);
-		return exchange;
+		return mockExchange(HttpMethod.GET, vars);
 	}
 
+	private MockServerWebExchange mockExchange(HttpMethod method,
+			Map<String, String> vars) {
+
+		MockServerHttpRequest request = null;
+		if (HttpMethod.GET.equals(method)) {
+			request = MockServerHttpRequest.get("/get").build();
+		}
+		else if (HttpMethod.POST.equals(method)) {
+			request = MockServerHttpRequest.post("/post").body("post body");
+		}
+
+		Assertions.assertNotNull(request, "Method was not selected");
+
+		MockServerWebExchange exchange = MockServerWebExchange.from(request);
+		ServerWebExchangeUtils.putUriTemplateVariables(exchange, vars);
+		return exchange;
+	}
 }


### PR DESCRIPTION
ServerWebExchangeUtils.cacheRequestBodyAndRequest method is public access, so it is able to call anywhere, anytime.
But if executed twice, previous DataBuffer reference is missed without release.

ServerWebExchangeUtils.cacheRequestBodyAndRequest is not safe now.

On many positions, CACHED_REQUEST_BODY_ATTR is checked before call.

But this structure can make human error. The checking machanism have to be inside of this function for preventing native memory leak.


