### PR TITLE
Fixed memory leak of CacheRequestBodyGatewayFilter

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
@@ -38,7 +38,7 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.C
 
 /**
  * @author weizibin
- * @author Dong-guen Hong
+ * @author dg-hong
  */
 public class CacheRequestBodyGatewayFilterFactory
 		extends AbstractGatewayFilterFactory<CacheRequestBodyGatewayFilterFactory.Config> {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
@@ -16,29 +16,33 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import java.net.URI;
-import java.util.List;
-
-import reactor.core.publisher.Mono;
-
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.Assert;
 import org.springframework.web.reactive.function.server.HandlerStrategies;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.List;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR;
 
 /**
  * @author weizibin
+ * @author Dong-guen Hong
  */
 public class CacheRequestBodyGatewayFilterFactory
 		extends AbstractGatewayFilterFactory<CacheRequestBodyGatewayFilterFactory.Config> {
+
+	static final String CACHED_ORIGIN_REQUEST_BODY_BACKUP_ATTR = "cachedOriginRequestBodyBackup";
 
 	private final List<HttpMessageReader<?>> messageReaders;
 
@@ -70,13 +74,26 @@ public class CacheRequestBodyGatewayFilterFactory
 					final ServerRequest serverRequest = ServerRequest
 							.create(exchange.mutate().request(serverHttpRequest).build(), messageReaders);
 					return serverRequest.bodyToMono((config.getBodyClass())).doOnNext(objectValue -> {
-						exchange.getAttributes().put(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR, objectValue);
+						Object previousCachedBody = exchange.getAttributes()
+								.put(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR,
+										objectValue);
+						exchange.getAttributes()
+								.put(CACHED_ORIGIN_REQUEST_BODY_BACKUP_ATTR,
+										previousCachedBody);
 					}).then(Mono.defer(() -> {
 						ServerHttpRequest cachedRequest = exchange
 								.getAttribute(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
 						Assert.notNull(cachedRequest, "cache request shouldn't be null");
 						exchange.getAttributes().remove(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
-						return chain.filter(exchange.mutate().request(cachedRequest).build());
+						return chain.filter(
+										exchange.mutate().request(cachedRequest).build())
+								.doFinally(s -> {
+									Object backedCachedBody = exchange.getAttributes()
+											.get(CACHED_ORIGIN_REQUEST_BODY_BACKUP_ATTR);
+									if (backedCachedBody instanceof DataBuffer backedCachedDataBuffer) {
+										DataBufferUtils.release(backedCachedDataBuffer);
+									}
+								});
 					}));
 				});
 			}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
@@ -38,7 +38,6 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.C
 
 /**
  * @author weizibin
- * @author dg-hong
  */
 public class CacheRequestBodyGatewayFilterFactory
 		extends AbstractGatewayFilterFactory<CacheRequestBodyGatewayFilterFactory.Config> {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import java.net.URI;
+import java.util.List;
+
+import reactor.core.publisher.Mono;
+
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
@@ -27,10 +32,6 @@ import org.springframework.util.Assert;
 import org.springframework.web.reactive.function.server.HandlerStrategies;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
-
-import java.net.URI;
-import java.util.List;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR;

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
@@ -16,7 +16,11 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -32,13 +36,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.io.buffer.PooledDataBuffer;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
-import reactor.core.publisher.Mono;
-
-import java.lang.reflect.Field;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -58,11 +57,9 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 	public void cacheRequestBodyWorks() {
 		testClient.post().uri("/post").header("Host", "www.cacherequestbody.org").bodyValue(BODY_VALUE).exchange()
 				.expectStatus().isOk().expectBody(Map.class).consumeWith(result -> {
-					Map<?, ?> response = result.getResponseBody();
-					assertThat(response).isNotNull();
+					Map<?, ?> response = result.getResponseBody(); assertThat(response).isNotNull();
 
-					String responseBody = (String) response.get("data");
-					assertThat(responseBody).isEqualTo(BODY_VALUE);
+					String responseBody = (String) response.get("data"); assertThat(responseBody).isEqualTo(BODY_VALUE);
 				});
 	}
 
@@ -70,8 +67,7 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 	public void cacheRequestBodyEmpty() {
 		testClient.post().uri("/post").header("Host", "www.cacherequestbodyempty.org").exchange().expectStatus().isOk()
 				.expectBody(Map.class).consumeWith(result -> {
-					Map<?, ?> response = result.getResponseBody();
-					assertThat(response).isNotNull();
+					Map<?, ?> response = result.getResponseBody(); assertThat(response).isNotNull();
 
 					assertThat(response.get("data")).isNull();
 				});
@@ -102,24 +98,19 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 		@Bean
 		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
 			return builder.routes()
-					.route("cache_request_body_java_test",
-							r -> r.path("/post").and().host("**.cacherequestbody.org")
-									.filters(f -> f.prefixPath("/httpbin").cacheRequestBody(String.class)
-											.filter(new AssertCachedRequestBodyGatewayFilter(BODY_VALUE))
-											.filter(new CheckCachedRequestBodyReleasedGatewayFilter()))
-									.uri(uri))
-					.route("cache_request_body_empty_java_test",
-							r -> r.path("/post").and().host("**.cacherequestbodyempty.org")
-									.filters(f -> f.prefixPath("/httpbin").cacheRequestBody(String.class)
-											.filter(new AssertCachedRequestBodyGatewayFilter(BODY_EMPTY)))
-									.uri(uri))
-					.route("cache_request_body_exists_java_test",
-							r -> r.path("/post").and().host("**.cacherequestbodyexists.org")
-									.filters(f -> f.prefixPath("/httpbin")
-											.filter(new SetExchangeCachedRequestBodyGatewayFilter(BODY_CACHED_EXISTS))
-											.cacheRequestBody(String.class)
-											.filter(new AssertCachedRequestBodyGatewayFilter(BODY_CACHED_EXISTS)))
-									.uri(uri))
+					.route("cache_request_body_java_test", r -> r.path("/post").and().host("**.cacherequestbody.org")
+							.filters(f -> f.prefixPath("/httpbin").cacheRequestBody(String.class)
+									.filter(new AssertCachedRequestBodyGatewayFilter(BODY_VALUE))
+									.filter(new CheckCachedRequestBodyReleasedGatewayFilter())).uri(uri))
+					.route("cache_request_body_empty_java_test", r -> r.path("/post").and()
+							.host("**.cacherequestbodyempty.org")
+							.filters(f -> f.prefixPath("/httpbin").cacheRequestBody(String.class)
+									.filter(new AssertCachedRequestBodyGatewayFilter(BODY_EMPTY))).uri(uri))
+					.route("cache_request_body_exists_java_test", r -> r.path("/post").and()
+							.host("**.cacherequestbodyexists.org").filters(f -> f.prefixPath("/httpbin")
+									.filter(new SetExchangeCachedRequestBodyGatewayFilter(BODY_CACHED_EXISTS))
+									.cacheRequestBody(String.class)
+									.filter(new AssertCachedRequestBodyGatewayFilter(BODY_CACHED_EXISTS))).uri(uri))
 					.build();
 		}
 
@@ -132,20 +123,17 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 		private String bodyExcepted;
 
 		AssertCachedRequestBodyGatewayFilter(String body) {
-			this.exceptNullBody = !StringUtils.hasText(body);
-			this.bodyExcepted = body;
+			this.exceptNullBody = !StringUtils.hasText(body); this.bodyExcepted = body;
 		}
 
 		@Override
 		public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-			String body = exchange.getAttribute(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR);
-			if (exceptNullBody) {
+			String body = exchange.getAttribute(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR); if (exceptNullBody) {
 				assertThat(body).isNull();
 			}
 			else {
 				assertThat(body).isEqualTo(bodyExcepted);
-			}
-			return chain.filter(exchange);
+			} return chain.filter(exchange);
 		}
 
 	}
@@ -178,8 +166,7 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 						.get(CacheRequestBodyGatewayFilterFactory.CACHED_ORIGIN_REQUEST_BODY_BACKUP_ATTR);
 				if (o instanceof PooledDataBuffer dataBuffer) {
 					if (dataBuffer.isAllocated()) {
-						exchange.getResponse()
-								.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+						exchange.getResponse().setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
 						fail("DataBuffer is not released");
 					}
 				}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
@@ -16,11 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import java.util.Map;
-
 import org.junit.jupiter.api.Test;
-import reactor.core.publisher.Mono;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -33,11 +29,19 @@ import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.io.buffer.PooledDataBuffer;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.lang.reflect.Field;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -101,7 +105,8 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 					.route("cache_request_body_java_test",
 							r -> r.path("/post").and().host("**.cacherequestbody.org")
 									.filters(f -> f.prefixPath("/httpbin").cacheRequestBody(String.class)
-											.filter(new AssertCachedRequestBodyGatewayFilter(BODY_VALUE)))
+											.filter(new AssertCachedRequestBodyGatewayFilter(BODY_VALUE))
+											.filter(new CheckCachedRequestBodyReleasedGatewayFilter()))
 									.uri(uri))
 					.route("cache_request_body_empty_java_test",
 							r -> r.path("/post").and().host("**.cacherequestbodyempty.org")
@@ -159,6 +164,27 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 			return chain.filter(exchange);
 		}
 
+	}
+
+	private static class CheckCachedRequestBodyReleasedGatewayFilter implements GatewayFilter {
+
+		CheckCachedRequestBodyReleasedGatewayFilter() {
+		}
+
+		@Override
+		public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+			return chain.filter(exchange).doAfterTerminate(() -> {
+				Object o = exchange.getAttributes()
+						.get(CacheRequestBodyGatewayFilterFactory.CACHED_ORIGIN_REQUEST_BODY_BACKUP_ATTR);
+				if (o instanceof PooledDataBuffer dataBuffer) {
+					if (dataBuffer.isAllocated()) {
+						exchange.getResponse()
+								.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR);
+						fail("DataBuffer is not released");
+					}
+				}
+			});
+		}
 	}
 
 }


### PR DESCRIPTION
Cached DataBuffer body in cacheRequestBodyAndRequest method is not released issue. Reference is missed because CACHED_REQUEST_BODY_ATTR key is overwritten to Java object.

![image](https://user-images.githubusercontent.com/4270676/212955653-8aa3f7c9-ed62-46ff-83a9-307c6f1cb138.png)


```java
ServerWebExchangeUtils.cacheRequestBodyAndRequest(exchange, (serverHttpRequest) -> {  /* 1 */
	final ServerRequest serverRequest = ServerRequest.create(exchange.mutate().request(serverHttpRequest).build(), messageReaders);
	return serverRequest.bodyToMono((config.getBodyClass())).doOnNext(objectValue -> {
		exchange.getAttributes().put(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR, objectValue); /* 2 */
	}).then(Mono.defer(() -> {
		ServerHttpRequest cachedRequest = exchange
				.getAttribute(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
		Assert.notNull(cachedRequest, "cache request shouldn't be null");
		exchange.getAttributes().remove(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
		return chain.filter(exchange.mutate().request(cachedRequest).build());
	}));
```

```java
/* Inside of 1 */
private static ServerHttpRequest decorate(ServerWebExchange exchange, DataBuffer dataBuffer, boolean cacheDecoratedRequest) {
      if (dataBuffer.readableByteCount() > 0) {
	if (log.isTraceEnabled()) {
		log.trace("retaining body in exchange attribute");
	}

	Object cachedDataBuffer = exchange.getAttribute(CACHED_REQUEST_BODY_ATTR);
	// don't cache if body is already cached
	if (!(cachedDataBuffer instanceof DataBuffer)) {
		exchange.getAttributes().put(CACHED_REQUEST_BODY_ATTR, dataBuffer); /* 1-2 */
	}
...
}
```

**Issue**
- cacheRequestBodyAndRequest is executed from "1".
- At the "1-2", dataBuffer is cached to AttributeMap with key "CACHED_REQUEST_BODY_ATTR"
- And then at the "2", key "CACHED_REQUEST_BODY_ATTR" is overwritten by java object maybe any class type(GC possible).
- This dataBuffer is used at the ServerHttpRequestDecorator so at this time this buffer is necessary.
- But on the "RemoveCachedBodyFilter", this dataBuffer can't be released, because the reference is missed from exchagne.AttributeMap as the key "CACHED_REQUEST_BODY_ATTR".


**Fixing codes**
The root cause of this issue is that "CacheRequestBodyGatewayFilter" is overwritten the dataBuffer and not handled about release.
So, given the responseability of release to "CacheRequestBodyGatewayFilter". Only the case of it is used.

