### PR TITLE
Fix CORS to process all routes

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -272,9 +272,9 @@ public class GatewayAutoConfiguration {
 	@ConditionalOnProperty(name = "spring.cloud.gateway.globalcors.enabled", matchIfMissing = true)
 	public CorsGatewayFilterApplicationListener corsGatewayFilterApplicationListener(
 			GlobalCorsProperties globalCorsProperties, RoutePredicateHandlerMapping routePredicateHandlerMapping,
-			RouteDefinitionLocator routeDefinitionLocator) {
+			RouteLocator routeLocator) {
 		return new CorsGatewayFilterApplicationListener(globalCorsProperties, routePredicateHandlerMapping,
-				routeDefinitionLocator);
+				routeLocator);
 	}
 
 	@Bean


### PR DESCRIPTION
In this functionality we are also using the `RouteDefinitionLocator` to process all routes, but [like we discussed](https://github.com/spring-cloud/spring-cloud-gateway/issues/2850#issuecomment-1406652747), doesn't include those routes defined in a `Bean` (using `RouteLocatorBuilder`).

I have changed it to use the `RouteLocator` which does allow the reading of all routes. I realize [this is not ideal](https://github.com/spring-cloud/spring-cloud-gateway/pull/2854/files#diff-514f32a5f09a66e9c51b46332e96cf4aa4449a5f7c2834bb2c11dbd2cc393492R80), but there doesn't seem to be any other way to get the path from this object 😞 