### PR TITLE
Add uri validation to save route

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
@@ -43,6 +43,7 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.Ordered;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -156,10 +157,27 @@ public class AbstractGatewayControllerEndpoint implements ApplicationEventPublis
 		else if (!unavailablePredicatesDefinitions.isEmpty()) {
 			handleUnavailableDefinition(PredicateDefinition.class.getSimpleName(), unavailablePredicatesDefinitions);
 		}
+
+		validateRouteUri(routeDefinition.getUri());
+	}
+
+	private void validateRouteUri(URI uri) {
+		if (uri == null) {
+			handleError("The URI can not be empty");
+		}
+
+		if (!StringUtils.hasText(uri.getScheme())) {
+			handleError("The URI format [%s] is incorrect, scheme can not be empty".formatted(uri));
+		}
 	}
 
 	private void handleUnavailableDefinition(String simpleName, Set<String> unavailableDefinitions) {
 		final String errorMessage = String.format("Invalid %s: %s", simpleName, unavailableDefinitions);
+		log.warn(errorMessage);
+		throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errorMessage);
+	}
+
+	private void handleError(String errorMessage) {
 		log.warn(errorMessage);
 		throw new ResponseStatusException(HttpStatus.BAD_REQUEST, errorMessage);
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
@@ -209,6 +209,30 @@ public class GatewayControllerEndpointTests {
 	}
 
 	@Test
+	public void testPostRouteWithUriWithoutScheme() {
+
+		RouteDefinition testRouteDefinition = new RouteDefinition();
+		testRouteDefinition.setUri(URI.create("example.org"));
+
+		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/routes/no-scheme-test-route")
+				  .accept(MediaType.APPLICATION_JSON).body(BodyInserters.fromValue(testRouteDefinition)).exchange()
+				  .expectStatus().isBadRequest().expectBody().jsonPath("$.message")
+				  .isEqualTo("The URI format [example.org] is incorrect, scheme can not be empty");
+	}
+
+	@Test
+	public void testPostRouteWithUri() {
+
+		RouteDefinition testRouteDefinition = new RouteDefinition();
+		testRouteDefinition.setUri(null);
+
+		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/routes/no-scheme-test-route")
+				  .accept(MediaType.APPLICATION_JSON).body(BodyInserters.fromValue(testRouteDefinition)).exchange()
+				  .expectStatus().isBadRequest().expectBody().jsonPath("$.message")
+				  .isEqualTo("The URI can not be empty");
+	}
+
+	@Test
 	public void testPostRouteWithNotExistingPredicate() {
 
 		RouteDefinition testRouteDefinition = new RouteDefinition();


### PR DESCRIPTION
### Problem

When an invalid URI is configured in a routeDefinition, the endpoint for saving a route returns 201 Created response. However, the invalid route will finally fail after calling `/refresh` endpoint.

If the developer configures more than one route, and the refresh fails because of one route, all the routes are not persisted, leaving Gateway in an inconsistent state

### Fix

It adds ahead validation of the $.uri to the endpoint POST `/actuator/gateway/route/{id}`.
If the provided URI doesn't have scheme or it is empty, the actuator response will be Bad Request with the message 
a) "The URI format [<URI>] is incorrect, scheme can not be empty"
b) "The URI can not be empty"