### PR TITLE
Add ServerWebExchange a new attribute for PathContainer to avoid repeating parsePath in PathRoutePredicateFactory. 

### DIFF
--- a/spring-cloud-gateway-server/pom.xml
+++ b/spring-cloud-gateway-server/pom.xml
@@ -223,6 +223,17 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.20</version>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.20</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
@@ -34,6 +34,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
 
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_PREDICATE_MATCHED_PATH_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_PREDICATE_MATCHED_PATH_ROUTE_ID_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_PREDICATE_PATH_CONTAINER_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_PREDICATE_ROUTE_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.putUriTemplateVariables;
 import static org.springframework.http.server.PathContainer.parsePath;
@@ -89,7 +90,12 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 		return new GatewayPredicate() {
 			@Override
 			public boolean test(ServerWebExchange exchange) {
-				PathContainer path = parsePath(exchange.getRequest().getURI().getRawPath());
+				PathContainer path = (PathContainer) exchange.getAttributes()
+						.get(GATEWAY_PREDICATE_PATH_CONTAINER_ATTR);
+				if (path == null) {
+					path = parsePath(exchange.getRequest().getURI().getRawPath());
+					exchange.getAttributes().put(GATEWAY_PREDICATE_PATH_CONTAINER_ATTR, path);
+				}
 
 				PathPattern match = null;
 				for (int i = 0; i < pathPatterns.size(); i++) {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -128,6 +128,11 @@ public final class ServerWebExchangeUtils {
 			"gatewayPredicateMatchedPathRouteIdAttr");
 
 	/**
+	 * Gateway predicate path container attribute name.
+	 */
+	public static final String GATEWAY_PREDICATE_PATH_CONTAINER_ATTR = qualify("gatewayPredicatePathContainer");
+
+	/**
 	 * Weight attribute name.
 	 */
 	public static final String WEIGHT_ATTR = qualify("routeWeight");

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicatePathContainerAttrBenchMarkTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicatePathContainerAttrBenchMarkTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.handler.predicate;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.Predicate;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+public class PathRoutePredicatePathContainerAttrBenchMarkTests {
+
+	private static List<Predicate<ServerWebExchange>> predicates;
+
+	private static String PATH_PATTERN_PREFIX;
+
+	private final static String HOST = "http://localhost:8080";
+
+	private final static int ROUTES_NUM = 2000;
+
+	static {
+		predicates = new LinkedList<>();
+		PATH_PATTERN_PREFIX = String.format("/%s/%s/", RandomStringUtils.random(20, true, false),
+				RandomStringUtils.random(10, true, false));
+		for (int i = 0; i < ROUTES_NUM; i++) {
+			PathRoutePredicateFactory.Config config = new PathRoutePredicateFactory.Config()
+					.setPatterns(Collections.singletonList(PATH_PATTERN_PREFIX + i)).setMatchTrailingSlash(true);
+			Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory().apply(config);
+			predicates.add(predicate);
+		}
+	}
+
+	@Benchmark
+	@Threads(2)
+	@Fork(2)
+	@BenchmarkMode(Mode.All)
+	@Warmup(iterations = 1, time = 3)
+	@Measurement(iterations = 10, time = 1)
+	public void testPathContainerAttr() {
+		Random random = new Random();
+		MockServerHttpRequest request = MockServerHttpRequest
+				.get(HOST + PATH_PATTERN_PREFIX + random.nextInt(ROUTES_NUM)).build();
+		MockServerWebExchange exchange = MockServerWebExchange.from(request);
+		for (Predicate<ServerWebExchange> predicate : predicates) {
+			if (predicate.test(exchange)) {
+				break;
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
### What I DO
During lookupRoute, serverWebExchange add a new attribute for PathContainer to avoid repeating parsePath in  **PathRoutePredicateFactory**.  Thereby reducing cpu load and increasing throughput.

**1. Background:**

We have an Spring Cloud Gateway online service with about 2k **path predicate routes**; 
And we found that Spring Cloud Gateway has high cpu load when pressure test request of a route.

**2. Flame Graph and Cause**

The CPU flame graph shows that the PathContainer.**parsePath** in PathRoutePredicateFactory consumes high cpu.

<img width="1230" alt="截屏2023-03-07 上午10 42 56" src="https://user-images.githubusercontent.com/125953751/223329155-ea2af584-a693-4955-87e1-0e88f88944c5.png">

From the code, It is normal that the large number of routes leads to frequent execution of Predicate.apply. 

But an exchange’s PathContainer is unchanged during the lookupRoute, there is no need to **parsePath** every time when test predicate.

<img width="697" alt="protected HonoeRoute LookupRoute (ServerwebExchange oxchange)" src="https://user-images.githubusercontent.com/125953751/223329294-bfa717ab-5dad-4a89-bf26-faf99e10a17d.png">

PathRoutePredicateFactory's test method.

<img width="658" alt="yub Lie boolean tost (SorvorwobExchange oxchango)" src="https://user-images.githubusercontent.com/125953751/223329351-7b744ee3-4be9-4fb5-806a-5c0f23005dc6.png">

**3. Change Details**

**So in PathRoutePredicateFactory,  I hope exchange add a new attribute as below,  to store its pathContainer.  
When there are many path routes, only parsePath one time for a request.**

<img width="686" alt="Boverride" src="https://user-images.githubusercontent.com/125953751/223329408-b404765b-9d86-4d28-a442-cc410e8806c2.png">

Below is the cpu flame graph after the update.

<img width="1234" alt="截屏2023-03-07 上午10 44 36" src="https://user-images.githubusercontent.com/125953751/223329462-ad54c466-dc9d-43c1-9f0f-bbf470acf816.png">

**4. BenchMark**

The following is the benchmark result of PathRoutePredicateFactory‘s test method.  Throughput has been significantly improved after adding the new attribute.

Result of Test method with new attribute.
<img width="1215" alt="截屏2023-03-06 下午11 27 03" src="https://user-images.githubusercontent.com/125953751/223329615-e188280e-2d40-4a97-87ce-a61de09aac66.png">

Result of Test method without new attribute.
<img width="1168" alt="0 2   G 001 w" src="https://user-images.githubusercontent.com/125953751/223329642-517decb8-2894-4d8f-a8c7-bb2b65bf1433.png">


