### PR TITLE
Remove duplicated DataBuffer that caused leak alert by response cache

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
@@ -98,7 +98,7 @@ public class ResponseCacheManager {
 		return body.map(dataBuffer -> {
 			ByteBuffer byteBuffer = dataBuffer.toByteBuffer().asReadOnlyBuffer();
 			cachedResponseBuilder.appendToBody(byteBuffer);
-			return response.bufferFactory().wrap(byteBuffer);
+			return dataBuffer;
 		}).doOnComplete(() -> {
 			CachedResponse responseToCache = cachedResponseBuilder.timestamp(toProcess.timestamp()).build();
 			saveMetadataInCache(metadataKey, metadata);


### PR DESCRIPTION
Issue: https://github.com/spring-cloud/spring-cloud-gateway/issues/2879

Having `response.bufferFactory().wrap(byteBuffer)` left the original DataBuffer without calling internally the `release()` method, which also decreases the counter of the incoming references to the object by Netty memory leak control.

This copy is not necessary and it was causing a memory leak.

I've run some tests locally using the example provided by @MatthiasZerau. Some screenshots are provided

![image](https://user-images.githubusercontent.com/9528270/224088305-9a0ce378-f5d2-4794-aec7-d9d6ade9c716.png)

After applying this fix

![image](https://user-images.githubusercontent.com/9528270/224088363-06e8a9ac-d401-43ab-b270-a4aa7c2e0119.png)

