### PR TITLE
Remove exception creation when creating CachedBodyOutputtMessage.

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/CachedBodyOutputMessage.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/CachedBodyOutputMessage.java
@@ -40,8 +40,7 @@ public class CachedBodyOutputMessage implements ReactiveHttpOutputMessage {
 
 	private boolean cached = false;
 
-	private Flux<DataBuffer> body = Flux
-			.error(new IllegalStateException("The body is not set. " + "Did handling complete with success?"));
+	private Flux<DataBuffer> body = null;
 
 	public CachedBodyOutputMessage(ServerWebExchange exchange, HttpHeaders httpHeaders) {
 		this.bufferFactory = exchange.getResponse().bufferFactory();
@@ -77,6 +76,9 @@ public class CachedBodyOutputMessage implements ReactiveHttpOutputMessage {
 	 * @return body as {@link Flux}
 	 */
 	public Flux<DataBuffer> getBody() {
+		if (body == null) {
+			return Flux.error(new IllegalStateException("The body is not set. " + "Did handling complete with success?"));
+		}
 		return this.body;
 	}
 


### PR DESCRIPTION
Remove exception creation when creating CachedBodyOutputtMessage.

Creating a CachedBodyOutputMessage uses a lot of resources. 


When creating an object of CachedBodyOutputMessage, the following default variables are set as private variables.
```
private Flux<DataBuffer> body = Flux
			.error(new IllegalStateException("The body is not set. " + "Did handling complete with success?"));

```
Generating the exception uses a lots of resource, as you can see from the image. 
![cloud-gateway](https://user-images.githubusercontent.com/10057874/224603925-02e62187-f497-4ae4-975f-56da7ab856ba.JPG)


I have changed it to null and generate an exception when uses the getBody() method.


Thanks :) 
