### PR TITLE
Invalid sections numbering

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -2564,7 +2564,7 @@ A per-route `response-timeout` with a negative value will disable the global `re
           response-timeout: -1
 ----
 
-=== Fluent Java Routes API
+== Fluent Java Routes API
 
 To allow for simple configuration in Java, the `RouteLocatorBuilder` bean includes a fluent API.
 The following listing shows how it works:
@@ -2606,13 +2606,13 @@ This style also allows for more custom predicate assertions.
 The predicates defined by `RouteDefinitionLocator` beans are combined using logical `and`.
 By using the fluent Java API, you can use the `and()`, `or()`, and `negate()` operators on the `Predicate` class.
 
-=== The `DiscoveryClient` Route Definition Locator
+== The `DiscoveryClient` Route Definition Locator
 
 You can configure the gateway to create routes based on services registered with a `DiscoveryClient` compatible service registry.
 
 To enable this, set `spring.cloud.gateway.discovery.locator.enabled=true` and make sure a `DiscoveryClient` implementation (such as Netflix Eureka, Consul, or Zookeeper) is on the classpath and enabled.
 
-==== Configuring Predicates and Filters For `DiscoveryClient` Routes
+=== Configuring Predicates and Filters For `DiscoveryClient` Routes
 
 By default, the gateway defines a single predicate and filter for routes created with a `DiscoveryClient`.
 


### PR DESCRIPTION
The sections "Fluent Java Routes API" and "The `DiscoveryClient` Route Definition Locator" are hierarchically defined under "Http timeouts configuration" but they are unrelated topics. Those sections should be raised one level up and thus should appear as standalone sections with proper numbering.