### PR TITLE
Be able to configure SSL client protocols and ciphers

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GrpcSslConfigurer.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GrpcSslConfigurer.java
@@ -24,6 +24,7 @@ import io.grpc.netty.NettyChannelBuilder;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.springframework.util.CollectionUtils;
 
 /**
  * @author Alberto C. Ríos
@@ -51,6 +52,14 @@ public class GrpcSslConfigurer extends AbstractSslConfigurer<NettyChannelBuilder
 
 		if (!useInsecureTrustManager && ssl.getTrustedX509Certificates().size() > 0) {
 			sslContextBuilder.trustManager(getTrustedX509CertificatesForTrustManager());
+		}
+
+		if(!CollectionUtils.isEmpty(ssl.getProtocols())) {
+			sslContextBuilder.protocols(ssl.getProtocols());
+		}
+
+		if(!CollectionUtils.isEmpty(ssl.getCiphers())) {
+			sslContextBuilder.ciphers(ssl.getCiphers());
 		}
 
 		return sslContextBuilder.keyManager(getKeyManagerFactory()).build();

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
@@ -416,6 +416,12 @@ public class HttpClientProperties {
 		/** Key password, default is same as keyStorePassword. */
 		private String keyPassword;
 
+		/** The protocols to enable, or empty to enable the default protocols. */
+		private List<String> protocols = new ArrayList<>();
+
+		/** The cipher suites to enable, in the order of preference. empty to use default cipher suites. */
+		private List<String> ciphers = new ArrayList<>();
+
 		public String getKeyStorePassword() {
 			return keyStorePassword;
 		}
@@ -454,6 +460,22 @@ public class HttpClientProperties {
 
 		public void setKeyPassword(String keyPassword) {
 			this.keyPassword = keyPassword;
+		}
+
+		public List<String> getProtocols() {
+			return protocols;
+		}
+
+		public void setProtocols(List<String> protocols) {
+			this.protocols = protocols;
+		}
+
+		public List<String> getCiphers() {
+			return ciphers;
+		}
+
+		public void setCiphers(List<String> ciphers) {
+			this.ciphers = ciphers;
 		}
 
 		public List<String> getTrustedX509Certificates() {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/HttpClientSslConfigurer.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/HttpClientSslConfigurer.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.gateway.config;
 import java.security.cert.X509Certificate;
 
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.springframework.util.CollectionUtils;
 import reactor.netty.http.Http11SslContextSpec;
 import reactor.netty.http.Http2SslContextSpec;
 import reactor.netty.http.client.HttpClient;
@@ -58,6 +59,13 @@ public class HttpClientSslConfigurer extends AbstractSslConfigurer<HttpClient, H
 			}
 			else if (ssl.isUseInsecureTrustManager()) {
 				setTrustManager(sslContextBuilder, InsecureTrustManagerFactory.INSTANCE);
+			}
+
+			if(!CollectionUtils.isEmpty(ssl.getProtocols())) {
+				sslContextBuilder.protocols(ssl.getProtocols());
+			}
+			if(!CollectionUtils.isEmpty(ssl.getCiphers())) {
+				sslContextBuilder.ciphers(ssl.getCiphers());
 			}
 
 			try {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/ssl/ForcedClientProtocolsSSLTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/ssl/ForcedClientProtocolsSSLTests.java
@@ -1,0 +1,14 @@
+package org.springframework.cloud.gateway.test.ssl;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@DirtiesContext
+@ActiveProfiles("forced-client-protocols-ssl")
+public class ForcedClientProtocolsSSLTests extends SingleCertSSLTests {
+
+}

--- a/spring-cloud-gateway-server/src/test/resources/application-forced-client-protocols-ssl.yml
+++ b/spring-cloud-gateway-server/src/test/resources/application-forced-client-protocols-ssl.yml
@@ -1,0 +1,13 @@
+spring:
+  cloud:
+    gateway:
+      httpclient:
+        ssl:
+          protocols:
+            - TLSv1.3
+            - TLSv1.2
+            - TLSv1.1
+            - TLSv1
+          ciphers:
+            - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+            - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256


### PR DESCRIPTION
This pull request adds the ability to specify SSL client protocols and ciphers if you don't want to use default values.

Indeed, the switch to java 17 allows only TLSv1.2 and TLSv1.3 by default.
I may have old backends that don't support  TLSv1.2 or TLSv1.3.
Conversely, I might want to make sure, for security reasons, that I only communicate in TLSv1.3 (and exclude TLSv1.2).