### PR TITLE
Add a new endpoint POST /batch/routes

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -2952,11 +2952,17 @@ The following table describes the structure of the response:
 
 |===
 
-=== Creating and Deleting a Particular Route
+=== Creating and Deleting a Particular Route Definition
 
-To create a route, make a `POST` request to `/gateway/routes/{id_route_to_create}` with a JSON body that specifies the fields of the route (see <<gateway-retrieving-information-about-a-particular-route>>).
+To create a route definition, make a `POST` request to `/gateway/routes/{id_route_to_create}` with a JSON body that specifies the fields of the route (see <<gateway-retrieving-information-about-a-particular-route>>).
 
-To delete a route, make a `DELETE` request to `/gateway/routes/{id_route_to_delete}`.
+To delete a route definition, make a `DELETE` request to `/gateway/routes/{id_route_to_delete}`.
+
+=== Creating multiple Route Definitions
+
+To create multiple route definitions in a single request, make a `POST` request to `/gateway/routes` with a JSON body that specifies the fields of the route, including the route id (see <<gateway-retrieving-information-about-a-particular-route>>).
+
+The route definitions will be discarded if any route raises an error during the creation of the routes.
 
 === Recap: The List of All endpoints
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
@@ -145,23 +145,19 @@ public class AbstractGatewayControllerEndpoint implements ApplicationEventPublis
 				.switchIfEmpty(Mono.defer(() -> Mono.just(ResponseEntity.badRequest().build())));
 	}
 
-	@PostMapping("/batch/routes")
+	@PostMapping("/routes")
 	@SuppressWarnings("unchecked")
 	public Mono<ResponseEntity<Object>> save(@RequestBody List<RouteDefinition> routes) {
-		routes.stream()
-			  .forEach(routeDef -> {
-				  validateRouteDefinition(routeDef);
-				  validateRouteId(routeDef);
-			  });
+		routes.stream().forEach(routeDef -> {
+			validateRouteDefinition(routeDef);
+			validateRouteId(routeDef);
+		});
 
 		return Flux.fromIterable(routes)
-				   .flatMap(routeDefinition ->
-						   this.routeDefinitionWriter.save(Mono.just(routeDefinition).map(r -> {
-							   log.debug("Saving route: " + routeDefinition);
-							   return r;
-						   })))
-				   // TODO Check
-				   .then(Mono.defer(() -> Mono.just(ResponseEntity.created(URI.create("/routes/" + routes.get(0).getId())).build())))
+				   .flatMap(routeDefinition -> this.routeDefinitionWriter.save(Mono.just(routeDefinition).map(r -> {
+					   log.debug("Saving route: " + routeDefinition);
+					   return r;
+				   }))).then(Mono.defer(() -> Mono.just(ResponseEntity.ok().build())))
 				   .switchIfEmpty(Mono.defer(() -> Mono.just(ResponseEntity.badRequest().build())));
 	}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/actuate/AbstractGatewayControllerEndpoint.java
@@ -145,6 +145,32 @@ public class AbstractGatewayControllerEndpoint implements ApplicationEventPublis
 				.switchIfEmpty(Mono.defer(() -> Mono.just(ResponseEntity.badRequest().build())));
 	}
 
+	@PostMapping("/batch/routes")
+	@SuppressWarnings("unchecked")
+	public Mono<ResponseEntity<Object>> save(@RequestBody List<RouteDefinition> routes) {
+		routes.stream()
+			  .forEach(routeDef -> {
+				  validateRouteDefinition(routeDef);
+				  validateRouteId(routeDef);
+			  });
+
+		return Flux.fromIterable(routes)
+				   .flatMap(routeDefinition ->
+						   this.routeDefinitionWriter.save(Mono.just(routeDefinition).map(r -> {
+							   log.debug("Saving route: " + routeDefinition);
+							   return r;
+						   })))
+				   // TODO Check
+				   .then(Mono.defer(() -> Mono.just(ResponseEntity.created(URI.create("/routes/" + routes.get(0).getId())).build())))
+				   .switchIfEmpty(Mono.defer(() -> Mono.just(ResponseEntity.badRequest().build())));
+	}
+
+	private void validateRouteId(RouteDefinition routeDefinition) {
+		if(routeDefinition.getId() == null) {
+			handleError("Saving multiple routes require specifying the ID for every route");
+		}
+	}
+
 	private void validateRouteDefinition(RouteDefinition routeDefinition) {
 		Set<String> unavailableFilterDefinitions = routeDefinition.getFilters().stream().filter(rd -> !isAvailable(rd))
 				.map(FilterDefinition::getName).collect(Collectors.toSet());

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
@@ -142,7 +142,6 @@ public class GatewayControllerEndpointTests {
 
 	@Test
 	public void testPostValidRouteDefinition() {
-
 		RouteDefinition testRouteDefinition = new RouteDefinition();
 		testRouteDefinition.setUri(URI.create("http://example.org"));
 
@@ -165,7 +164,6 @@ public class GatewayControllerEndpointTests {
 
 	@Test
 	public void testPostMultipleValidRouteDefinitions() {
-
 		RouteDefinition testRouteDefinition = new RouteDefinition();
 		testRouteDefinition.setUri(URI.create("http://example.org"));
 		String routeId1 = UUID.randomUUID().toString();
@@ -198,13 +196,14 @@ public class GatewayControllerEndpointTests {
 		PredicateDefinition methodRoutePredicateDefinition2 = new PredicateDefinition("Method=GET");
 		PredicateDefinition testPredicateDefinition2 = new PredicateDefinition("Test=value-2");
 		testRouteDefinition2.setPredicates(
-				Arrays.asList(hostRoutePredicateDefinition2, methodRoutePredicateDefinition2, testPredicateDefinition2));
+				Arrays.asList(hostRoutePredicateDefinition2, methodRoutePredicateDefinition2, testPredicateDefinition2)
+		);
 
 		List<RouteDefinition> multipleRouteDefs = List.of(testRouteDefinition, testRouteDefinition2);
 
-		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/batch/routes")
+		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/routes")
 				  .accept(MediaType.APPLICATION_JSON).body(BodyInserters.fromValue(multipleRouteDefs)).exchange()
-				  .expectStatus().isCreated();
+				  .expectStatus().isOk();
 		testClient.get().uri("http://localhost:" + port + "/actuator/gateway/routedefinitions")
 				  .accept(MediaType.APPLICATION_JSON).exchange()
 				  .expectBody()
@@ -238,13 +237,13 @@ public class GatewayControllerEndpointTests {
 
 		List<RouteDefinition> multipleRouteDefs = List.of(testRouteDefinition, testRouteDefinition2);
 
-		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/batch/routes")
+		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/routes")
 				  .accept(MediaType.APPLICATION_JSON).body(BodyInserters.fromValue(multipleRouteDefs)).exchange()
 				  .expectStatus().is4xxClientError();
 
 		testClient.get().uri("http://localhost:" + port + "/actuator/gateway/routedefinitions")
 				  .accept(MediaType.APPLICATION_JSON).exchange()
-				.expectBody()
+				  .expectBody()
 				  .jsonPath("[?(@.id in ['%s','%s'])].id".formatted(routeId1, routeId2)).doesNotExist();
 	}
 	

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Predicate;
 
 import org.assertj.core.util.Maps;
@@ -162,6 +163,91 @@ public class GatewayControllerEndpointTests {
 				.expectStatus().isCreated();
 	}
 
+	@Test
+	public void testPostMultipleValidRouteDefinitions() {
+
+		RouteDefinition testRouteDefinition = new RouteDefinition();
+		testRouteDefinition.setUri(URI.create("http://example.org"));
+		String routeId1 = UUID.randomUUID().toString();
+		testRouteDefinition.setId(routeId1);
+
+		FilterDefinition prefixPathFilterDefinition = new FilterDefinition("PrefixPath=/test-path");
+		FilterDefinition redirectToFilterDefinition = new FilterDefinition("RemoveResponseHeader=Sensitive-Header");
+		FilterDefinition testFilterDefinition = new FilterDefinition("TestFilter");
+		testRouteDefinition.setFilters(
+				Arrays.asList(prefixPathFilterDefinition, redirectToFilterDefinition, testFilterDefinition));
+
+		PredicateDefinition hostRoutePredicateDefinition = new PredicateDefinition("Host=myhost.org");
+		PredicateDefinition methodRoutePredicateDefinition = new PredicateDefinition("Method=GET");
+		PredicateDefinition testPredicateDefinition = new PredicateDefinition("Test=value");
+		testRouteDefinition.setPredicates(
+				Arrays.asList(hostRoutePredicateDefinition, methodRoutePredicateDefinition, testPredicateDefinition));
+
+		RouteDefinition testRouteDefinition2 = new RouteDefinition();
+		testRouteDefinition2.setUri(URI.create("http://example-2.org"));
+		String routeId2 = UUID.randomUUID().toString();
+		testRouteDefinition2.setId(routeId2);
+
+		FilterDefinition prefixPathFilterDefinition2 = new FilterDefinition("PrefixPath=/test-path-2");
+		FilterDefinition redirectToFilterDefinition2 = new FilterDefinition("RemoveResponseHeader=Sensitive-Header-2");
+		FilterDefinition testFilterDefinition2 = new FilterDefinition("TestFilter");
+		testRouteDefinition2.setFilters(
+				Arrays.asList(prefixPathFilterDefinition2, redirectToFilterDefinition2, testFilterDefinition2));
+
+		PredicateDefinition hostRoutePredicateDefinition2 = new PredicateDefinition("Host=myhost-2.org");
+		PredicateDefinition methodRoutePredicateDefinition2 = new PredicateDefinition("Method=GET");
+		PredicateDefinition testPredicateDefinition2 = new PredicateDefinition("Test=value-2");
+		testRouteDefinition2.setPredicates(
+				Arrays.asList(hostRoutePredicateDefinition2, methodRoutePredicateDefinition2, testPredicateDefinition2));
+
+		List<RouteDefinition> multipleRouteDefs = List.of(testRouteDefinition, testRouteDefinition2);
+
+		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/batch/routes")
+				  .accept(MediaType.APPLICATION_JSON).body(BodyInserters.fromValue(multipleRouteDefs)).exchange()
+				  .expectStatus().isCreated();
+		testClient.get().uri("http://localhost:" + port + "/actuator/gateway/routedefinitions")
+				  .accept(MediaType.APPLICATION_JSON).exchange()
+				  .expectBody()
+				  .jsonPath("[?(@.id in ['%s','%s'])].id".formatted(routeId1, routeId2)).exists();
+	}
+
+	@Test
+	public void testPostMultipleRoutesWithOneWrong_doesntPersistRouteDefinitions() {
+
+		RouteDefinition testRouteDefinition = new RouteDefinition();
+		testRouteDefinition.setUri(URI.create("http://example.org"));
+		String routeId1 = UUID.randomUUID().toString();
+		testRouteDefinition.setId(routeId1);
+
+		FilterDefinition prefixPathFilterDefinition = new FilterDefinition("PrefixPath=/test-path");
+		FilterDefinition redirectToFilterDefinition = new FilterDefinition("RemoveResponseHeader=Sensitive-Header");
+		FilterDefinition testFilterDefinition = new FilterDefinition("TestFilter");
+		testRouteDefinition.setFilters(
+				Arrays.asList(prefixPathFilterDefinition, redirectToFilterDefinition, testFilterDefinition));
+
+		PredicateDefinition hostRoutePredicateDefinition = new PredicateDefinition("Host=myhost.org");
+		PredicateDefinition methodRoutePredicateDefinition = new PredicateDefinition("Method=GET");
+		PredicateDefinition testPredicateDefinition = new PredicateDefinition("Test=value");
+		testRouteDefinition.setPredicates(
+				Arrays.asList(hostRoutePredicateDefinition, methodRoutePredicateDefinition, testPredicateDefinition));
+
+		RouteDefinition testRouteDefinition2 = new RouteDefinition();
+		testRouteDefinition2.setUri(URI.create("this-is-wrong"));
+		String routeId2 = UUID.randomUUID().toString();
+		testRouteDefinition2.setId(routeId2);
+
+		List<RouteDefinition> multipleRouteDefs = List.of(testRouteDefinition, testRouteDefinition2);
+
+		testClient.post().uri("http://localhost:" + port + "/actuator/gateway/batch/routes")
+				  .accept(MediaType.APPLICATION_JSON).body(BodyInserters.fromValue(multipleRouteDefs)).exchange()
+				  .expectStatus().is4xxClientError();
+
+		testClient.get().uri("http://localhost:" + port + "/actuator/gateway/routedefinitions")
+				  .accept(MediaType.APPLICATION_JSON).exchange()
+				.expectBody()
+				  .jsonPath("[?(@.id in ['%s','%s'])].id".formatted(routeId1, routeId2)).doesNotExist();
+	}
+	
 	@Test
 	public void testPostValidShortcutRouteDefinition() {
 		RouteDefinition testRouteDefinition = new RouteDefinition();


### PR DESCRIPTION
It extends `POST /actuator/gateway/routes` endpoint to persist multiple `RouteDefinition` elements in a single request.

Validation is done before persisting any RouteDefinition.

Example

POST http://localhost:9099/actuator/gateway/routes
```json
[
    {
        "id": "route-1",
        "predicates": [
            {
                "name": "Path",
                "args": {
                    "_genkey_0": "/test/**"
                }
            }
        ],
        "filters": [
            {
                "name": "StripPrefix",
                "args": {
                    "_genkey_0": "1"
                }
            }
        ],
        "uri": "http://httpbin.org",
        "order": 0
    },
    {
        "id": "route-2",
        "predicates": [
            {
                "name": "Path",
                "args": {
                    "_genkey_0": "/test/**"
                }
            }
        ],
        "filters": [
            {
                "name": "StripPrefix",
                "args": {
                    "_genkey_0": "1"
                }
            }
        ],
        "uri": "http://httpbin.org",
        "order": 0
    }
]
```

> Response: 200 OK (no 201 because we are not creating a single resource)

Note: To upload more than the default `262144` payload size, you need to update the following property. I would like to update only the Management endpoint, but it seems a global size for the whole module.

```yml
spring:
  codec:
    max-in-memory-size: 100KB
```

I have created an [implementation](https://github.com/ilozano2/sc-management-codec-max-size) that could be included in spring-boot to only increase `max-in-memory-size` of the Management Server (Actuator endpoints) in case you want to protect the management server and leave the default value in the SCG Server for preventing any DDOS attack.