### PR TITLE
Fix bug when combining LocalResponseCache

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilter.java
@@ -95,11 +95,10 @@ public class ResponseCacheGatewayFilter implements GatewayFilter, Ordered {
 
 			Flux<DataBuffer> decoratedBody;
 			if (responseCacheManager.isResponseCacheable(response)) {
-				decoratedBody = responseCacheManager.processFromUpstream(metadataKey, exchange,
-						(Flux<DataBuffer>) body);
+				decoratedBody = responseCacheManager.processFromUpstream(metadataKey, exchange, Flux.from(body));
 			}
 			else {
-				decoratedBody = (Flux<DataBuffer>) body;
+				decoratedBody = Flux.from(body);
 			}
 
 			return super.writeWith(decoratedBody);

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
@@ -207,6 +207,16 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 				.header(CUSTOM_HEADER, "2").exchange().expectBody().jsonPath("$.headers." + CUSTOM_HEADER, "2");
 	}
 
+	@Test
+	void shouldWorkInCombinationWithRemoveJsonAttributes() {
+		String uri = "/" + UUID.randomUUID() + "/cache-and-remove-jsonattrs/headers";
+
+		testClient.method(HttpMethod.GET).uri(uri).header("Host", "www.localresponsecache.org")
+				 .exchange().expectBody(String.class).consumeWith(body -> {
+					 assertThat(body.getResponseBody()).doesNotContain("headers");
+				  });
+	}
+
 	private Long parseMaxAge(String cacheControlValue) {
 		if (StringUtils.hasText(cacheControlValue)) {
 			Pattern maxAgePattern = Pattern.compile("\\bmax-age=(\\d+)\\b");
@@ -241,6 +251,13 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 		@Bean
 		public RouteLocator testRouteLocator(RouteLocatorBuilder builder) {
 			return builder.routes()
+				    .route("local_response_cache_combined_remove_json_attrs",
+						    r -> r.path("/{namespace}/cache-and-remove-jsonattrs/**").and().host("{sub}.localresponsecache.org")
+							  		.filters(f -> f.stripPrefix(2).prefixPath("/httpbin")
+											   .localResponseCache(Duration.ofMinutes(2), null)
+											   .removeJsonAttributes("headers")
+									)
+									.uri(uri))
 					.route("local_response_cache_java_test",
 							r -> r.path("/{namespace}/cache/**").and().host("{sub}.localresponsecache.org")
 									.filters(f -> f.stripPrefix(2).prefixPath("/httpbin")


### PR DESCRIPTION
Using

```yml
- StripPrefix=0
- LocalResponseCache=3m,1MB
- RemoveJsonAttributesResponseBody=args,data,files,Sec-Fetch-Dest,true
      uri: https://httpbin.org
```

the Flux<DataBuffer> was replaced by other type, provoking a ClassCastException