### PR TITLE
Remove hopbyhop list should be lower case

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
@@ -37,10 +37,10 @@ public class RemoveHopByHopHeadersFilter implements HttpHeadersFilter, Ordered {
 	public static final Set<String> HEADERS_REMOVED_ON_REQUEST = new HashSet<>(
 			Arrays.asList("connection", "keep-alive", "transfer-encoding", "te", "trailer", "proxy-authorization",
 					"proxy-authenticate", "x-application-context", "upgrade"
-					// these two are not listed in
-					// https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3
-					// "proxy-connection",
-					// "content-length",
+			// these two are not listed in
+			// https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3
+			// "proxy-connection",
+			// "content-length",
 			));
 
 	private int order = Ordered.LOWEST_PRECEDENCE - 1;

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.Ordered;
@@ -36,10 +37,10 @@ public class RemoveHopByHopHeadersFilter implements HttpHeadersFilter, Ordered {
 	public static final Set<String> HEADERS_REMOVED_ON_REQUEST = new HashSet<>(
 			Arrays.asList("connection", "keep-alive", "transfer-encoding", "te", "trailer", "proxy-authorization",
 					"proxy-authenticate", "x-application-context", "upgrade"
-			// these two are not listed in
-			// https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3
-			// "proxy-connection",
-			// "content-length",
+					// these two are not listed in
+					// https://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-14#section-7.1.3
+					// "proxy-connection",
+					// "content-length",
 			));
 
 	private int order = Ordered.LOWEST_PRECEDENCE - 1;
@@ -51,7 +52,8 @@ public class RemoveHopByHopHeadersFilter implements HttpHeadersFilter, Ordered {
 	}
 
 	public void setHeaders(Set<String> headers) {
-		this.headers = headers;
+		this.headers = headers.stream().map(String::toLowerCase).collect(
+				Collectors.toSet());
 	}
 
 	@Override


### PR DESCRIPTION
```java
for (Map.Entry<String, List<String>> entry : input.entrySet()) {
	if (!this.headers.contains(entry.getKey().toLowerCase())) {
		filtered.addAll(entry.getKey(), entry.getValue());
	}
}
```
In the filtering codes, input keys are changed to lowercase before checking.
But if header list is set by called setHeader method. the list is not assured that is all lowser case.

```yml
  filter:
    remove-hop-by-hop:
      headers: Proxy-Authenticate, Proxy-Authorization,
        Keep-Alive, TE, Trailer, Transfer-Encoding,
        x-application-context
```

If user define their custom headers with like above, that is not working as expected.

Hence In my opinion, if filtering code use only lowser case, that's better custom headers also to be changed automatically.