### PR TITLE
Change the error of the documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-gateway.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-gateway.adoc
@@ -2734,7 +2734,7 @@ spring:
         predicates:
         - Path=/service/**
         metadata:
-          cors
+          cors:
             allowedOrigins: '*'
             allowedMethods:
               - GET


### PR DESCRIPTION
The configuration example of CORS in the document lacks one ":"