### PR TITLE
Fix Bug : RemoveCachedBodyFilter does not release direct memory correctly resulting in a memory leak #2969

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
@@ -99,6 +99,8 @@ public class DiscoveryClientRouteDefinitionLocator implements RouteDefinitionLoc
 		return serviceInstances.filter(instances -> !instances.isEmpty()).flatMap(Flux::fromIterable)
 				.filter(includePredicate).collectMap(ServiceInstance::getServiceId)
 				// remove duplicates
+                .filter(instance ->  !instance.getServiceId().startsWith(" "))
+				// filter out illegal serviceIds
 				.flatMapMany(map -> Flux.fromIterable(map.values())).map(instance -> {
 					RouteDefinition routeDefinition = buildRouteDefinition(urlExpr, instance);
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
@@ -98,9 +98,15 @@ public class DiscoveryClientRouteDefinitionLocator implements RouteDefinitionLoc
 
 		return serviceInstances.filter(instances -> !instances.isEmpty()).flatMap(Flux::fromIterable)
 				.filter(includePredicate).collectMap(ServiceInstance::getServiceId)
+				// Filter out illegal serviceIds
+                .filter(instance -> {
+                    if (instance.getServiceId().startsWith(" ")) {
+                        log.debug("Illegal ServiceId: +" + instance.getServiceId());
+                        return false;
+                    }
+                    return true;
+                })
 				// remove duplicates
-                .filter(instance ->  !instance.getServiceId().startsWith(" "))
-				// filter out illegal serviceIds
 				.flatMapMany(map -> Flux.fromIterable(map.values())).map(instance -> {
 					RouteDefinition routeDefinition = buildRouteDefinition(urlExpr, instance);
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/RemoveCachedBodyFilter.java
@@ -40,7 +40,8 @@ public class RemoveCachedBodyFilter implements GlobalFilter, Ordered {
 					if (log.isTraceEnabled()) {
 						log.trace("releasing cached body in exchange attribute");
 					}
-					dataBuffer.release();
+					// ensure proper release
+					while(!dataBuffer.release()) {}
 				}
 			}
 		});


### PR DESCRIPTION
Fixes #2969 

RemoveCachedBodyFilter uses the remove method to remove CACHED_REQUEST_BODY_ATTR from the exchange object, but it cannot guarantee that the dataBuffer will be released correctly.

When calling ServerWebExchangeUtils.cacheRequestBody multiple times in the project to generate a nested multi-layer ServerHttpRequestDecorator, it will cause a memory leak and eventually throw an OutOfDirectMemoryError

So in RemoveCachedBodyFilter, it should be ensured that the cached dataBuffer is released correctly.

This PR contains a fix for this problem. The idea is to ensure that databuf is released correctly by judging the return value of release.

Please review this PR, if looks ok please approve it.