### PR TITLE
Remove concatMap in lookupRoute to improve throughput

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -126,17 +126,16 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 
 	protected Mono<Route> lookupRoute(ServerWebExchange exchange) {
 		return this.routeLocator.getRoutes()
-				// individually filter routes so that filterWhen error delaying is not a
-				// problem
-				.concatMap(route -> Mono.just(route).filterWhen(r -> {
+				.filterWhen(route -> {
 					// add the current route we are testing
-					exchange.getAttributes().put(GATEWAY_PREDICATE_ROUTE_ATTR, r.getId());
-					return r.getPredicate().apply(exchange);
+					exchange.getAttributes().put(GATEWAY_PREDICATE_ROUTE_ATTR, route.getId());
+					try {
+						return route.getPredicate().apply(exchange);
+					} catch (Exception e) {
+						logger.error("Error applying predicate for route: " + route.getId(), e);
+					}
+					return Mono.just(false);
 				})
-						// instead of immediately stopping main flux due to error, log and
-						// swallow it
-						.doOnError(e -> logger.error("Error applying predicate for route: " + route.getId(), e))
-						.onErrorResume(e -> Mono.empty()))
 				// .defaultIfEmpty() put a static Route not found
 				// or .switchIfEmpty()
 				// .switchIfEmpty(Mono.<Route>empty().log("noroute"))

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
@@ -66,7 +66,7 @@ public class RoutePredicateHandlerMappingTests {
 		Route routeFalse = Route.async().id("routeFalse").uri("http://localhost")
 				.asyncPredicate(swe -> Mono.just(false)).build();
 		Route routeError = Route.async().id("routeError").uri("http://localhost")
-				.asyncPredicate(swe -> Mono.error(new IllegalStateException("boom1"))).build();
+				.asyncPredicate(swe -> Mono.just(test())).build();
 		Route routeFail = Route.async().id("routeFail").uri("http://localhost").asyncPredicate(swe -> {
 			throw new IllegalStateException("boom2");
 		}).build();
@@ -85,6 +85,10 @@ public class RoutePredicateHandlerMappingTests {
 
 		Assertions.assertTrue(capturedOutput.getOut().contains("Error applying predicate for route: routeFail"));
 		Assertions.assertTrue(capturedOutput.getOut().contains("java.lang.IllegalStateException: boom2"));
+	}
+
+	boolean test() {
+		throw new IllegalStateException("boom1");
 	}
 
 }


### PR DESCRIPTION
### What I DO

In lookupRoute, translate route to Mono will lead into context propagation and additional operators.

When the number of routes increases, it becomes the bottleneck of throughput. 

So the PR removes the concatMap in lookupRoute.

**1. Background:**

After the modification of [PR]https://github.com/spring-cloud/spring-cloud-gateway/pull/2884, I found that the throughput did not meet expectations.

But there's no suspicious on Spring Cloud Gateway; So turned attention to Reactor.

**2. Flame Graph and Cause**

By testing 2k routes that predicate is `asyncPredicate(s -> Mono.just(Boolean))`  ，we found the context propagation in MonoFilterWhen.onNext and operators in the concatMap function is the bottleneck. 
<img width="1579" alt="1" src="https://github.com/spring-cloud/spring-cloud-gateway/assets/125953751/0322b1e5-64fe-4e82-a8a0-83696aaee592">
<img width="885" alt="3" src="https://github.com/spring-cloud/spring-cloud-gateway/assets/125953751/298a0a0f-13b0-442e-b7f2-61702b7b76ce">
<img width="907" alt="2" src="https://github.com/spring-cloud/spring-cloud-gateway/assets/125953751/3995108c-3871-43ba-9630-ef16f162a3a3">

<img width="954" alt="4" src="https://github.com/spring-cloud/spring-cloud-gateway/assets/125953751/9b96f193-4fa8-4712-bb88-42c805c288a9">

**3. Change Details**

So in lookupRoute, I hope to remove the concatMap and use filterWhen instead it.
<img width="855" alt="截屏2023-06-07 下午3 22 38" src="https://github.com/spring-cloud/spring-cloud-gateway/assets/125953751/dee6cbf0-093e-45ea-884f-d67d9be2ecc5">
For the delay error mentioned in the [PR]https://github.com/spring-cloud/spring-cloud-gateway/pull/427, filterWhen function doesn't return MonoError, so i think no exceptions and logs will be swallowed.



**4.Throughput Improvement**

After modification, the bottleneck is solved, not too much context propagation and operators.
<img width="1583" alt="截屏2023-06-07 下午12 42 47" src="https://github.com/spring-cloud/spring-cloud-gateway/assets/125953751/89f1034c-cf44-44ba-8d4c-6ff57bba4ed5">

I have tested the throughput before and after the modification under different routing quantities. 
I used  `wrk -t 1 -c 10 -d 10s http://localhost/test` on a 8 core MacBook Pro M1. Below is the result.
<img width="389" alt="截屏2023-06-07 下午3 00 59" src="https://github.com/spring-cloud/spring-cloud-gateway/assets/125953751/1cc85f16-e843-4843-bd05-a265bf1fa1ca">

From the test results, it can be seen that the modified throughput is significantly improved.
