### PR TITLE
Support setting Spring.webflux.base-path and supporting it in path predicate

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway/request-predicates-factories.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway/request-predicates-factories.adoc
@@ -192,6 +192,8 @@ This route matches if the request path was, for example: `/red/1` or `/red/1/` o
 
 If `matchTrailingSlash` is set to `false`, then request path `/red/1/` will not be matched.
 
+If you have set `spring.webflux.base-path` property, this will influence the path matching. The property value will be automatically prepended to the path patterns. For example, with `spring.webflux.base-path=/app` and a path pattern of `/red/{segment}`, the full pattern used for matching would be `/app/red/{segment}`.
+
 This predicate extracts the URI template variables (such as `segment`, defined in the preceding example) as a map of names and values and places it in the `ServerWebExchange.getAttributes()` with a key defined in `ServerWebExchangeUtils.URI_TEMPLATE_VARIABLES_ATTRIBUTE`.
 Those values are then available for use by <<gateway-route-filters,`GatewayFilter` factories>>
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -56,6 +56,7 @@ import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.autoconfigure.web.embedded.NettyWebServerFactoryCustomizer;
 import org.springframework.boot.autoconfigure.web.reactive.HttpHandlerAutoConfiguration;
 import org.springframework.boot.autoconfigure.web.reactive.WebFluxAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.PropertyMapper;
 import org.springframework.boot.ssl.SslBundles;
@@ -190,6 +191,7 @@ import org.springframework.web.reactive.socket.server.upgrade.ReactorNettyReques
  * @author Mete Alpaslan Katırcıoğlu
  * @author Alberto C. Ríos
  * @author Olga Maciaszek-Sharma
+ * @author FuYiNan Guo
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "spring.cloud.gateway.enabled", matchIfMissing = true)
@@ -471,8 +473,8 @@ public class GatewayAutoConfiguration {
 
 	@Bean
 	@ConditionalOnEnabledPredicate
-	public PathRoutePredicateFactory pathRoutePredicateFactory() {
-		return new PathRoutePredicateFactory();
+	public PathRoutePredicateFactory pathRoutePredicateFactory(WebFluxProperties webFluxProperties) {
+		return new PathRoutePredicateFactory(webFluxProperties);
 	}
 
 	@Bean

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
@@ -26,6 +26,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
 import org.springframework.cloud.gateway.handler.predicate.PathRoutePredicateFactory.Config;
@@ -133,14 +134,14 @@ public class PathRoutePredicateFactoryTests extends BaseWebClientTests {
 	@Test
 	public void toStringFormat() {
 		Config config = new Config().setPatterns(Arrays.asList("patternA", "patternB")).setMatchTrailingSlash(false);
-		Predicate predicate = new PathRoutePredicateFactory().apply(config);
+		Predicate predicate = new PathRoutePredicateFactory(new WebFluxProperties()).apply(config);
 		assertThat(predicate.toString()).contains("patternA").contains("patternB").contains("false");
 	}
 
 	@Test
 	public void toStringFormatMatchTrailingSlashTrue() {
 		Config config = new Config().setPatterns(Arrays.asList("patternA", "patternB")).setMatchTrailingSlash(true);
-		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory().apply(config);
+		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new WebFluxProperties()).apply(config);
 		assertThat(predicate.toString()).contains("patternA").contains("patternB").contains("true");
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicatePathContainerAttrBenchMarkTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicatePathContainerAttrBenchMarkTests.java
@@ -30,6 +30,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
+import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
@@ -54,7 +55,7 @@ public class PathRoutePredicatePathContainerAttrBenchMarkTests {
 			PathRoutePredicateFactory.Config config = new PathRoutePredicateFactory.Config()
 				.setPatterns(Collections.singletonList(PATH_PATTERN_PREFIX + i))
 				.setMatchTrailingSlash(true);
-			Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory().apply(config);
+			Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new WebFluxProperties()).apply(config);
 			predicates.add(predicate);
 		}
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayPathTagsProviderTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayPathTagsProviderTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 import io.micrometer.core.instrument.Tags;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.autoconfigure.web.reactive.WebFluxProperties;
 import org.springframework.cloud.gateway.handler.predicate.HostRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.MethodRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.PathRoutePredicateFactory;
@@ -56,7 +57,7 @@ public class GatewayPathTagsProviderTests {
 		Route route = Route.async()
 			.id("git")
 			.uri(ROUTE_URI)
-			.predicate(new PathRoutePredicateFactory().apply(pathConfig)
+			.predicate(new PathRoutePredicateFactory(new WebFluxProperties()).apply(pathConfig)
 				.and(new HostRoutePredicateFactory().apply(hostConfig)))
 			.build();
 
@@ -81,8 +82,8 @@ public class GatewayPathTagsProviderTests {
 		Route route = Route.async()
 			.id("git")
 			.uri(ROUTE_URI)
-			.predicate(new PathRoutePredicateFactory().apply(pathConfig)
-				.or(new PathRoutePredicateFactory().apply(pathConfig2)))
+			.predicate(new PathRoutePredicateFactory(new WebFluxProperties()).apply(pathConfig)
+				.or(new PathRoutePredicateFactory(new WebFluxProperties()).apply(pathConfig2)))
 			.build();
 
 		ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get(ROUTE_URI).build());


### PR DESCRIPTION
Fix Bug : Setting Spring.webflux.base-path All Path Predicates Return 404 Results

Issues : 
[New Issue : #2944](https://github.com/spring-cloud/spring-cloud-gateway/issues/2944)
[Three Years Ago Issue : #1759](https://github.com/spring-cloud/spring-cloud-gateway/issues/1759)
