### PR TITLE
Supported ratelimiter on redis cluster mode

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
@@ -146,7 +146,11 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 	}
 
 	static List<String> getKeys(String id) {
-		return Arrays.asList(id);
+		// use `{}` around keys to use Redis Key hash tags
+		// this allows for using redis cluster
+
+		// Make a unique key per user.
+		return Arrays.asList("request_rate_limiter.{" + id + "}");
 	}
 
 	public boolean isIncludeHeaders() {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
@@ -146,16 +146,7 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 	}
 
 	static List<String> getKeys(String id) {
-		// use `{}` around keys to use Redis Key hash tags
-		// this allows for using redis cluster
-
-		// Make a unique key per user.
-		String prefix = "request_rate_limiter.{" + id;
-
-		// You need two Redis keys for Token Bucket.
-		String tokenKey = prefix + "}.tokens";
-		String timestampKey = prefix + "}.timestamp";
-		return Arrays.asList(tokenKey, timestampKey);
+		return Arrays.asList(id);
 	}
 
 	public boolean isIncludeHeaders() {

--- a/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
+++ b/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
@@ -1,7 +1,6 @@
 redis.replicate_commands()
 
-local tokens_key = KEYS[1]
-local timestamp_key = KEYS[2]
+local key = KEYS[1]
 --redis.log(redis.LOG_WARNING, "tokens_key " .. tokens_key)
 
 local rate = tonumber(ARGV[1])
@@ -24,13 +23,13 @@ end
 --redis.log(redis.LOG_WARNING, "filltime " .. fill_time)
 --redis.log(redis.LOG_WARNING, "ttl " .. ttl)
 
-local last_tokens = tonumber(redis.call("get", tokens_key))
+local last_tokens = tonumber(redis.call('HGET', key, 'tokens'))
 if last_tokens == nil then
   last_tokens = capacity
 end
 --redis.log(redis.LOG_WARNING, "last_tokens " .. last_tokens)
 
-local last_refreshed = tonumber(redis.call("get", timestamp_key))
+local last_refreshed = tonumber(redis.call('HGET', key, 'timestamp'))
 if last_refreshed == nil then
   last_refreshed = 0
 end
@@ -52,8 +51,9 @@ end
 --redis.log(redis.LOG_WARNING, "new_tokens " .. new_tokens)
 
 if ttl > 0 then
-  redis.call("setex", tokens_key, ttl, new_tokens)
-  redis.call("setex", timestamp_key, ttl, now)
+  redis.call('HSET', key, 'tokens', new_tokens)
+  redis.call('HSET', key, 'timestamp', now)
+  redis.call('EXPIRE', key, ttl)
 end
 
 -- return { allowed_num, new_tokens, capacity, filled_tokens, requested, new_tokens }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterLuaScriptTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterLuaScriptTests.java
@@ -64,7 +64,7 @@ public class RedisRateLimiterLuaScriptTests {
 	}
 
 	static List<String> getKeys(String id) {
-		return List.of(id);
+		return List.of(KEY_PREFIX + ".{" + id + "}");
 	}
 
 	static List<String> getArgs(long rate, long capacity, long now, long requested) {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterLuaScriptTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterLuaScriptTests.java
@@ -64,10 +64,7 @@ public class RedisRateLimiterLuaScriptTests {
 	}
 
 	static List<String> getKeys(String id) {
-		String prefix = KEY_PREFIX + ".{" + id;
-		String tokens = prefix + "}.tokens";
-		String timestamp = prefix + "}.timestamp";
-		return Arrays.asList(tokens, timestamp);
+		return List.of(id);
 	}
 
 	static List<String> getArgs(long rate, long capacity, long now, long requested) {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -128,8 +128,7 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 
 	@Test
 	public void keysUseRedisKeyHashTags() {
-		assertThat(RedisRateLimiter.getKeys("1")).containsExactly("request_rate_limiter.{1}.tokens",
-				"request_rate_limiter.{1}.timestamp");
+		assertThat(RedisRateLimiter.getKeys("1")).containsExactly("request_rate_limiter.{1}");
 	}
 
 	@Test


### PR DESCRIPTION
Now ratelimiter is not worked on cluster mode, because 2 keys are used in one call. 
So, changed from 2 key to 1 key on lua script using redis command "HGET", "HSET".

Fixes gh-3001