### PR TITLE
Adding Logging Statement to gRPC Server Shutdown

### DIFF
--- a/spring-cloud-gateway-integration-tests/grpc/src/main/java/org/springframework/cloud/gateway/tests/grpc/GRPCApplication.java
+++ b/spring-cloud-gateway-integration-tests/grpc/src/main/java/org/springframework/cloud/gateway/tests/grpc/GRPCApplication.java
@@ -98,6 +98,7 @@ public class GRPCApplication {
 			if (server != null) {
 				server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
 			}
+			log.info("gRPC server stopped");
 		}
 
 		static class HelloService extends HelloServiceGrpc.HelloServiceImplBase {


### PR DESCRIPTION
This Pull Request introduces a minor modification to the GRPCServer class within the package org.springframework.cloud.gateway.tests.grpc. The change involves adding a logging statement in the stop() method of the GRPCServer class. 

The rationale behind this change is to provide a consistent logging mechanism throughout the lifecycle of the gRPC server. As it stands, we have a logging statement during the server's startup, but not during its shutdown. This addition will provide better visibility and traceability for developers and operators, especially when debugging or monitoring the application.