### PR TITLE
Allow stripPrefix to be less strict about contextPaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _site/
 *.swo
 .vscode/
 .flattened-pom.xml
+.devcontainer/

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/StripPrefixGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/StripPrefixGatewayFilterFactory.java
@@ -79,8 +79,11 @@ public class StripPrefixGatewayFilterFactory
 					newPath.append('/');
 				}
 
-				ServerHttpRequest newRequest = request.mutate().path(newPath.toString()).build();
-
+				ServerHttpRequest.Builder requestBuilder = request.mutate().path(newPath.toString());
+				if (!(config.getEnforceContextPath())) {
+					requestBuilder.contextPath(null);
+				}
+				ServerHttpRequest newRequest = requestBuilder.build();
 				exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, newRequest.getURI());
 
 				return chain.filter(exchange.mutate().request(newRequest).build());
@@ -89,7 +92,7 @@ public class StripPrefixGatewayFilterFactory
 			@Override
 			public String toString() {
 				return filterToStringCreator(StripPrefixGatewayFilterFactory.this).append("parts", config.getParts())
-						.toString();
+						.append("enforeContextPath", config.getEnforceContextPath()).toString();
 			}
 		};
 	}
@@ -98,12 +101,22 @@ public class StripPrefixGatewayFilterFactory
 
 		private int parts = 1;
 
+		private boolean enforceContextPath = true;
+
 		public int getParts() {
 			return parts;
 		}
 
 		public void setParts(int parts) {
 			this.parts = parts;
+		}
+
+		public boolean getEnforceContextPath() {
+			return enforceContextPath;
+		}
+
+		public void setEnforceContextPath(boolean enforceContextPath) {
+			this.enforceContextPath = enforceContextPath;
 		}
 
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -743,6 +743,20 @@ public class GatewayFilterSpec extends UriSpec {
 	}
 
 	/**
+	 * Strips the prefix from the path of the request before it is routed by the Gateway.
+	 * @param parts the number of parts of the path to remove
+	 * @param enforeContextPath whether the resulting path must contain the context-path
+	 * defined for the application
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec stripPrefix(int parts, boolean enforceContextPath) {
+		return filter(getBean(StripPrefixGatewayFilterFactory.class).apply(c -> {
+			c.setParts(parts);
+			c.setEnforceContextPath(enforceContextPath);
+		}));
+	}
+
+	/**
 	 * A filter which changes the URI the request will be routed to by the Gateway by
 	 * pulling it from a header on the request.
 	 * @param headerName the header name containing the URI


### PR DESCRIPTION
@spencergibb I was thinking about the issue #1935 .. would something like this be appropriate?

This is not complete, and test would need to be added.  But it would be convenient of users of StripPrefix (or additional filters) could dictate whether the strict validation should be enforced?

I know for the use case I am facing we don't need the context path enforced on the target service.  But I am presuming that this was introduced for a reason.  However, when I override this locally with a different filter (which is the same as StripPrefix but with the change in the PR hard coded), everything seems to work fine.

If you think there is merit here, I am happy to continue getting the tests to pass and adding in new tests.  I just wanted to confirm with you whether this was a plausible solution.  If so, I will try to get this into a mergeable state (in case I haven't been clear, this Pull Request is not in a mergeable state).

Thanks