### PR TITLE
RoutePredicateHandlerMapping can be optimized

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/CachedBodyOutputMessage.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/CachedBodyOutputMessage.java
@@ -91,7 +91,7 @@ public class CachedBodyOutputMessage implements ReactiveHttpOutputMessage {
 
 	@Override
 	public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<? extends DataBuffer>> body) {
-		return writeWith(Flux.from(body).flatMap(p -> p));
+		return writeWith(Flux.from(body));
 	}
 
 	@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/CachedBodyOutputMessage.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/CachedBodyOutputMessage.java
@@ -91,7 +91,7 @@ public class CachedBodyOutputMessage implements ReactiveHttpOutputMessage {
 
 	@Override
 	public Mono<Void> writeAndFlushWith(Publisher<? extends Publisher<? extends DataBuffer>> body) {
-		return writeWith(Flux.from(body));
+		return writeWith(Flux.from(body).flatMap(p -> p));
 	}
 
 	@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -88,14 +88,14 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 			exchange.getAttributes().put(GATEWAY_REACTOR_CONTEXT_ATTR, contextView);
 			return lookupRoute(exchange)
 					// .log("route-predicate-handler-mapping", Level.FINER) //name this
-					.flatMap((Function<Route, Mono<?>>) r -> {
+					.map((Function<Route, ?>) r -> {
 						exchange.getAttributes().remove(GATEWAY_PREDICATE_ROUTE_ATTR);
 						if (logger.isDebugEnabled()) {
 							logger.debug("Mapping [" + getExchangeDesc(exchange) + "] to " + r);
 						}
 
 						exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, r);
-						return Mono.just(webHandler);
+						return webHandler;
 					}).switchIfEmpty(Mono.empty().then(Mono.fromRunnable(() -> {
 						exchange.getAttributes().remove(GATEWAY_PREDICATE_ROUTE_ATTR);
 						if (logger.isTraceEnabled()) {


### PR DESCRIPTION
When I look up the code of Spring Cloud Gateway, I find some details that can be optimized. One optimization method in reactive programming is to reduce the number of nested layers of Flux or Mono, which can not only save memory, but also improve execution efficiency. In theory, there is no need to nest a layer of Mono