### PR TITLE
Add ParameterizedTypeReference to ModifyRequestBodyGatewayFilterFactory

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
@@ -26,6 +26,7 @@ import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.cloud.gateway.support.BodyInserterContext;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.HttpHeaders;
@@ -64,7 +65,7 @@ public class ModifyRequestBodyGatewayFilterFactory
 		return new GatewayFilter() {
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-				Class inClass = config.getInClass();
+				ParameterizedTypeReference inClass = config.getInClass();
 				ServerRequest serverRequest = ServerRequest.create(exchange, messageReaders);
 
 				// TODO: flux or mono
@@ -140,28 +141,36 @@ public class ModifyRequestBodyGatewayFilterFactory
 
 	public static class Config {
 
-		private Class inClass;
+		private ParameterizedTypeReference inClass;
 
-		private Class outClass;
+		private ParameterizedTypeReference outClass;
 
 		private String contentType;
 
 		private RewriteFunction rewriteFunction;
 
-		public Class getInClass() {
+		public ParameterizedTypeReference getInClass() {
 			return inClass;
 		}
 
 		public Config setInClass(Class inClass) {
-			this.inClass = inClass;
+			return setInClass(ParameterizedTypeReference.forType(inClass));
+		}
+
+		public Config setInClass(ParameterizedTypeReference inTypeReference) {
+			this.inClass = inTypeReference;
 			return this;
 		}
 
-		public Class getOutClass() {
+		public ParameterizedTypeReference getOutClass() {
 			return outClass;
 		}
 
 		public Config setOutClass(Class outClass) {
+			return setOutClass(ParameterizedTypeReference.forType(outClass));
+		}
+
+		public Config setOutClass(ParameterizedTypeReference outClass) {
 			this.outClass = outClass;
 			return this;
 		}
@@ -177,6 +186,14 @@ public class ModifyRequestBodyGatewayFilterFactory
 
 		public <T, R> Config setRewriteFunction(Class<T> inClass, Class<R> outClass,
 				RewriteFunction<T, R> rewriteFunction) {
+			setInClass(inClass);
+			setOutClass(outClass);
+			setRewriteFunction(rewriteFunction);
+			return this;
+		}
+
+		public <T, R> Config setRewriteFunction(ParameterizedTypeReference<T> inClass,
+				ParameterizedTypeReference<R> outClass, RewriteFunction<T, R> rewriteFunction) {
 			setInClass(inClass);
 			setOutClass(outClass);
 			setRewriteFunction(rewriteFunction);

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -31,6 +31,7 @@ import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.core.ParameterizedTypeReference;
 import reactor.retry.Repeat;
 import reactor.retry.Retry;
 
@@ -288,6 +289,23 @@ public class GatewayFilterSpec extends UriSpec {
 
 	/**
 	 * A filter that can be used to modify the request body.
+	 * @param inClass the parameterized type reference to convert the incoming request
+	 * body to
+	 * @param outClass the parameterized type reference the Gateway will add to the
+	 * request before it is routed
+	 * @param rewriteFunction the {@link RewriteFunction} that transforms the request body
+	 * @param <T> the original request body class
+	 * @param <R> the new request body class
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public <T, R> GatewayFilterSpec modifyRequestBody(ParameterizedTypeReference<T> inClass,
+			ParameterizedTypeReference<R> outClass, RewriteFunction<T, R> rewriteFunction) {
+		return filter(getBean(ModifyRequestBodyGatewayFilterFactory.class)
+				.apply(c -> c.setRewriteFunction(inClass, outClass, rewriteFunction)));
+	}
+
+	/**
+	 * A filter that can be used to modify the request body.
 	 * @param inClass the class to convert the incoming request body to
 	 * @param outClass the class the Gateway will add to the request before it is routed
 	 * @param newContentType the new Content-Type header to be sent
@@ -298,6 +316,24 @@ public class GatewayFilterSpec extends UriSpec {
 	 */
 	public <T, R> GatewayFilterSpec modifyRequestBody(Class<T> inClass, Class<R> outClass, String newContentType,
 			RewriteFunction<T, R> rewriteFunction) {
+		return filter(getBean(ModifyRequestBodyGatewayFilterFactory.class)
+				.apply(c -> c.setRewriteFunction(inClass, outClass, rewriteFunction).setContentType(newContentType)));
+	}
+
+	/**
+	 * A filter that can be used to modify the request body.
+	 * @param inClass the parameterized type reference to convert the incoming request
+	 * body to
+	 * @param outClass the parameterized type reference the Gateway will add to the
+	 * request before it is routed
+	 * @param newContentType the new Content-Type header to be sent
+	 * @param rewriteFunction the {@link RewriteFunction} that transforms the request body
+	 * @param <T> the original request body class
+	 * @param <R> the new request body class
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public <T, R> GatewayFilterSpec modifyRequestBody(ParameterizedTypeReference<T> inClass,
+			ParameterizedTypeReference<R> outClass, String newContentType, RewriteFunction<T, R> rewriteFunction) {
 		return filter(getBean(ModifyRequestBodyGatewayFilterFactory.class)
 				.apply(c -> c.setRewriteFunction(inClass, outClass, rewriteFunction).setContentType(newContentType)));
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryTests.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -69,6 +70,14 @@ public class ModifyRequestBodyGatewayFilterFactoryTests extends BaseWebClientTes
 				.isEqualTo("Exceeded limit on max bytes to buffer : 13");
 	}
 
+	@Test
+	public void modifyRequestBodyParameterizedTypeReference() {
+		testClient.post().uri("/post").header("Host", "www.modifyrequestbodyspacetounderscore.org")
+				.header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+				.body(BodyInserters.fromValue("foo bar baz")).exchange().expectStatus().isEqualTo(HttpStatus.OK)
+				.expectBody().jsonPath("data").isEqualTo("FOO_BAR_BAZ");
+	}
+
 	@EnableAutoConfiguration
 	@SpringBootConfiguration
 	@Import(DefaultTestConfig.class)
@@ -102,6 +111,13 @@ public class ModifyRequestBodyGatewayFilterFactoryTests extends BaseWebClientTes
 														"tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge-tolarge");
 											}))
 									.uri(uri))
+					.route("test_modify_request_body_with_parameterizedtypereference",
+							r -> r.order(-1).host("**.modifyrequestbodyspacetounderscore.org")
+									.filters(f -> f.modifyRequestBody(new ParameterizedTypeReference<String>() {
+									}, new ParameterizedTypeReference<String>() {
+									}, (swe, body) -> {
+										return Mono.just(body.replaceAll(" ", "_").toUpperCase());
+									})).uri(uri))
 					.build();
 		}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactoryUnitTests.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.rewrite.ModifyRequestBodyGatewayFilterFactory.Config;
+import org.springframework.core.ParameterizedTypeReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,6 +31,18 @@ public class ModifyRequestBodyGatewayFilterFactoryUnitTests {
 		Config config = new Config();
 		config.setInClass(String.class);
 		config.setOutClass(Integer.class);
+		config.setContentType("mycontenttype");
+		GatewayFilter filter = new ModifyRequestBodyGatewayFilterFactory().apply(config);
+		assertThat(filter.toString()).contains("String").contains("Integer").contains("mycontenttype");
+	}
+
+	@Test
+	public void toStringFormatWithParameterizedTypeReferences() {
+		Config config = new Config();
+		config.setInClass(new ParameterizedTypeReference<String>() {
+		});
+		config.setOutClass(new ParameterizedTypeReference<Integer>() {
+		});
 		config.setContentType("mycontenttype");
 		GatewayFilter filter = new ModifyRequestBodyGatewayFilterFactory().apply(config);
 		assertThat(filter.toString()).contains("String").contains("Integer").contains("mycontenttype");


### PR DESCRIPTION
Hi!

I've had a go at fixing gh-2635. I'm not 100% convinced that my approach is the best way as I am concerned that my changes may break some of the public API (if `ModifyRequestBodyGatewayFilterFactory.Config` is considered part of that API) as I have changed the types which are returned from the `getInClass` and `getOutClass` methods.

If this is considered breaking, I can do some additional work to avoid causing such breaks, particularly if you're able to provide some advice on an acceptable way forward with it.

If I'm going completely down the wrong path here, please do let me know. Hope this helps and I'm open to making any changes as required.

Fixes gh-2635