### PR TITLE
Fix contribution link in README.adoc and add a link to repository map

### DIFF
--- a/docs/src/main/asciidoc/README.adoc
+++ b/docs/src/main/asciidoc/README.adoc
@@ -1,5 +1,6 @@
 image::https://github.com/spring-cloud/spring-cloud-gateway/workflows/Build/badge.svg?style=svg["Actions Status", link="https://github.com/spring-cloud/spring-cloud-gateway/actions"]
 image::https://codecov.io/gh/spring-cloud/spring-cloud-gateway/branch/main/graph/badge.svg["Codecov", link="https://codecov.io/gh/spring-cloud/spring-cloud-gateway/branch/main"]
+image::https://sourcespy.com/shield.svg["Repository Map", link="https://sourcespy.com/github/springcloudspringcloudgateway/"]
 
 
 
@@ -25,4 +26,4 @@ include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/main/
 [[contributing]]
 = Contributing
 
-include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/main/docs/src/main/asciidoc/contributing.adoc[]
+include::https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/main/docs/modules/ROOT/partials/contributing.adoc[]


### PR DESCRIPTION
Fixing broken link to contribution guidelines.

Adding a link to the high-level diagrams including module, library dependency and others at (https://sourcespy.com/github/springcloudspringcloudgateway/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project. In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.