### PR TITLE
Support query parameters in RedirectTo filter

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway/gatewayfilter-factories/redirectto-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway/gatewayfilter-factories/redirectto-factory.adoc
@@ -1,10 +1,12 @@
 [[redirectto-gatewayfilter-factory]]
 = `RedirectTo` `GatewayFilter` Factory
 
-The `RedirectTo` `GatewayFilter` factory takes two parameters, `status` and `url`.
+The `RedirectTo` `GatewayFilter` factory takes three parameters, `status`, `url`, and optionally `includeRequestParams`.
 The `status` parameter should be a 300 series redirect HTTP code, such as 301.
 The `url` parameter should be a valid URL.
 This is the value of the `Location` header.
+The `includeRequestParams` parameter indicates whether request query parameters should be included on the `url`.
+When not set, it will be treated as `false`.
 For relative redirects, you should use `uri: no://op` as the uri of your route definition.
 The following listing configures a `RedirectTo` `GatewayFilter`:
 
@@ -24,3 +26,20 @@ spring:
 This will send a status 302 with a `Location:https://acme.org` header to perform a redirect.
 
 
+The following example configures a `RedirectTo` `GatewayFilter` with `includeRequestParams` set to `true`.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      routes:
+      - id: prefixpath_route
+        uri: https://example.org
+        filters:
+        - RedirectTo=302, https://acme.org, true
+----
+
+When a request with query `?skip=10` is made to the gateway, the gateway will send a status 302 with a
+`Location:https://acme.org?skip=10` header to perform a redirect.

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/ServerMvcIntegrationTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/ServerMvcIntegrationTests.java
@@ -412,6 +412,13 @@ public class ServerMvcIntegrationTests {
 				.expectHeader().valueEquals(HttpHeaders.LOCATION, "https://exampleredirect.com");
 	}
 
+	@Test
+	public void redirectToWithQueryParamsWorks() {
+		restClient.get().uri("/anything/redirectqueryparams?page=3").exchange()
+				.expectStatus().isEqualTo(HttpStatus.MOVED_PERMANENTLY)
+				.expectHeader().valueEquals(HttpHeaders.LOCATION, "https://exampleredirect.com?page=3");
+	}
+
 	private MultiValueMap<String, HttpEntity<?>> createMultipartData() {
 		ClassPathResource part = new ClassPathResource("test/1x1.png");
 		MultipartBodyBuilder builder = new MultipartBodyBuilder();
@@ -852,6 +859,15 @@ public class ServerMvcIntegrationTests {
 			return route(path("/anything/redirect"), http())
 					.filter(redirectTo(HttpStatus.MOVED_PERMANENTLY, URI.create("https://exampleredirect.com")))
 					.withAttribute(MvcUtils.GATEWAY_ROUTE_ID_ATTR, "testredirectto");
+			// @formatter:on
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> gatewayRouterFunctionsRedirectToWithQueryParams() {
+			// @formatter:off
+			return route(path("/anything/redirectqueryparams"), http())
+					.filter(redirectTo(HttpStatus.MOVED_PERMANENTLY, URI.create("https://exampleredirect.com"), true))
+					.withAttribute(MvcUtils.GATEWAY_ROUTE_ID_ATTR, "testredirecttoqueryparams");
 			// @formatter:on
 		}
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -486,6 +486,18 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @param status an HTTP status code, should be a {@code 300} series redirect
 	 * @param url the URL to redirect to. This URL will be set in the {@code location}
 	 * header
+	 * @param includeRequestParams if true, query params will be passed to the url
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec redirect(int status, String url, boolean includeRequestParams) {
+		return redirect(String.valueOf(status), url, includeRequestParams);
+	}
+
+	/**
+	 * A filter that will return a redirect response back to the client.
+	 * @param status an HTTP status code, should be a {@code 300} series redirect
+	 * @param url the URL to redirect to. This URL will be set in the {@code location}
+	 * header
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(String status, URI url) {
@@ -500,7 +512,19 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(String status, String url) {
-		return filter(getBean(RedirectToGatewayFilterFactory.class).apply(status, url));
+		return redirect(status, url, false);
+	}
+
+	/**
+	 * A filter that will return a redirect response back to the client.
+	 * @param status an HTTP status code, should be a {@code 300} series redirect
+	 * @param url the URL to redirect to. This URL will be set in the {@code location}
+	 * header
+	 * @param includeRequestParams if true, query params will be passed to the url
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec redirect(String status, String url, boolean includeRequestParams) {
+		return filter(getBean(RedirectToGatewayFilterFactory.class).apply(status, url, includeRequestParams));
 	}
 
 	/**
@@ -511,8 +535,21 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec redirect(HttpStatus status, URL url) {
+		return redirect(status, url, false);
+	}
+
+	/**
+	 * A filter that will return a redirect response back to the client.
+	 * @param status an HTTP status code, should be a {@code 300} series redirect
+	 * @param url the URL to redirect to. This URL will be set in the {@code location}
+	 * header
+	 * @param includeRequestParams if true, query params will be passed to the url
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec redirect(HttpStatus status, URL url, boolean includeRequestParams) {
 		try {
-			return filter(getBean(RedirectToGatewayFilterFactory.class).apply(status, url.toURI()));
+			return filter(getBean(RedirectToGatewayFilterFactory.class)
+					.apply(status, url.toURI(), includeRequestParams));
 		}
 		catch (URISyntaxException e) {
 			throw new IllegalArgumentException("Invalid URL", e);

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RedirectToGatewayFilterFactoryTests.java
@@ -48,6 +48,19 @@ public class RedirectToGatewayFilterFactoryTests extends BaseWebClientTests {
 	}
 
 	@Test
+	public void redirectToUrlDoesNotPassQueryParametersByDefault() {
+		testClient.get().uri("/?membership=gold").header("Host", "www.redirectto.org").exchange().expectStatus()
+				.isEqualTo(HttpStatus.FOUND).expectHeader().valueEquals(HttpHeaders.LOCATION, "https://example.org");
+	}
+
+	@Test
+	public void redirectToUrlAddsQueryParametersWhenEnabledOnFilter() {
+		testClient.get().uri("/?membership=gold").header("Host", "queryparams.redirectto.org").exchange().expectStatus()
+				.isEqualTo(HttpStatus.FOUND).expectHeader()
+				.valueEquals(HttpHeaders.LOCATION, "https://example.org?membership=gold");
+	}
+
+	@Test
 	public void redirectToRelativeUrlFilterWorks() {
 		testClient.get().uri("/").header("Host", "www.relativeredirect.org").exchange().expectStatus()
 				.isEqualTo(HttpStatus.FOUND).expectHeader().valueEquals(HttpHeaders.LOCATION, "/index.html#/customers");
@@ -60,12 +73,26 @@ public class RedirectToGatewayFilterFactoryTests extends BaseWebClientTests {
 	}
 
 	@Test
+	public void redirectToRelativeUrlDoesNotPassQueryParametersByDefault() {
+		testClient.get().uri("/?membership=gold").header("Host", "www.relativeredirect.org").exchange().expectStatus()
+				.isEqualTo(HttpStatus.FOUND).expectHeader().valueEquals(HttpHeaders.LOCATION, "/index.html#/customers");
+	}
+
+	@Test
+	public void redirectToRelativeUrlAddsQueryParametersWhenEnabledOnFilter() {
+		testClient.get().uri("/?membership=gold").header("Host", "queryparams.relativeredirect.org").exchange()
+				.expectStatus().isEqualTo(HttpStatus.FOUND).expectHeader()
+				.valueEquals(HttpHeaders.LOCATION, "/index.html?membership=gold#/customers");
+	}
+
+	@Test
 	public void toStringFormat() {
 		Config config = new Config();
 		config.setStatus("301");
 		config.setUrl("http://newurl");
+		config.setIncludeRequestParams(true);
 		GatewayFilter filter = new RedirectToGatewayFilterFactory().apply(config);
-		assertThat(filter.toString()).contains("301").contains("http://newurl");
+		assertThat(filter.toString()).contains("301").contains("http://newurl").contains("true");
 	}
 
 	@EnableAutoConfiguration
@@ -78,6 +105,9 @@ public class RedirectToGatewayFilterFactoryTests extends BaseWebClientTests {
 			return builder.routes()
 					.route("relative_redirect_uri_object", r -> r.host("strcode.relativeredirect.org")
 							.filters(f -> f.redirect("302", URI.create("/index.html#/customers"))).uri("no://op"))
+					.route("relative_redirect_with_query_params",
+							r -> r.host("queryparams.relativeredirect.org")
+									.filters(f -> f.redirect(302, "/index.html#/customers", true)).uri("no://op"))
 					.route("relative_redirect", r -> r.host("**.relativeredirect.org")
 							.filters(f -> f.redirect(302, "/index.html#/customers")).uri("no://op"))
 					.build();

--- a/spring-cloud-gateway-server/src/test/resources/application.yml
+++ b/spring-cloud-gateway-server/src/test/resources/application.yml
@@ -296,6 +296,14 @@ spring:
         filters:
           - SetPath=/anything/{digits}
 
+        # =====================================
+      - id: redirect_to_include_query_params_test
+        uri: ${test.uri}
+        predicates:
+        - Host=queryparams.redirectto.org
+        filters:
+        - RedirectTo=302, https://example.org, true
+
       # =====================================
       - id: redirect_to_test
         uri: ${test.uri}


### PR DESCRIPTION
Adds an optional boolean parameter to the `RedirectTo` filter to indicate whether the request query parameters should be included on the `url`. The parameter is treated as false when not set to preserve backwards compatibility.