### PR TITLE
Proposal to clarify in the docs that request size filter acts on Content-Length header

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestSizeGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestSizeGatewayFilterFactory.java
@@ -30,7 +30,8 @@ import org.springframework.web.server.ServerWebExchange;
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
 
 /**
- * This filter blocks the request, if the request size is more than the permissible size.
+ * This filter blocks the request if the size in Content-Length header value is more than the permissible size.
+ * Has no effect if Content-Length header is missing.
  * The default request size is 5 MB.
  *
  * @author Arpan

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -805,7 +805,7 @@ public class GatewayFilterSpec extends UriSpec {
 	}
 
 	/**
-	 * A filter that sets the maximum permissible size of a Request.
+	 * A filter that sets the maximum permissible size of a Content-Length header value in the Request.
 	 * @param size the maximum size of a request
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
@@ -814,7 +814,7 @@ public class GatewayFilterSpec extends UriSpec {
 	}
 
 	/**
-	 * A filter that sets the maximum permissible size of a Request.
+	 * A filter that sets the maximum permissible size of a Content-Length header value in the Request.
 	 * @param size the maximum size of a request
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */


### PR DESCRIPTION
Hi!

This is a proposal to clarify in the java docs that the request size filter acts on the Content-Length header. Has no effect when the header is missing in cases such as ``Transfer-Encoding: chunked``.