### PR TITLE
Correct bug about the order when routes are refreshed by group

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
@@ -88,8 +88,9 @@ public class CachingRouteLocator
 						.onErrorResume(s -> Mono.just(List.of()));
 
 				scopedRoutes.subscribe(scopedRoutesList -> {
-					Flux.concat(Flux.fromIterable(scopedRoutesList), getNonScopedRoutes(event)).materialize()
-							.collect(Collectors.toList()).subscribe(signals -> {
+					Flux.concat(Flux.fromIterable(scopedRoutesList), getNonScopedRoutes(event))
+							.sort(AnnotationAwareOrderComparator.INSTANCE).materialize().collect(Collectors.toList())
+							.subscribe(signals -> {
 								applicationEventPublisher.publishEvent(new RefreshRoutesResultEvent(this));
 								cache.put(CACHE_KEY, signals);
 							}, this::handleRefreshError);


### PR DESCRIPTION
Correct bug about the order when routes are refreshed by group

Steps to reproduce it without this fix

1. POST a route with order 1000 and group:1 in the metadata ("route-order-1000"
2. POST /refresh?metadata=group:1
3. Check the route was refreshed - GET /gateway/routes
4. POST a route with order 0 and group:2 in the metadata ("route-order-0"
5. POST /refresh?metadata=group:2
6. Check the order of the refreshed routes GET /gateway/routes

Expected: the ordered list will be "route-order-0" first, then "route-order-1000"
Currently: the ordered list is in the wrong order, having "route-order-0" at the end