### PR TITLE
Improve error message

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/AbstractSslConfigurer.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/AbstractSslConfigurer.java
@@ -118,7 +118,7 @@ public abstract class AbstractSslConfigurer<T, S> {
 						ssl.getKeyStorePassword() != null ? ssl.getKeyStorePassword().toCharArray() : null);
 			}
 			catch (Exception e) {
-				throw new RuntimeException("Could not load key store ' " + ssl.getKeyStore() + "'", e);
+				throw new RuntimeException("Could not load key store '" + ssl.getKeyStore() + "'", e);
 			}
 
 			return store;


### PR DESCRIPTION
Improve error message when key store could not be loaded (should not include a space)