### PR TITLE
Allow forcing order of filters through Java DSL configuration.

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -128,6 +128,27 @@ public class GatewayFilterSpec extends UriSpec {
 	}
 
 	/**
+	 * Applies the filter to the route.
+	 * @param gatewayFilter the filter to apply
+	 * @param order the order to apply the filter
+	 * @param forceOrder if <code>true</code>, then force the order even if the supplied
+	 * {@link GatewayFilter} implements {@link Ordered}
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec filter(GatewayFilter gatewayFilter, int order, boolean forceOrder) {
+		if (gatewayFilter instanceof Ordered) {
+			if (!forceOrder) {
+				this.routeBuilder.filter(gatewayFilter);
+				log.warn("GatewayFilter already implements ordered " + gatewayFilter.getClass()
+						+ "ignoring order parameter: " + order);
+				return this;
+			}
+		}
+		this.routeBuilder.filter(new OrderedGatewayFilter(gatewayFilter, order));
+		return this;
+	}
+
+	/**
 	 * Applies the list of filters to the route.
 	 * @param gatewayFilters the filters to apply
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpecTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpecTests.java
@@ -41,24 +41,46 @@ public class GatewayFilterSpecTests {
 
 	@Test
 	public void orderedInterfaceRespected() {
-		testFilter(MyOrderedFilter.class, new MyOrderedFilter(), 1000);
+		testFilter(MyOrderedFilter.class, new MyOrderedFilter(), 1000, null, false);
+	}
+
+	@Test
+	public void orderedInterfaceRespectedWhenOrderSpecified() {
+		testFilter(MyOrderedFilter.class, new MyOrderedFilter(), 1000, 5, false);
 	}
 
 	@Test
 	public void unorderedWithDefaultOrder() {
-		testFilter(OrderedGatewayFilter.class, new MyUnorderedFilter(), 0);
+		testFilter(OrderedGatewayFilter.class, new MyUnorderedFilter(), 0, null, false);
 	}
 
-	private void testFilter(Class<? extends GatewayFilter> type, GatewayFilter gatewayFilter, int order) {
+	@Test
+	public void forceOrderWithOrderedInterface() {
+		testFilter(OrderedGatewayFilter.class, new MyOrderedFilter(), 5, 5, true);
+	}
+
+	private void testFilter(Class<? extends GatewayFilter> type, GatewayFilter gatewayFilter, int expectedOrder,
+			Integer specifiedOrder, Boolean forceOrder) {
 		ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
 		Route.AsyncBuilder routeBuilder = Route.async().id("123").uri("abc:123").predicate(exchange -> true);
 		RouteLocatorBuilder.Builder routes = new RouteLocatorBuilder(context).routes();
 		GatewayFilterSpec spec = new GatewayFilterSpec(routeBuilder, routes);
-		spec.filter(gatewayFilter);
+
+		if (specifiedOrder != null) {
+			if (forceOrder != null) {
+				spec.filter(gatewayFilter, specifiedOrder, forceOrder);
+			}
+			else {
+				spec.filter(gatewayFilter, specifiedOrder);
+			}
+		}
+		else {
+			spec.filter(gatewayFilter);
+		}
 
 		Route route = routeBuilder.build();
 		assertThat(route.getFilters()).hasSize(1);
-		assertFilter(route.getFilters().get(0), type, order);
+		assertFilter(route.getFilters().get(0), type, expectedOrder);
 	}
 
 	private void assertFilter(GatewayFilter filter, Class<? extends GatewayFilter> type, int order) {


### PR DESCRIPTION
There should be some way to force the ordering of filters even if those filters implement the `Ordered` interface.  This PR adds that capability.