### PR TITLE
Rework LocalResponseCache into a general ResponseCache to support Caffiene and Redis CacheManagers

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/ConfigurableHintsRegistrationProcessor.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/ConfigurableHintsRegistrationProcessor.java
@@ -38,7 +38,7 @@ import org.springframework.cloud.gateway.filter.factory.FallbackHeadersGatewayFi
 import org.springframework.cloud.gateway.filter.factory.JsonToGrpcGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.SpringCloudCircuitBreakerResilience4JFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.TokenRelayGatewayFilterFactory;
-import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.ratelimit.RedisRateLimiter;
 import org.springframework.cloud.gateway.support.Configurable;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
@@ -75,7 +75,7 @@ class ConfigurableHintsRegistrationProcessor implements BeanFactoryInitializatio
 					"org.springframework.web.reactive.DispatcherHandler"),
 			SpringCloudCircuitBreakerResilience4JFilterFactory.class, circuitBreakerConditionalClasses,
 			FallbackHeadersGatewayFilterFactory.class, circuitBreakerConditionalClasses,
-			LocalResponseCacheGatewayFilterFactory.class,
+			ResponseCacheGatewayFilterFactory.class,
 			Set.of("com.github.benmanes.caffeine.cache.Weigher", "com.github.benmanes.caffeine.cache.Caffeine",
 					"org.springframework.cache.caffeine.CaffeineCacheManager"));
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
@@ -70,7 +70,6 @@ public class LocalResponseCacheAutoConfiguration {
 	}
 
 	@Bean(name = RESPONSE_CACHE_MANAGER_NAME)
-	@Conditional(LocalResponseCacheAutoConfiguration.OnGlobalLocalResponseCacheCondition.class)
 	public CacheManager gatewayCacheManager(LocalResponseCacheProperties cacheProperties) {
 		return createGatewayCacheManager(cacheProperties);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
@@ -23,9 +23,9 @@ import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.Cache;
@@ -61,27 +61,22 @@ public class LocalResponseCacheAutoConfiguration {
 	@Bean
 	@Conditional(LocalResponseCacheAutoConfiguration.OnGlobalLocalResponseCacheCondition.class)
 	public GlobalLocalResponseCacheGatewayFilter globalLocalResponseCacheGatewayFilter(
-			ResponseCacheManagerFactory responseCacheManagerFactory,
-			@Qualifier(RESPONSE_CACHE_MANAGER_NAME) CacheManager cacheManager,
+			ResponseCacheManagerFactory responseCacheManagerFactory, CacheManager cacheManager,
 			LocalResponseCacheProperties properties) {
 		return new GlobalLocalResponseCacheGatewayFilter(responseCacheManagerFactory, responseCache(cacheManager),
 				properties.getTimeToLive());
 	}
 
-	@Bean(name = RESPONSE_CACHE_MANAGER_NAME)
-	@Conditional(LocalResponseCacheAutoConfiguration.OnGlobalLocalResponseCacheCondition.class)
-	public CacheManager gatewayCacheManager(LocalResponseCacheProperties cacheProperties) {
-		return createGatewayCacheManager(cacheProperties);
-	}
-
 	@Bean
 	public LocalResponseCacheGatewayFilterFactory localResponseCacheGatewayFilterFactory(
-			ResponseCacheManagerFactory responseCacheManagerFactory, LocalResponseCacheProperties properties) {
+			ResponseCacheManagerFactory responseCacheManagerFactory, LocalResponseCacheProperties properties,
+			CacheManager cacheManager) {
 		return new LocalResponseCacheGatewayFilterFactory(responseCacheManagerFactory, properties.getTimeToLive(),
-				properties.getSize());
+				properties.getSize(), cacheManager);
 	}
 
 	@Bean
+	@ConditionalOnMissingBean
 	public ResponseCacheManagerFactory responseCacheManagerFactory(CacheKeyGenerator cacheKeyGenerator) {
 		return new ResponseCacheManagerFactory(cacheKeyGenerator);
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/RedisResponseCacheAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/RedisResponseCacheAutoConfiguration.java
@@ -16,14 +16,9 @@
 
 package org.springframework.cloud.gateway.config;
 
-import java.time.Duration;
-
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -31,17 +26,17 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
-import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.cloud.gateway.config.conditional.ConditionalOnEnabledFilter;
 import org.springframework.cloud.gateway.filter.factory.cache.GlobalLocalResponseCacheGatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
 import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheManagerFactory;
-import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheSizeWeigher;
 import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CacheKeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCache;
+import org.springframework.data.redis.cache.RedisCacheManager;
 
 /**
  * @author Ignacio Lozano
@@ -49,36 +44,29 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties({ LocalResponseCacheProperties.class })
-@ConditionalOnClass({ Weigher.class, Caffeine.class, CaffeineCacheManager.class })
+@ConditionalOnClass({ RedisCache.class, RedisCacheManager.class })
 @ConditionalOnEnabledFilter(ResponseCacheGatewayFilterFactory.class)
-public class LocalResponseCacheAutoConfiguration {
+public class RedisResponseCacheAutoConfiguration {
 
-	private static final Log LOGGER = LogFactory.getLog(LocalResponseCacheAutoConfiguration.class);
+	private static final Log LOGGER = LogFactory.getLog(RedisResponseCacheAutoConfiguration.class);
 
 	private static final String RESPONSE_CACHE_NAME = "response-cache";
 
 	/* for testing */ static final String RESPONSE_CACHE_MANAGER_NAME = "gatewayCacheManager";
 
 	@Bean
-	@Conditional(LocalResponseCacheAutoConfiguration.OnGlobalLocalResponseCacheCondition.class)
+	@Conditional(RedisResponseCacheAutoConfiguration.OnGlobalLocalResponseCacheCondition.class)
 	public GlobalLocalResponseCacheGatewayFilter globalLocalResponseCacheGatewayFilter(
-			ResponseCacheManagerFactory responseCacheManagerFactory,
-			@Qualifier(RESPONSE_CACHE_MANAGER_NAME) CacheManager cacheManager,
+			ResponseCacheManagerFactory responseCacheManagerFactory, RedisCacheManager cacheManager,
 			LocalResponseCacheProperties properties) {
 		return new GlobalLocalResponseCacheGatewayFilter(responseCacheManagerFactory, responseCache(cacheManager),
 				properties.getTimeToLive());
 	}
 
-	@Bean(name = RESPONSE_CACHE_MANAGER_NAME)
-	@Conditional(LocalResponseCacheAutoConfiguration.OnGlobalLocalResponseCacheCondition.class)
-	public CacheManager gatewayCacheManager(LocalResponseCacheProperties cacheProperties) {
-		return createGatewayCacheManager(cacheProperties);
-	}
-
 	@Bean
 	public ResponseCacheGatewayFilterFactory localResponseCacheGatewayFilterFactory(
 			ResponseCacheManagerFactory responseCacheManagerFactory, LocalResponseCacheProperties properties,
-			@Qualifier(RESPONSE_CACHE_MANAGER_NAME) CacheManager cacheManager) {
+			CacheManager cacheManager) {
 		return new ResponseCacheGatewayFilterFactory(responseCacheManagerFactory, properties.getTimeToLive(),
 				properties.getSize(), cacheManager);
 	}
@@ -95,23 +83,6 @@ public class LocalResponseCacheAutoConfiguration {
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
-	public static CaffeineCacheManager createGatewayCacheManager(LocalResponseCacheProperties cacheProperties) {
-		Caffeine caffeine = Caffeine.newBuilder();
-		LOGGER.info("Initializing Caffeine");
-		Duration ttlSeconds = cacheProperties.getTimeToLive();
-		caffeine.expireAfterWrite(ttlSeconds);
-
-		if (cacheProperties.getSize() != null) {
-			caffeine.maximumWeight(cacheProperties.getSize().toBytes()).weigher(responseCacheSizeWeigher());
-		}
-		CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
-		caffeineCacheManager.setCaffeine(caffeine);
-		return caffeineCacheManager;
-	}
-
-	private static ResponseCacheSizeWeigher responseCacheSizeWeigher() {
-		return new ResponseCacheSizeWeigher();
-	}
 
 	Cache responseCache(CacheManager cacheManager) {
 		return cacheManager.getCache(RESPONSE_CACHE_NAME);

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/RedisResponseCacheAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/RedisResponseCacheAutoConfiguration.java
@@ -48,6 +48,8 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 @EnableConfigurationProperties({ LocalResponseCacheProperties.class })
 @ConditionalOnClass({ RedisCache.class, RedisConnectionFactory.class })
 @ConditionalOnEnabledFilter(ResponseCacheGatewayFilterFactory.class)
+@ConditionalOnProperty(value = "spring.cloud.gateway.filter.local-response-cache.cache-implementation",
+		havingValue = "redis")
 public class RedisResponseCacheAutoConfiguration {
 
 	private static final Log LOGGER = LogFactory.getLog(RedisResponseCacheAutoConfiguration.class);

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/CachedResponse.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/CachedResponse.java
@@ -52,7 +52,7 @@ public final class CachedResponse implements Serializable {
 
 	private Date timestamp;
 
-	private CachedResponse(HttpStatusCode statusCode, HttpHeaders headers, List<ByteBuffer> body, Date timestamp) {
+	public CachedResponse(HttpStatusCode statusCode, HttpHeaders headers, List<ByteBuffer> body, Date timestamp) {
 		this.statusCode = statusCode;
 		this.headers = headers;
 		this.body = body;
@@ -104,7 +104,7 @@ public final class CachedResponse implements Serializable {
 		return bodyStream.toByteArray();
 	}
 
-	String bodyAsString() throws IOException {
+	public String bodyAsString() throws IOException {
 		InputStream byteStream = new ByteArrayInputStream(bodyAsByteArray());
 		if (headers.getOrEmpty(HttpHeaders.CONTENT_ENCODING).contains("gzip")) {
 			byteStream = new GZIPInputStream(byteStream);

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/GlobalLocalResponseCacheGatewayFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/GlobalLocalResponseCacheGatewayFilter.java
@@ -27,11 +27,11 @@ import org.springframework.cloud.gateway.filter.NettyWriteResponseFilter;
 import org.springframework.core.Ordered;
 import org.springframework.web.server.ServerWebExchange;
 
-import static org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory.LOCAL_RESPONSE_CACHE_FILTER_APPLIED;
+import static org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheGatewayFilterFactory.LOCAL_RESPONSE_CACHE_FILTER_APPLIED;
 
 /**
  * Caches responses for routes that don't have the
- * {@link LocalResponseCacheGatewayFilterFactory} configured.
+ * {@link ResponseCacheGatewayFilterFactory} configured.
  *
  * @author Ignacio Lozano
  * @author Marta Medio

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.Cache;
-import org.springframework.cloud.gateway.config.LocalResponseCacheAutoConfiguration;
+import org.springframework.cache.CacheManager;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
 import org.springframework.cloud.gateway.support.HasRouteId;
@@ -55,25 +55,27 @@ public class LocalResponseCacheGatewayFilterFactory
 
 	private DataSize defaultSize;
 
+	private CacheManager cacheManager;
+
 	public LocalResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
-			Duration defaultTimeToLive) {
-		this(cacheManagerFactory, defaultTimeToLive, null);
+			Duration defaultTimeToLive, CacheManager cacheManager) {
+		this(cacheManagerFactory, defaultTimeToLive, null, cacheManager);
 	}
 
 	public LocalResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
-			Duration defaultTimeToLive, DataSize defaultSize) {
+			Duration defaultTimeToLive, DataSize defaultSize, CacheManager cacheManager) {
 		super(RouteCacheConfiguration.class);
 		this.cacheManagerFactory = cacheManagerFactory;
 		this.defaultTimeToLive = defaultTimeToLive;
 		this.defaultSize = defaultSize;
+		this.cacheManager = cacheManager;
 	}
 
 	@Override
 	public GatewayFilter apply(RouteCacheConfiguration config) {
 		LocalResponseCacheProperties cacheProperties = mapRouteCacheConfig(config);
 
-		Cache routeCache = LocalResponseCacheAutoConfiguration.createGatewayCacheManager(cacheProperties)
-				.getCache(config.getRouteId() + "-cache");
+		Cache routeCache = cacheManager.getCache(config.getRouteId() + "-cache");
 		return new ResponseCacheGatewayFilter(cacheManagerFactory.create(routeCache, cacheProperties.getTimeToLive()));
 
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilter.java
@@ -66,7 +66,7 @@ public class ResponseCacheGatewayFilter implements GatewayFilter, Ordered {
 
 	private Mono<Void> filterWithCache(ServerWebExchange exchange, GatewayFilterChain chain) {
 		final String metadataKey = responseCacheManager.resolveMetadataKey(exchange);
-		Optional<CachedResponse> cached = responseCacheManager.getFromCache(exchange.getRequest(), metadataKey);
+		Optional<CachedResponse> cached = responseCacheManager.getFromCache(exchange, metadataKey);
 
 		if (cached.isPresent()) {
 			return responseCacheManager.processFromCache(exchange, metadataKey, cached.get());

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilter.java
@@ -31,7 +31,7 @@ import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.web.server.ServerWebExchange;
 
-import static org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory.LOCAL_RESPONSE_CACHE_FILTER_APPLIED;
+import static org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheGatewayFilterFactory.LOCAL_RESPONSE_CACHE_FILTER_APPLIED;
 
 /**
  * {@literal LocalResponseCache} Gateway Filter that stores HTTP Responses in a cache, so

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterFactory.java
@@ -21,9 +21,9 @@ import java.util.List;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.Cache;
-import org.springframework.cache.CacheManager;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.factory.AbstractGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.cache.provider.CacheManagerProvider;
 import org.springframework.cloud.gateway.support.HasRouteId;
 import org.springframework.util.unit.DataSize;
 import org.springframework.validation.annotation.Validated;
@@ -55,27 +55,28 @@ public class ResponseCacheGatewayFilterFactory
 
 	private DataSize defaultSize;
 
-	private CacheManager cacheManager;
+	private CacheManagerProvider cacheManagerProvider;
 
 	public ResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
-			Duration defaultTimeToLive, CacheManager cacheManager) {
-		this(cacheManagerFactory, defaultTimeToLive, null, cacheManager);
+			Duration defaultTimeToLive, CacheManagerProvider cacheManagerProvider) {
+		this(cacheManagerFactory, defaultTimeToLive, null, cacheManagerProvider);
 	}
 
 	public ResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
-			Duration defaultTimeToLive, DataSize defaultSize, CacheManager cacheManager) {
+			Duration defaultTimeToLive, DataSize defaultSize, CacheManagerProvider cacheManagerProvider) {
 		super(RouteCacheConfiguration.class);
 		this.cacheManagerFactory = cacheManagerFactory;
 		this.defaultTimeToLive = defaultTimeToLive;
 		this.defaultSize = defaultSize;
-		this.cacheManager = cacheManager;
+		this.cacheManagerProvider = cacheManagerProvider;
 	}
 
 	@Override
 	public GatewayFilter apply(RouteCacheConfiguration config) {
 		LocalResponseCacheProperties cacheProperties = mapRouteCacheConfig(config);
 
-		Cache routeCache = cacheManager.getCache(config.getRouteId() + "-cache");
+		Cache routeCache = cacheManagerProvider.getCacheManager(cacheProperties)
+				.getCache(config.getRouteId() + "-cache");
 		return new ResponseCacheGatewayFilter(cacheManagerFactory.create(routeCache, cacheProperties.getTimeToLive()));
 
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterFactory.java
@@ -40,8 +40,8 @@ import org.springframework.validation.annotation.Validated;
  * @author Ignacio Lozano
  */
 @ConditionalOnProperty(value = "spring.cloud.gateway.filter.local-response-cache.enabled", havingValue = "true")
-public class LocalResponseCacheGatewayFilterFactory
-		extends AbstractGatewayFilterFactory<LocalResponseCacheGatewayFilterFactory.RouteCacheConfiguration> {
+public class ResponseCacheGatewayFilterFactory
+		extends AbstractGatewayFilterFactory<ResponseCacheGatewayFilterFactory.RouteCacheConfiguration> {
 
 	/**
 	 * Exchange attribute name to track if the request has been already process by cache
@@ -57,12 +57,12 @@ public class LocalResponseCacheGatewayFilterFactory
 
 	private CacheManager cacheManager;
 
-	public LocalResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
+	public ResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
 			Duration defaultTimeToLive, CacheManager cacheManager) {
 		this(cacheManagerFactory, defaultTimeToLive, null, cacheManager);
 	}
 
-	public LocalResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
+	public ResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
 			Duration defaultTimeToLive, DataSize defaultSize, CacheManager cacheManager) {
 		super(RouteCacheConfiguration.class);
 		this.cacheManagerFactory = cacheManagerFactory;

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
@@ -74,7 +74,8 @@ public class ResponseCacheManager {
 	private static final List<HttpStatusCode> statusesToCache = Arrays.asList(HttpStatus.OK, HttpStatus.PARTIAL_CONTENT,
 			HttpStatus.MOVED_PERMANENTLY);
 
-	public Optional<CachedResponse> getFromCache(ServerHttpRequest request, String metadataKey) {
+	public Optional<CachedResponse> getFromCache(ServerWebExchange exchange, String metadataKey) {
+		ServerHttpRequest request = exchange.getRequest();
 		CachedResponseMetadata metadata = retrieveMetadata(metadataKey);
 		String key = cacheKeyGenerator.generateKey(request,
 				metadata != null ? metadata.varyOnHeaders() : Collections.emptyList());
@@ -106,7 +107,7 @@ public class ResponseCacheManager {
 		});
 	}
 
-	private Optional<CachedResponse> getFromCache(String key) {
+	protected Optional<CachedResponse> getFromCache(String key) {
 		CachedResponse cachedResponse;
 		try {
 			cachedResponse = cache.get(key, CachedResponse.class);
@@ -153,26 +154,26 @@ public class ResponseCacheManager {
 		return metadata;
 	}
 
-	boolean isResponseCacheable(ServerHttpResponse response) {
+	protected boolean isResponseCacheable(ServerHttpResponse response) {
 		return isStatusCodeToCache(response) && isCacheControlAllowed(response) && !isVaryWildcard(response);
 	}
 
-	private boolean isStatusCodeToCache(ServerHttpResponse response) {
+	protected boolean isStatusCodeToCache(ServerHttpResponse response) {
 		return statusesToCache.contains(response.getStatusCode());
 	}
 
-	boolean isRequestCacheable(ServerHttpRequest request) {
+	protected boolean isRequestCacheable(ServerHttpRequest request) {
 		return HttpMethod.GET.equals(request.getMethod()) && !hasRequestBody(request) && isCacheControlAllowed(request);
 	}
 
-	private boolean isVaryWildcard(ServerHttpResponse response) {
+	protected boolean isVaryWildcard(ServerHttpResponse response) {
 		HttpHeaders headers = response.getHeaders();
 		List<String> varyValues = headers.getOrEmpty(HttpHeaders.VARY);
 
 		return varyValues.stream().anyMatch(VARY_WILDCARD::equals);
 	}
 
-	private boolean isCacheControlAllowed(HttpMessage request) {
+	protected boolean isCacheControlAllowed(HttpMessage request) {
 		HttpHeaders headers = request.getHeaders();
 		List<String> cacheControlHeader = headers.getOrEmpty(HttpHeaders.CACHE_CONTROL);
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManagerFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManagerFactory.java
@@ -27,7 +27,7 @@ import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.Cache
  */
 public class ResponseCacheManagerFactory {
 
-	private final CacheKeyGenerator cacheKeyGenerator;
+	protected final CacheKeyGenerator cacheKeyGenerator;
 
 	public ResponseCacheManagerFactory(CacheKeyGenerator cacheKeyGenerator) {
 		this.cacheKeyGenerator = cacheKeyGenerator;

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/provider/CacheManagerProvider.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/provider/CacheManagerProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache.provider;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
+
+public interface CacheManagerProvider {
+
+	CacheManager getCacheManager(LocalResponseCacheProperties localResponseCacheProperties);
+
+}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/provider/CaffieneCacheManagerProvider.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/provider/CaffieneCacheManagerProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache.provider;
+
+import java.time.Duration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
+import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheSizeWeigher;
+
+public class CaffieneCacheManagerProvider implements CacheManagerProvider {
+
+	private static final Log LOGGER = LogFactory.getLog(CaffieneCacheManagerProvider.class);
+
+	@Override
+	public CacheManager getCacheManager(LocalResponseCacheProperties cacheProperties) {
+		Caffeine caffeine = Caffeine.newBuilder();
+		LOGGER.info("Initializing Caffeine");
+		Duration ttlSeconds = cacheProperties.getTimeToLive();
+		caffeine.expireAfterWrite(ttlSeconds);
+
+		if (cacheProperties.getSize() != null) {
+			caffeine.maximumWeight(cacheProperties.getSize().toBytes()).weigher(new ResponseCacheSizeWeigher());
+		}
+		CaffeineCacheManager caffeineCacheManager = new CaffeineCacheManager();
+		caffeineCacheManager.setCaffeine(caffeine);
+		return caffeineCacheManager;
+	}
+
+}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/provider/RedisCacheManagerProvider.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/provider/RedisCacheManagerProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache.provider;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+public class RedisCacheManagerProvider implements CacheManagerProvider {
+
+	private final RedisConnectionFactory redisConnectionFactory;
+
+	public RedisCacheManagerProvider(RedisConnectionFactory redisConnectionFactory) {
+		this.redisConnectionFactory = redisConnectionFactory;
+	}
+
+	@Override
+	public CacheManager getCacheManager(LocalResponseCacheProperties localResponseCacheProperties) {
+		RedisCacheConfiguration redisCacheConfigurationWithTtl = RedisCacheConfiguration.defaultCacheConfig()
+				.entryTtl(localResponseCacheProperties.getTimeToLive());
+
+		return RedisCacheManager.builder(redisConnectionFactory).cacheDefaults(redisCacheConfigurationWithTtl).build();
+	}
+
+}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -75,7 +75,7 @@ import org.springframework.cloud.gateway.filter.factory.SetStatusGatewayFilterFa
 import org.springframework.cloud.gateway.filter.factory.SpringCloudCircuitBreakerFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.StripPrefixGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.TokenRelayGatewayFilterFactory;
-import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.rewrite.ModifyRequestBodyGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.rewrite.ModifyResponseBodyGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.rewrite.RewriteFunction;
@@ -233,8 +233,8 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec localResponseCache(Duration timeToLive, DataSize size) {
-		return filter(getBean(LocalResponseCacheGatewayFilterFactory.class)
-				.apply(c -> c.setTimeToLive(timeToLive).setSize(size)));
+		return filter(
+				getBean(ResponseCacheGatewayFilterFactory.class).apply(c -> c.setTimeToLive(timeToLive).setSize(size)));
 	}
 
 	/**

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/builder/GatewayFilterSpec.java
@@ -117,11 +117,25 @@ public class GatewayFilterSpec extends UriSpec {
 	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
 	 */
 	public GatewayFilterSpec filter(GatewayFilter gatewayFilter, int order) {
+		return filter(gatewayFilter, order, false);
+	}
+
+	/**
+	 * Applies the filter to the route.
+	 * @param gatewayFilter the filter to apply
+	 * @param order the order to apply the filter
+	 * @param forceOrder if <code>true</code>, then force the order even if the supplied
+	 * {@link GatewayFilter} implements {@link Ordered}
+	 * @return a {@link GatewayFilterSpec} that can be used to apply additional filters
+	 */
+	public GatewayFilterSpec filter(GatewayFilter gatewayFilter, int order, boolean forceOrder) {
 		if (gatewayFilter instanceof Ordered) {
-			this.routeBuilder.filter(gatewayFilter);
-			log.warn("GatewayFilter already implements ordered " + gatewayFilter.getClass()
-					+ "ignoring order parameter: " + order);
-			return this;
+			if (!forceOrder) {
+				this.routeBuilder.filter(gatewayFilter);
+				log.warn("GatewayFilter already implements ordered " + gatewayFilter.getClass()
+						+ "ignoring order parameter: " + order);
+				return this;
+			}
 		}
 		this.routeBuilder.filter(new OrderedGatewayFilter(gatewayFilter, order));
 		return this;

--- a/spring-cloud-gateway-server/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-gateway-server/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -9,3 +9,4 @@ org.springframework.cloud.gateway.config.SimpleUrlHandlerMappingGlobalCorsAutoCo
 org.springframework.cloud.gateway.config.GatewayReactiveLoadBalancerClientAutoConfiguration
 org.springframework.cloud.gateway.config.GatewayReactiveOAuth2AutoConfiguration
 org.springframework.cloud.gateway.config.LocalResponseCacheAutoConfiguration
+org.springframework.cloud.gateway.config.RedisResponseCacheAutoConfiguration

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/conditional/DisableBuiltInFiltersTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/config/conditional/DisableBuiltInFiltersTests.java
@@ -82,7 +82,7 @@ public class DisableBuiltInFiltersTests {
 					"spring.cloud.gateway.filter.add-response-header.enabled=false",
 					"spring.cloud.gateway.filter.json-to-grpc.enabled=false",
 					"spring.cloud.gateway.filter.modify-request-body.enabled=false",
-					"spring.cloud.gateway.filter.local-response-cache.enabled=false",
+					"spring.cloud.gateway.filter.response-cache.enabled=false",
 					"spring.cloud.gateway.filter.dedupe-response-header.enabled=false",
 					"spring.cloud.gateway.filter.modify-response-body.enabled=false",
 					"spring.cloud.gateway.filter.prefix-path.enabled=false",

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterFactoryTests.java
@@ -51,7 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @DirtiesContext
 @ActiveProfiles(profiles = "local-cache-filter")
-public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTests {
+public class ResponseCacheGatewayFilterFactoryTests extends BaseWebClientTests {
 
 	private static final String CUSTOM_HEADER = "X-Custom-Date";
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/provider/CaffieneCacheManagerProviderTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/provider/CaffieneCacheManagerProviderTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache.provider;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
+import org.springframework.util.unit.DataSize;
+
+class CaffieneCacheManagerProviderTest {
+
+	@Test
+	void providedCacheManagerIsCaffieneCacheManager() {
+		LocalResponseCacheProperties localResponseCacheProperties = new LocalResponseCacheProperties();
+		localResponseCacheProperties.setSize(DataSize.ofKilobytes(6789));
+		localResponseCacheProperties.setTimeToLive(Duration.ofSeconds(99));
+
+		CaffieneCacheManagerProvider caffieneCacheManagerProvider = new CaffieneCacheManagerProvider();
+		CacheManager cacheManager = caffieneCacheManagerProvider.getCacheManager(localResponseCacheProperties);
+
+		Assertions.assertInstanceOf(CaffeineCacheManager.class, cacheManager);
+	}
+
+}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/provider/RedisCacheManagerProviderTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/provider/RedisCacheManagerProviderTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache.provider;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+class RedisCacheManagerProviderTest {
+
+	@Test
+	void providedCacheManagerIsRedisCacheManager() {
+		LocalResponseCacheProperties localResponseCacheProperties = new LocalResponseCacheProperties();
+		localResponseCacheProperties.setTimeToLive(Duration.ofSeconds(99));
+
+		RedisConnectionFactory redisConnectionFactory = Mockito.mock(RedisConnectionFactory.class);
+		RedisCacheManagerProvider redisCacheManagerProvider = new RedisCacheManagerProvider(redisConnectionFactory);
+		CacheManager cacheManager = redisCacheManagerProvider.getCacheManager(localResponseCacheProperties);
+
+		Assertions.assertInstanceOf(RedisCacheManager.class, cacheManager);
+	}
+
+}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/NameUtilsTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/NameUtilsTests.java
@@ -97,7 +97,7 @@ class NameUtilsTests {
 				.collect(Collectors.toList());
 
 		List<String> expectedNames = Arrays.asList("add-request-header", "dedupe-response-header", "fallback-headers",
-				"map-request-header", "json-to-grpc", "local-response-cache");
+				"map-request-header", "json-to-grpc", "response-cache");
 
 		assertThat(resultNames).isEqualTo(expectedNames);
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/NameUtilsTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/NameUtilsTests.java
@@ -32,7 +32,7 @@ import org.springframework.cloud.gateway.filter.factory.FallbackHeadersGatewayFi
 import org.springframework.cloud.gateway.filter.factory.GatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.JsonToGrpcGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.MapRequestHeaderGatewayFilterFactory;
-import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory;
+import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheGatewayFilterFactory;
 import org.springframework.cloud.gateway.handler.predicate.AfterRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.CloudFoundryRouteServiceRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.ReadBodyRoutePredicateFactory;
@@ -91,7 +91,7 @@ class NameUtilsTests {
 		List<Class<? extends GatewayFilterFactory<?>>> predicates = Arrays.asList(
 				AddRequestHeaderGatewayFilterFactory.class, DedupeResponseHeaderGatewayFilterFactory.class,
 				FallbackHeadersGatewayFilterFactory.class, MapRequestHeaderGatewayFilterFactory.class,
-				JsonToGrpcGatewayFilterFactory.class, LocalResponseCacheGatewayFilterFactory.class);
+				JsonToGrpcGatewayFilterFactory.class, ResponseCacheGatewayFilterFactory.class);
 
 		List<String> resultNames = predicates.stream().map(NameUtils::normalizeFilterFactoryNameAsProperty)
 				.collect(Collectors.toList());


### PR DESCRIPTION
LocalResponseCacheGatewayFilterFactory offers a lot of great functionality assuming that you're fine with a Caffiene-backed cache implementation.  For my particular use case, I'm interested in using a Redis cache and distributing the cache storage across several instances of the spring-cloud-gateway app.

This pull request:
1. renames parts of the plumbing that are common regardless of caching implementation from `LocalResponseCache*` to `ResponseCache*`
2. adds auto configuration for Redis-backed CacheManager
3. changes the access modifiers of some classes/methods in order to make my use case work out

Any feedback/suggestions are appreciated.  If modifications are required in order to get this back into the mainline please let me know.