### PR TITLE
(main) Fix GRPC dependencies for GRPCApplicationTests

### DIFF
--- a/spring-cloud-gateway-integration-tests/grpc/pom.xml
+++ b/spring-cloud-gateway-integration-tests/grpc/pom.xml
@@ -11,7 +11,8 @@
 	<description>Spring Cloud Gateway gRPC Integration Test</description>
 
 	<properties>
-		<grpc.version>1.59.0</grpc.version>
+		<protoc.version>3.25.1</protoc.version>
+		<grpc.version>1.59.1</grpc.version>
 	</properties>
 
 	<parent>
@@ -112,9 +113,9 @@
 				<artifactId>protobuf-maven-plugin</artifactId>
 				<version>0.6.1</version>
 				<configuration>
-					<protocArtifact>com.google.protobuf:protoc:3.19.4:exe:${os.detected.classifier}</protocArtifact>
+					<protocArtifact>com.google.protobuf:protoc:${protoc.version}:exe:${os.detected.classifier}</protocArtifact>
 					<pluginId>grpc-java</pluginId>
-					<pluginArtifact>io.grpc:protoc-gen-grpc-java:1.44.0:exe:${os.detected.classifier}</pluginArtifact>
+					<pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
The main fix is bumping GRPC to 1.59.1, for some reason 1.59.0 fails.
Additionally,
* Use same GRPC version for SCG runtime and proto code generation.
* The protobuf compiler version is set with a version to help bumping.

**NOTE**: protoc is the compiler used for the GRPC test service, it'd fine to bump to the most recent, it does not affect the SCG runtime.