### PR TITLE
Fix TokenRelayGatewayFilter to check valid accessToken exists at first

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -170,6 +170,7 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.ReactiveOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.web.server.ServerOAuth2AuthorizedClientRepository;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.util.ClassUtils;
 import org.springframework.validation.Validator;
@@ -187,6 +188,7 @@ import org.springframework.web.reactive.socket.server.upgrade.ReactorNettyReques
  * @author Mete Alpaslan Katırcıoğlu
  * @author Alberto C. Ríos
  * @author Olga Maciaszek-Sharma
+ * @author Injae Kim 
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = "spring.cloud.gateway.enabled", matchIfMissing = true)
@@ -859,8 +861,9 @@ public class GatewayAutoConfiguration {
 
 		@Bean
 		public TokenRelayGatewayFilterFactory tokenRelayGatewayFilterFactory(
-				ObjectProvider<ReactiveOAuth2AuthorizedClientManager> clientManager) {
-			return new TokenRelayGatewayFilterFactory(clientManager);
+				ObjectProvider<ReactiveOAuth2AuthorizedClientManager> clientManager,
+				ServerOAuth2AuthorizedClientRepository authorizedClientRepository) {
+			return new TokenRelayGatewayFilterFactory(clientManager, authorizedClientRepository);
 		}
 
 	}


### PR DESCRIPTION
Fixes #2316

### Motivation

https://github.com/spring-cloud/spring-cloud-gateway/blob/fb3b782afc40db9c220667ff8cc52d4968075099/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/TokenRelayGatewayFilterFactory.java#L63-L64

- On `TokenRelayGatewayFilterFactory`, we found that it always fetches the access token via the the refresh token which is stored within the current users session
  - ⚠️ This is unnecessary since a session still might have a **valid access token stored which is not yet expired**

### Modification
- Fix `TokenRelayGatewayFilter ` to check valid stored access token(which is not expired yet) exists at first

### Result
- Now if there's valid stored access token exists, use it and not fetches the new access token
- Close #2316
