### PR TITLE
Update gateway-request-predicates.adoc

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-mvc/gateway-request-predicates.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-mvc/gateway-request-predicates.adoc
@@ -19,11 +19,12 @@ The following example configures an after route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: after_route
-        uri: https://example.org
-        predicates:
-        - After=2017-01-20T17:42:47.789-07:00[America/Denver]
+      mvc:
+        routes:
+        - id: after_route
+          uri: https://example.org
+          predicates:
+          - After=2017-01-20T17:42:47.789-07:00[America/Denver]
 ----
 
 .GatewaySampleApplication.java
@@ -61,11 +62,12 @@ The following example configures a before route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: before_route
-        uri: https://example.org
-        predicates:
-        - Before=2017-01-20T17:42:47.789-07:00[America/Denver]
+      mvc:
+        routes:
+        - id: before_route
+          uri: https://example.org
+          predicates:
+          - Before=2017-01-20T17:42:47.789-07:00[America/Denver]
 ----
 
 .GatewaySampleApplication.java
@@ -105,11 +107,12 @@ The following example configures a between route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: between_route
-        uri: https://example.org
-        predicates:
-        - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]
+      mvc:
+        routes:
+        - id: between_route
+          uri: https://example.org
+          predicates:
+          - Between=2017-01-20T17:42:47.789-07:00[America/Denver], 2017-01-21T17:42:47.789-07:00[America/Denver]
 ----
 
 .GatewaySampleApplication.java
@@ -148,11 +151,12 @@ The following example configures a cookie route predicate factory:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: cookie_route
-        uri: https://example.org
-        predicates:
-        - Cookie=chocolate, ch.p
+      mvc:
+        routes:
+        - id: cookie_route
+          uri: https://example.org
+          predicates:
+          - Cookie=chocolate, ch.p
 ----
 
 .GatewaySampleApplication.java
@@ -189,11 +193,12 @@ The following example configures a header route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: header_route
-        uri: https://example.org
-        predicates:
-        - Header=X-Request-Id, \d+
+      mvc:
+        routes:
+        - id: header_route
+          uri: https://example.org
+          predicates:
+          - Header=X-Request-Id, \d+
 ----
 
 .GatewaySampleApplication.java
@@ -231,11 +236,12 @@ The following example configures a host route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: host_route
-        uri: https://example.org
-        predicates:
-        - Host=**.somehost.org,**.anotherhost.org
+      mvc:
+        routes:
+        - id: host_route
+          uri: https://example.org
+          predicates:
+          - Host=**.somehost.org,**.anotherhost.org
 ----
 
 .GatewaySampleApplication.java
@@ -278,11 +284,12 @@ The following example configures a method route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: method_route
-        uri: https://example.org
-        predicates:
-        - Method=GET,POST
+      mvc:
+        routes:
+        - id: method_route
+          uri: https://example.org
+          predicates:
+          - Method=GET,POST
 ----
 
 .GatewaySampleApplication.java
@@ -345,11 +352,12 @@ The following example configures a path route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: path_route
-        uri: https://example.org
-        predicates:
-        - Path=/red/{segment},/blue/{segment}
+      mvc:
+        routes:
+        - id: path_route
+          uri: https://example.org
+          predicates:
+          - Path=/red/{segment},/blue/{segment}
 ----
 
 .GatewaySampleApplication.java
@@ -402,11 +410,12 @@ The following example configures a query route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: query_route
-        uri: https://example.org
-        predicates:
-        - Query=green
+      mvc:
+        routes:
+        - id: query_route
+          uri: https://example.org
+          predicates:
+          - Query=green
 ----
 
 .GatewaySampleApplication.java
@@ -437,11 +446,12 @@ The preceding route matches if the request contained a `green` query parameter.
 spring:
   cloud:
     gateway:
-      routes:
-      - id: query_route
-        uri: https://example.org
-        predicates:
-        - Query=red, gree.
+      mvc:
+        routes:
+        - id: query_route
+          uri: https://example.org
+          predicates:
+          - Query=red, gree.
 ----
 
 .GatewaySampleApplication.java
@@ -480,11 +490,12 @@ The following example configures a RemoteAddr route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: remoteaddr_route
-        uri: https://example.org
-        predicates:
-        - RemoteAddr=192.168.1.1/24
+      mvc:
+        routes:
+        - id: remoteaddr_route
+          uri: https://example.org
+          predicates:
+          - RemoteAddr=192.168.1.1/24
 ----
 
 This route matches if the remote address of the request was, for example, `192.168.1.10`.
@@ -559,15 +570,16 @@ The following example configures a weight route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: weight_high
-        uri: https://weighthigh.org
-        predicates:
-        - Weight=group1, 8
-      - id: weight_low
-        uri: https://weightlow.org
-        predicates:
-        - Weight=group1, 2
+      mvc:
+        routes:
+        - id: weight_high
+          uri: https://weighthigh.org
+          predicates:
+          - Weight=group1, 8
+        - id: weight_low
+          uri: https://weightlow.org
+          predicates:
+          - Weight=group1, 2
 ----
 
 .GatewaySampleApplication.java
@@ -617,11 +629,12 @@ The following example configures a XForwardedRemoteAddr route predicate:
 spring:
   cloud:
     gateway:
-      routes:
-      - id: xforwarded_remoteaddr_route
-        uri: https://example.org
-        predicates:
-        - XForwardedRemoteAddr=192.168.1.1/24
+      mvc:
+        routes:
+        - id: xforwarded_remoteaddr_route
+          uri: https://example.org
+          predicates:
+          - XForwardedRemoteAddr=192.168.1.1/24
 ----
 
 This route matches if the `X-Forwarded-For` header contains, for example, `192.168.1.10`.


### PR DESCRIPTION
When I was reviewing and using the tutorial, I found that when using the 'spring-cloud-starter-gateway-mvc' package, it is necessary to add an 'mvc' layer. However, the examples in the documentation do not include this.