### PR TITLE
RouterFunctionHolder not accessible. Fixes 3199

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcPropertiesBeanDefinitionRegistrar.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcPropertiesBeanDefinitionRegistrar.java
@@ -338,11 +338,11 @@ public class GatewayMvcPropertiesBeanDefinitionRegistrar implements ImportBeanDe
 	 * Simply holds the composite gateway RouterFunction. This class can be refresh scope
 	 * without fear of having multiple RouterFunction mappings.
 	 */
-	static class RouterFunctionHolder {
+	public static class RouterFunctionHolder {
 
 		private final RouterFunction<ServerResponse> routerFunction;
 
-		RouterFunctionHolder(RouterFunction<ServerResponse> routerFunction) {
+		public RouterFunctionHolder(RouterFunction<ServerResponse> routerFunction) {
 			this.routerFunction = routerFunction;
 		}
 


### PR DESCRIPTION
Resolves exception:
Caused by: java.lang.IllegalAccessError: class $$SpringCGLIB$$0 cannot access its superclass org.springframework.cloud.gateway.server.mvc.config.GatewayMvcPropertiesBeanDefinitionRegistrar$RouterFunctionHolder

Class org.springframework.cloud.gateway.server.mvc.config.GatewayMvcPropertiesBeanDefinitionRegistrar$RouterFunctionHolder was not accessible.

Fixes gh-3199