### PR TITLE
Fix publishEvent RefreshRoutesResultEvent before cache.put

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
@@ -91,8 +91,8 @@ public class CachingRouteLocator
 					Flux.concat(Flux.fromIterable(scopedRoutesList), getNonScopedRoutes(event))
 							.sort(AnnotationAwareOrderComparator.INSTANCE).materialize().collect(Collectors.toList())
 							.subscribe(signals -> {
-								applicationEventPublisher.publishEvent(new RefreshRoutesResultEvent(this));
 								cache.put(CACHE_KEY, signals);
+								applicationEventPublisher.publishEvent(new RefreshRoutesResultEvent(this));
 							}, this::handleRefreshError);
 				}, this::handleRefreshError);
 			}
@@ -101,8 +101,8 @@ public class CachingRouteLocator
 
 				allRoutes.subscribe(list -> Flux.fromIterable(list).materialize().collect(Collectors.toList())
 						.subscribe(signals -> {
-							applicationEventPublisher.publishEvent(new RefreshRoutesResultEvent(this));
 							cache.put(CACHE_KEY, signals);
+							applicationEventPublisher.publishEvent(new RefreshRoutesResultEvent(this));
 						}, this::handleRefreshError), this::handleRefreshError);
 			}
 		}


### PR DESCRIPTION
publishEvent RefreshRoutesResultEvent executed in front of cache.put()
will cause the object which is listening to RefreshRoutesResultEvent
get data from routeLocator.getRoutes() is still old