### PR TITLE
preserve target paths on mvc gateways

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunction.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunction.java
@@ -72,6 +72,8 @@ public class ProxyExchangeHandlerFunction implements HandlerFunction<ServerRespo
 				.scheme(uri.getScheme())
 				.host(uri.getHost())
 				.port(uri.getPort())
+				.replacePath(uri.getPath())
+				.path(serverRequest.uri().getPath())
 				.replaceQueryParams(serverRequest.params())
 				.build(encoded)
 				.toUri();


### PR DESCRIPTION
the previous implementation completely removed the path of the configured target which is unexpected and did not match the API (target is given as URI (string) which naturally can contain paths)

I created and attached a small project to reproduce the issue with the current code, see GatewayConfiguration.java, so when calling http://localhost:8080/gateway/hello it is expected to see the content from http://localhost:8080/finallevel/hello but instead the content of http://localhost:8080/hello only is displayed

[gateway-pathsgone.zip](https://github.com/spring-cloud/spring-cloud-gateway/files/14219764/gateway-pathsgone.zip)
