### PR TITLE
Add GlobalFilter for Gateway MVC

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/GlobalFilter.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/GlobalFilter.java
@@ -1,0 +1,22 @@
+package org.springframework.cloud.gateway.server.mvc.filter;
+
+import org.springframework.web.servlet.function.HandlerFilterFunction;
+import org.springframework.web.servlet.function.ServerResponse;
+
+/**
+ * Contract for interception-style, chained processing of gateway requests that may be
+ * used to implement cross-cutting, application-agnostic requirements such as security,
+ * timeouts, and others.
+ *
+ * Only applies to matched gateway routes.
+ *
+ * Copied from reactive gateway server
+ *
+ * @author Andre Sustac
+ * @since 4.1
+ */
+public interface GlobalFilter {
+
+	HandlerFilterFunction<ServerResponse, ServerResponse> filter();
+
+}

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/GlobalFilter.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/GlobalFilter.java
@@ -17,6 +17,11 @@ import org.springframework.web.servlet.function.ServerResponse;
  */
 public interface GlobalFilter {
 
+	/**
+	 * Process the web request and (optionally) delegate to the next
+	 * filter
+	 * @return HandlerFilterFunction that will be used to register gateway RouterFunctions
+	 */
 	HandlerFilterFunction<ServerResponse, ServerResponse> filter();
 
 }


### PR DESCRIPTION
Replicate the Spring Cloud Gateway Reactive [GlobalFilter](https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway/global-filters.html) interface behavior in Gateway MVC.
Only the interface is created (and not every implementation, which are already handled within the `FilterDiscoverer`).

The GlobalFilter interface allows applications to create a filter bean which will be executed **only** on matched gateway routes. It also supports for Order annotation.

Exemple implementation:
```java
@Configuration
public class CustomGlobalFilter implements GlobalFilter {
    @Override
    public HandlerFilterFunction<ServerResponse, ServerResponse> filter() {
        return (request, next) -> {
            LOGGER.info("Routing to route '{}'", request.attribute(MvcUtils.GATEWAY_ROUTE_ID_ATTR));
            return next.handle(request);
        };
    }
}
```

Fixes #3239 and #3143