### PR TITLE
Added removal of Connection option headers. Fixes GH-2653

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilter.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.Ordered;
@@ -67,11 +68,17 @@ public class RemoveHopByHopHeadersFilter implements HttpHeadersFilter, Ordered {
 	}
 
 	@Override
-	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
+	public HttpHeaders filter(HttpHeaders originalHeaders, ServerWebExchange exchange) {
 		HttpHeaders filtered = new HttpHeaders();
+		List<String> connectionOptions = originalHeaders.getConnection()
+				.stream()
+				.map(String::toLowerCase)
+				.toList();
+		Set<String> headersToRemove = Stream.concat(headers.stream(), connectionOptions.stream())
+				.collect(Collectors.toSet());
 
-		for (Map.Entry<String, List<String>> entry : input.entrySet()) {
-			if (!this.headers.contains(entry.getKey().toLowerCase())) {
+		for (Map.Entry<String, List<String>> entry : originalHeaders.entrySet()) {
+			if (!headersToRemove.contains(entry.getKey().toLowerCase())) {
 				filtered.addAll(entry.getKey(), entry.getValue());
 			}
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/headers/RemoveHopByHopHeadersFilterTests.java
@@ -29,6 +29,7 @@ import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.springframework.cloud.gateway.filter.headers.RemoveHopByHopHeadersFilter.HEADERS_REMOVED_ON_REQUEST;
 
 /**
@@ -75,11 +76,14 @@ public class RemoveHopByHopHeadersFilterTests {
 	public void removesHeadersListedInConnectionHeader() {
 		MockServerHttpRequest.BaseBuilder<?> builder = MockServerHttpRequest.get("http://localhost/get");
 
-		builder.header(HttpHeaders.CONNECTION, "upgrade", "keep-alive");
+		String arbitraryConnectionOption = "xyz";
+		assumeThat(HEADERS_REMOVED_ON_REQUEST).doesNotContain(arbitraryConnectionOption);
+		builder.header(HttpHeaders.CONNECTION, "upgrade", "keep-alive", arbitraryConnectionOption.toUpperCase());
 		builder.header(HttpHeaders.UPGRADE, "WebSocket");
-		builder.header("Keep-Alive", "timeout:5");
+		builder.header("Keep-Alive", "timeout=5");
+		builder.header(arbitraryConnectionOption, "");
 
-		testFilter(MockServerWebExchange.from(builder), "upgrade", "keep-alive");
+		testFilter(MockServerWebExchange.from(builder), arbitraryConnectionOption);
 	}
 
 	private void testFilter(MockServerWebExchange exchange, String... additionalHeaders) {


### PR DESCRIPTION
Added removal of `Connection` option headers, if any present. Edited the corresponding test to reflect the changes

It's my first PR, but I encourage you to pull no punches if I fell short of expectations for Spring Cloud Gateway contributors. I will do my best to fix any potential issues