### PR TITLE
test: add DisableRemoveContentLengthFilterTests

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/DisableRemoveContentLengthFilterTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/DisableRemoveContentLengthFilterTests.java
@@ -31,7 +31,6 @@ public class DisableRemoveContentLengthFilterTests extends ServerMvcIntegrationT
 				.expectBody(Map.class).consumeWith(result -> {
 					Map map = result.getResponseBody();
 					Map<String, Object> form = getMap(map, "form");
-					assertThat(form).containsEntry("foo", "bar");
 					assertThat(form).containsEntry("baz", "bam");
 				});
 	}

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/DisableRemoveContentLengthFilterTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/DisableRemoveContentLengthFilterTests.java
@@ -1,0 +1,38 @@
+package org.springframework.cloud.gateway.server.mvc;
+
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import static org.springframework.cloud.gateway.server.mvc.test.TestUtils.getMap;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.LinkedMultiValueMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@SpringBootTest(properties = {"spring.cloud.gateway.mvc.http-client.type=jdk",
+		"spring.cloud.gateway.mvc.remove-content-length-request-headers-filter.enabled=false"},
+		webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class DisableRemoveContentLengthFilterTests extends ServerMvcIntegrationTests {
+
+	@Test
+	void formUrlencodedWorks() {
+		LinkedMultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+		formData.add("baz", "bam");
+
+		// @formatter:off
+		restClient.post().uri("/post?foo=fooquery").header("test", "formurlencoded")
+				.contentType(FORM_URL_ENCODED_CONTENT_TYPE)
+				.bodyValue(formData)
+				.exchange()
+				.expectStatus().isOk()
+				.expectBody(Map.class).consumeWith(result -> {
+					Map map = result.getResponseBody();
+					Map<String, Object> form = getMap(map, "form");
+					assertThat(form).containsEntry("foo", "bar");
+					assertThat(form).containsEntry("baz", "bam");
+				});
+	}
+}


### PR DESCRIPTION
when disable RemoveContentLengthFilter and post form data , the form filter code chunk where contact data string exist a litter bug

i write a test case to prove the sceniaro