### PR TITLE
Fix Deprecated Redis Command

### DIFF
--- a/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
+++ b/spring-cloud-gateway-server/src/main/resources/META-INF/scripts/request_rate_limiter.lua
@@ -52,8 +52,8 @@ end
 --redis.log(redis.LOG_WARNING, "new_tokens " .. new_tokens)
 
 if ttl > 0 then
-  redis.call("setex", tokens_key, ttl, new_tokens)
-  redis.call("setex", timestamp_key, ttl, now)
+  redis.call("set", tokens_key, new_tokens, "ex", ttl)
+  redis.call("set", timestamp_key, now, "ex", ttl)
 end
 
 -- return { allowed_num, new_tokens, capacity, filled_tokens, requested, new_tokens }


### PR DESCRIPTION
Redis' SETEX command is deprecated

I actually used this replacement in my project, and it worked successfully.
I am sending this request in case the command will not work in the future.

Thank you

> https://redis.io/commands/setex/
> As of Redis version 2.6.12, this command is regarded as deprecated.
> It can be replaced by [SET](https://redis.io/commands/set) with the EX argument when migrating or writing new code.