### PR TITLE
Fix Bug(Gateway MVC): Make sure Retry filter sends correct body

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
@@ -102,8 +102,14 @@ public abstract class MvcUtils {
 	public static ByteArrayInputStream cacheBody(ServerRequest request) {
 		try {
 			byte[] bytes = StreamUtils.copyToByteArray(request.servletRequest().getInputStream());
-			ByteArrayInputStream body = new ByteArrayInputStream(bytes);
-			putAttribute(request, MvcUtils.CACHED_REQUEST_BODY_ATTR, body);
+			ByteArrayInputStream body;
+			if (bytes.length > 0) {
+				body = new ByteArrayInputStream(bytes);
+				putAttribute(request, MvcUtils.CACHED_REQUEST_BODY_ATTR, body);
+			}
+			else {
+				body = getAttribute(request, CACHED_REQUEST_BODY_ATTR);
+			}
 			return body;
 		}
 		catch (IOException e) {

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/RetryFilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/RetryFilterFunctions.java
@@ -43,6 +43,8 @@ import org.springframework.web.servlet.function.HandlerFilterFunction;
 import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.servlet.function.ServerResponse;
 
+import static org.springframework.cloud.gateway.server.mvc.filter.BodyFilterFunctions.adaptCachedBody;
+
 public abstract class RetryFilterFunctions {
 
 	private RetryFilterFunctions() {
@@ -75,7 +77,7 @@ public abstract class RetryFilterFunctions {
 			if (isRetryableStatusCode(serverResponse.statusCode(), config)
 					&& isRetryableMethod(request.method(), config)) {
 				// use this to transfer information to HttpStatusRetryPolicy
-				throw new RetryException(request, serverResponse);
+				throw new RetryException(adaptCachedBody().apply(request), serverResponse);
 			}
 			return serverResponse;
 		});

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
@@ -24,6 +24,8 @@ import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.servlet.function.ServerResponse;
 
+import static org.springframework.cloud.gateway.server.mvc.common.MvcUtils.cacheBody;
+
 public class RestClientProxyExchange implements ProxyExchange {
 
 	private final RestClient restClient;
@@ -41,7 +43,7 @@ public class RestClientProxyExchange implements ProxyExchange {
 	}
 
 	private static int copyBody(Request request, OutputStream outputStream) throws IOException {
-		return StreamUtils.copy(request.getServerRequest().servletRequest().getInputStream(), outputStream);
+		return StreamUtils.copy(cacheBody(request.getServerRequest()), outputStream);
 	}
 
 	private static ServerResponse doExchange(Request request, ClientHttpResponse clientResponse) throws IOException {


### PR DESCRIPTION
Fix Bug(Gateway MVC): Make sure Retry filter sends correct body when retrying POST/PUT/etc

Retry filter will send empty body when retrying POST/PUT/etc, see https://github.com/spring-cloud/spring-cloud-gateway/issues/3336