### PR TITLE
#2975-Suggestion-Add-Permissions-Policy-as-configurable-option-to-Sec…

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway/gatewayfilter-factories/secureheaders-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway/gatewayfilter-factories/secureheaders-factory.adoc
@@ -29,10 +29,55 @@ The following properties are available:
 To disable the default values set the `spring.cloud.gateway.filter.secure-headers.disable` property with comma-separated values.
 The following example shows how to do so:
 
-[source]
+.application.yml
+[source,yaml]
 ----
-spring.cloud.gateway.filter.secure-headers.disable=x-frame-options,strict-transport-security
+spring:
+  cloud:
+    gateway:
+      filter:
+        secure-headers:
+          disable: x-frame-options,strict-transport-security
 ----
 
-NOTE: The lowercase full name of the secure header needs to be used to disable it..
+NOTE: The lowercase full name of the secure header needs to be used to disable it.
 
+== Further options
+
+You may opt in to add the `Permissions-Policy` header to the response. Permissions Policy is a security header
+that allows web developers to manage which browser features a website can utilize. Please see
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy[Permissions-Policy] and
+https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#directives[Directives] to configure it
+for your environment.
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      filter:
+        secure-headers:
+          enable: permissions-policy
+          permissions-policy : geolocation=(self "https://example.com")
+----
+
+In the above https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy/geolocation[example]
+the Geolocation API is disabled within all browsing contexts except for its own origin and those whose origin is "https://example.com".
+
+WARNING: When you enable Permissions-Policy and do not explicitly configure any directives, a default value will be applied.
+Specifically, this default value disables a wide range of standardized and experimental features.
+This behavior might not be appropriate for your specific environment or use case.
+
+Permissions-Policy default value when enabled and no explicit configuration:
+
+`Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=(), cross-origin-isolated=(),
+display-capture=(), document-domain=(), encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(),
+fullscreen=(), geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), navigation-override=(),
+payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(),
+web-share=(), xr-spatial-tracking=()`
+
+
+NOTE: You can check the Permissions Policy feature list for Chrome with https://developer.chrome.com/docs/privacy-security/permissions-policy#chrome_devtools_integration[DevTool Integration].
+
+When you configure the header value for your environment, make sure to check the browser console for syntax errors.

--- a/spring-cloud-gateway-sample/src/main/resources/application-secureheaders.yml
+++ b/spring-cloud-gateway-sample/src/main/resources/application-secureheaders.yml
@@ -1,0 +1,50 @@
+test:
+    hostport: httpbin.org:80
+  #  hostport: localhost:5000
+    uri: http://${test.hostport}
+  #uri: lb://httpbin
+
+
+spring:
+  cloud:
+    gateway:
+      filter:
+        secure-headers:
+          disable: x-frame-options,strict-transport-security
+          enable: permissions-policy
+          permissions-policy : geolocation=("https://example.com")
+      default-filters:
+      #- PrefixPath=/httpbin
+      #- AddResponseHeader=X-Response-Default-Foo, Default-Bar
+
+      routes:
+      # =====================================
+      # to run server
+      # $ wscat --listen 9000
+      # to run client
+      # $ wscat --connect ws://localhost:8080/echo
+      - id: websocket_test
+        uri: ws://localhost:9000
+        order: 9000
+        predicates:
+        - Path=/echo
+      # =====================================
+      - id: default_path_to_httpbin
+        uri: ${test.uri}
+        order: 10000
+        predicates:
+        - Path=/**
+        filters:
+          - name: SecureHeaders
+
+logging:
+  level:
+    org.springframework.cloud.gateway: TRACE
+    org.springframework.http.server.reactive: DEBUG
+    org.springframework.web.reactive: DEBUG
+    reactor.ipc.netty: DEBUG
+    reactor.netty: DEBUG
+
+management.endpoints.web.exposure.include: '*'
+
+

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersProperties.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersProperties.java
@@ -16,16 +16,24 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
- * @author Spencer Gibb, Thirunavukkarasu Ravichandran
+ * @author Spencer Gibb, Thirunavukkarasu Ravichandran, Jörg Richter
  */
 @ConfigurationProperties("spring.cloud.gateway.filter.secure-headers")
 public class SecureHeadersProperties {
+
+	/**
+	 * Xss-Protection header name.
+	 */
+	public static final String X_XSS_PROTECTION_HEADER = "X-Xss-Protection";
 
 	/**
 	 * Xss-Protection header default.
@@ -33,9 +41,19 @@ public class SecureHeadersProperties {
 	public static final String X_XSS_PROTECTION_HEADER_DEFAULT = "1 ; mode=block";
 
 	/**
+	 * Strict transport security header name.
+	 */
+	public static final String STRICT_TRANSPORT_SECURITY_HEADER = "Strict-Transport-Security";
+
+	/**
 	 * Strict transport security header default.
 	 */
 	public static final String STRICT_TRANSPORT_SECURITY_HEADER_DEFAULT = "max-age=631138519";
+
+	/**
+	 * Frame options header name.
+	 */
+	public static final String X_FRAME_OPTIONS_HEADER = "X-Frame-Options";
 
 	/**
 	 * Frame Options header default.
@@ -43,9 +61,19 @@ public class SecureHeadersProperties {
 	public static final String X_FRAME_OPTIONS_HEADER_DEFAULT = "DENY";
 
 	/**
+	 * Content-Type Options header name.
+	 */
+	public static final String X_CONTENT_TYPE_OPTIONS_HEADER = "X-Content-Type-Options";
+
+	/**
 	 * Content-Type Options header default.
 	 */
 	public static final String X_CONTENT_TYPE_OPTIONS_HEADER_DEFAULT = "nosniff";
+
+	/**
+	 * Referrer Policy header name.
+	 */
+	public static final String REFERRER_POLICY_HEADER = "Referrer-Policy";
 
 	/**
 	 * Referrer Policy header default.
@@ -53,9 +81,19 @@ public class SecureHeadersProperties {
 	public static final String REFERRER_POLICY_HEADER_DEFAULT = "no-referrer";
 
 	/**
+	 * Content-Security Policy header name.
+	 */
+	public static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
+
+	/**
 	 * Content-Security Policy header default.
 	 */
 	public static final String CONTENT_SECURITY_POLICY_HEADER_DEFAULT = "default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline'";
+
+	/**
+	 * Download Options header name.
+	 */
+	public static final String X_DOWNLOAD_OPTIONS_HEADER = "X-Download-Options";
 
 	/**
 	 * Download Options header default.
@@ -63,9 +101,46 @@ public class SecureHeadersProperties {
 	public static final String X_DOWNLOAD_OPTIONS_HEADER_DEFAULT = "noopen";
 
 	/**
+	 * Permitted Cross-Domain Policies header name.
+	 */
+	public static final String X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER = "X-Permitted-Cross-Domain-Policies";
+
+	/**
 	 * Permitted Cross-Domain Policies header default.
 	 */
 	public static final String X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER_DEFAULT = "none";
+
+	/**
+	 * Permissions Policy header name. Opt-In required by external configuration.
+	 */
+	public static final String PERMISSIONS_POLICY_HEADER = "Permissions-Policy";
+
+	/**
+	 * Permissions Policy header default. Opt-In by external configuration required,
+	 * because the header default disables a comprehensive list of features.
+	 */
+	public static final String PERMISSIONS_POLICY_HEADER_OPT_IN_DEFAULT = "accelerometer=(), ambient-light-sensor=(), "
+			+ "autoplay=(), battery=(), camera=(), cross-origin-isolated=(), display-capture=(), document-domain=(), "
+			+ "encrypted-media=(), execution-while-not-rendered=(), execution-while-out-of-viewport=(), fullscreen=(), "
+			+ "geolocation=(), gyroscope=(), keyboard-map=(), magnetometer=(), microphone=(), midi=(), "
+			+ "navigation-override=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), "
+			+ "screen-wake-lock=(), sync-xhr=(), usb=(), web-share=(), xr-spatial-tracking=()";
+
+	public SecureHeadersProperties() {
+
+		defaultHeaders = Stream.of(
+						SecureHeadersProperties.X_XSS_PROTECTION_HEADER,
+						SecureHeadersProperties.STRICT_TRANSPORT_SECURITY_HEADER,
+						SecureHeadersProperties.X_FRAME_OPTIONS_HEADER,
+						SecureHeadersProperties.X_CONTENT_TYPE_OPTIONS_HEADER,
+						SecureHeadersProperties.REFERRER_POLICY_HEADER,
+						SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER,
+						SecureHeadersProperties.X_DOWNLOAD_OPTIONS_HEADER,
+						SecureHeadersProperties.X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER
+				).map(String::toLowerCase)
+				.collect(Collectors.toUnmodifiableSet());
+
+	}
 
 	private String xssProtectionHeader = X_XSS_PROTECTION_HEADER_DEFAULT;
 
@@ -83,7 +158,13 @@ public class SecureHeadersProperties {
 
 	private String permittedCrossDomainPolicies = X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER_DEFAULT;
 
-	private List<String> disable = new ArrayList<>();
+	private String permissionsPolicy = PERMISSIONS_POLICY_HEADER_OPT_IN_DEFAULT;
+
+	private final Set<String> defaultHeaders;
+
+	private Set<String> enabledHeaders = new HashSet<>();
+
+	private Set<String> disabledHeaders = new HashSet<>();
 
 	public String getXssProtectionHeader() {
 		return xssProtectionHeader;
@@ -149,28 +230,66 @@ public class SecureHeadersProperties {
 		this.permittedCrossDomainPolicies = permittedCrossDomainPolicies;
 	}
 
-	public List<String> getDisable() {
-		return disable;
+	public String getPermissionsPolicy() {
+		return permissionsPolicy;
+	}
+
+	public void setPermissionsPolicy(String permissionsPolicy) {
+		this.permissionsPolicy = permissionsPolicy;
+	}
+
+	/**
+	 * @return the opt-in header names to enable, in lower case
+	 */
+	public Set<String> getEnabledHeaders() {
+		return enabledHeaders;
+	}
+
+	public void setEnable(List<String> enable) {
+		if (enable != null) {
+			enabledHeaders = enable.stream()
+					.map(String::toLowerCase)
+					.collect(Collectors.toUnmodifiableSet());
+		}
+	}
+
+	/**
+	 * @return the default/opt-out header names to disable, in lower case
+	 */
+	public Set<String> getDisabledHeaders() {
+		return disabledHeaders;
 	}
 
 	public void setDisable(List<String> disable) {
-		this.disable = disable;
+		if (disable != null) {
+			disabledHeaders = disable.stream()
+					.map(String::toLowerCase)
+					.collect(Collectors.toUnmodifiableSet());
+		}
+	}
+
+	/**
+	 * @return the default/opt-out header names to apply, in lower case
+	 */
+	public Set<String> getDefaultHeaders() {
+		return defaultHeaders;
 	}
 
 	@Override
 	public String toString() {
-		final StringBuffer sb = new StringBuffer("SecureHeadersProperties{");
-		sb.append("xssProtectionHeader='").append(xssProtectionHeader).append('\'');
-		sb.append(", strictTransportSecurity='").append(strictTransportSecurity).append('\'');
-		sb.append(", frameOptions='").append(frameOptions).append('\'');
-		sb.append(", contentTypeOptions='").append(contentTypeOptions).append('\'');
-		sb.append(", referrerPolicy='").append(referrerPolicy).append('\'');
-		sb.append(", contentSecurityPolicy='").append(contentSecurityPolicy).append('\'');
-		sb.append(", downloadOptions='").append(downloadOptions).append('\'');
-		sb.append(", permittedCrossDomainPolicies='").append(permittedCrossDomainPolicies).append('\'');
-		sb.append(", disabled='").append(disable).append('\'');
-		sb.append('}');
-		return sb.toString();
+		return "SecureHeadersProperties{" +
+				"xssProtectionHeader='" + xssProtectionHeader + '\'' +
+				", strictTransportSecurity='" + strictTransportSecurity + '\'' +
+				", frameOptions='" + frameOptions + '\'' +
+				", contentTypeOptions='" + contentTypeOptions + '\'' +
+				", referrerPolicy='" + referrerPolicy + '\'' +
+				", contentSecurityPolicy='" + contentSecurityPolicy + '\'' +
+				", downloadOptions='" + downloadOptions + '\'' +
+				", permittedCrossDomainPolicies='" + permittedCrossDomainPolicies + '\'' +
+				", permissionsPolicy='" + permissionsPolicy + '\'' +
+				", defaultHeaders=" + defaultHeaders +
+				", enable=" + enabledHeaders +
+				", disable=" + disabledHeaders +
+				'}';
 	}
-
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryTests.java
@@ -34,13 +34,14 @@ import org.springframework.web.reactive.function.client.ClientResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.CONTENT_SECURITY_POLICY_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.REFERRER_POLICY_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.STRICT_TRANSPORT_SECURITY_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_CONTENT_TYPE_OPTIONS_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_DOWNLOAD_OPTIONS_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_FRAME_OPTIONS_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.PERMISSIONS_POLICY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.REFERRER_POLICY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.STRICT_TRANSPORT_SECURITY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_CONTENT_TYPE_OPTIONS_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_DOWNLOAD_OPTIONS_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_FRAME_OPTIONS_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER;
 import static org.springframework.cloud.gateway.test.TestUtils.assertStatus;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
@@ -56,8 +57,8 @@ public class SecureHeadersGatewayFilterFactoryTests extends BaseWebClientTests {
 
 		StepVerifier.create(result).consumeNextWith(response -> {
 			assertStatus(response, HttpStatus.OK);
+
 			HttpHeaders httpHeaders = response.headers().asHttpHeaders();
-			// assertThat(httpHeaders.getFirst(X_XSS_PROTECTION_HEADER)).isEqualTo(defaults.getXssProtectionHeader());
 			assertThat(httpHeaders.getFirst(STRICT_TRANSPORT_SECURITY_HEADER))
 					.isEqualTo(defaults.getStrictTransportSecurity());
 			assertThat(httpHeaders.getFirst(X_FRAME_OPTIONS_HEADER)).isEqualTo(defaults.getFrameOptions());
@@ -68,6 +69,9 @@ public class SecureHeadersGatewayFilterFactoryTests extends BaseWebClientTests {
 			assertThat(httpHeaders.getFirst(X_DOWNLOAD_OPTIONS_HEADER)).isEqualTo(defaults.getDownloadOptions());
 			assertThat(httpHeaders.getFirst(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER))
 					.isEqualTo(defaults.getPermittedCrossDomainPolicies());
+
+			assertThat(httpHeaders.get(PERMISSIONS_POLICY_HEADER)).isNull();
+
 		}).expectComplete().verify(DURATION);
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
@@ -16,7 +16,11 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
+import org.assertj.core.api.StringAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -33,18 +37,19 @@ import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.CONTENT_SECURITY_POLICY_HEADER;
 import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.Config;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.REFERRER_POLICY_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.STRICT_TRANSPORT_SECURITY_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_CONTENT_TYPE_OPTIONS_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_DOWNLOAD_OPTIONS_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_FRAME_OPTIONS_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER;
-import static org.springframework.cloud.gateway.filter.factory.SecureHeadersGatewayFilterFactory.X_XSS_PROTECTION_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.PERMISSIONS_POLICY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.REFERRER_POLICY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.STRICT_TRANSPORT_SECURITY_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_CONTENT_TYPE_OPTIONS_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_DOWNLOAD_OPTIONS_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_FRAME_OPTIONS_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER;
+import static org.springframework.cloud.gateway.filter.factory.SecureHeadersProperties.X_XSS_PROTECTION_HEADER;
 
 /**
- * @author Thirunavukkarasu Ravichandran
+ * @author Thirunavukkarasu Ravichandran, Jörg Richter
  */
 public class SecureHeadersGatewayFilterFactoryUnitTests {
 
@@ -75,7 +80,7 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 		filter.filter(exchange, filterChain).block();
 
 		ServerHttpResponse response = exchange.getResponse();
-		assertThat(response.getHeaders()).containsKeys(X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER,
+		assertThat(response.getHeaders()).containsOnlyKeys(X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER,
 				X_FRAME_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER,
 				CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER);
 	}
@@ -105,8 +110,8 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(
 				new SecureHeadersProperties());
 		Config config = new Config();
-		config.setStrictTransportSecurity("max-age=65535");
-		config.setReferrerPolicy("referrer");
+		config.setStrictTransportSecurityHeaderValue("max-age=65535");
+		config.setReferrerPolicyHeaderValue("referrer");
 		filter = filterFactory.apply(config);
 
 		filter.filter(exchange, filterChain).block();
@@ -135,13 +140,18 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 	@Test
 	public void doesNotDuplicateHeaders() {
 		String originalHeaderValue = "original-header-value";
-		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(
-				new SecureHeadersProperties());
+
+		SecureHeadersProperties secureHeadersProperties = new SecureHeadersProperties();
+		secureHeadersProperties.setDisable(Collections.emptyList());
+		secureHeadersProperties.setEnable(List.of(PERMISSIONS_POLICY_HEADER));
+
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(secureHeadersProperties);
+
 		Config config = new Config();
 
 		String[] headers = { X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER, X_FRAME_OPTIONS_HEADER,
 				X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER, CONTENT_SECURITY_POLICY_HEADER,
-				X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER };
+				X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER, PERMISSIONS_POLICY_HEADER };
 
 		for (String header : headers) {
 			filter = filterFactory.apply(config);
@@ -161,6 +171,72 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 	public void toStringFormat() {
 		GatewayFilter filter = new SecureHeadersGatewayFilterFactory(new SecureHeadersProperties()).apply(new Config());
 		Assertions.assertThat(filter.toString()).contains("SecureHeaders");
+	}
+
+	@Test
+	public void doNotAddPermissionsPolicyWhenNotEnabled() {
+		SecureHeadersProperties properties = new SecureHeadersProperties();
+
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
+		filter = filterFactory.apply(new Config());
+
+		filter.filter(exchange, filterChain).block();
+
+		ServerHttpResponse response = captor.getValue().getResponse();
+		assertThat(response.getHeaders()).doesNotContainKeys(PERMISSIONS_POLICY_HEADER);
+	}
+
+	@Test
+	public void addPermissionsPolicyWhenEnabled() {
+		SecureHeadersProperties properties = new SecureHeadersProperties();
+		properties.setEnable(List.of("permissions-policy"));
+
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
+		filter = filterFactory.apply(new Config());
+
+		filter.filter(exchange, filterChain).block();
+
+		ServerHttpResponse response = captor.getValue().getResponse();
+
+		assertThat(response.getHeaders()).containsKeys(X_XSS_PROTECTION_HEADER, STRICT_TRANSPORT_SECURITY_HEADER,
+				X_FRAME_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER,
+				CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER);
+
+		assertThat(response.getHeaders().get(PERMISSIONS_POLICY_HEADER), StringAssert.class).hasSize(1).element(0)
+				.isEqualTo(SecureHeadersProperties.PERMISSIONS_POLICY_HEADER_OPT_IN_DEFAULT);
+	}
+
+	@Test
+	public void addPermissionsPolicyAndOverrideDefaults() {
+		SecureHeadersProperties properties = new SecureHeadersProperties();
+		properties.setEnable(List.of("permissions-policy"));
+		properties.setPermissionsPolicy("camera=*");
+
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
+		filter = filterFactory.apply(new Config());
+
+		filter.filter(exchange, filterChain).block();
+
+		ServerHttpResponse response = captor.getValue().getResponse();
+		assertThat(response.getHeaders().get(PERMISSIONS_POLICY_HEADER), StringAssert.class).hasSize(1).element(0)
+				.isEqualTo("camera=*");
+	}
+
+	@Test
+	public void applyCompositionWithDisabledHeadersAndPermissionPolicy() {
+		SecureHeadersProperties properties = new SecureHeadersProperties();
+		properties.setDisable(asList("x-xss-protection", "strict-transport-security", "x-frame-options",
+				"x-content-type-options", "referrer-policy", "content-security-policy", "x-download-options"));
+		properties.setEnable(List.of("permissions-policy"));
+
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
+		filter = filterFactory.apply(new Config());
+
+		filter.filter(exchange, filterChain).block();
+
+		ServerHttpResponse response = captor.getValue().getResponse();
+		assertThat(response.getHeaders()).containsOnlyKeys(X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
+				PERMISSIONS_POLICY_HEADER);
 	}
 
 }


### PR DESCRIPTION
Added Permissions-Policy header as opt-in feature in SecureHeaders-GatewayFilter

Permissions Policy is a security header that allows web developers to manage which browser features a website can utilize.
It is an opt-in header and has to be enabled. When enabled, it applies a default that disables a comprehensive list of features.
It is recommended to configure this header to the respective environment and use case.

The documentation was updated to include information about Permissions-Policy and further resources.
The test suite was updated to include Permission-Policy.

Fixes gh-2975