### PR TITLE
Remove Origin header when forwarding

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -431,6 +431,11 @@ public final class ServerWebExchangeUtils {
 		// remove attributes that may disrupt the forwarded request
 		exchange.getAttributes().remove(GATEWAY_PREDICATE_PATH_CONTAINER_ATTR);
 
+		// CORS check is applied to the original request, but should not be applied to
+		// internally forwarded requests.
+		// See https://github.com/spring-cloud/spring-cloud-gateway/issues/3350.
+		exchange = exchange.mutate().request(request -> request.headers(headers -> headers.setOrigin(null))).build();
+
 		return handler.handle(exchange);
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
@@ -37,6 +37,7 @@ import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.assertArg;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -93,9 +94,8 @@ public class ForwardRoutingFilterTests {
 		forwardRoutingFilter.filter(exchange, chain);
 
 		verifyNoMoreInteractions(chain);
-		verify(dispatcherHandler).handle(exchange);
-
-		assertThat(exchange.getAttributes().get(GATEWAY_ALREADY_ROUTED_ATTR)).isNull();
+		verify(dispatcherHandler).handle(
+				assertArg(exchange -> assertThat(exchange.getAttributes().get(GATEWAY_ALREADY_ROUTED_ATTR)).isNull()));
 	}
 
 	@Test

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
@@ -107,6 +107,13 @@ public abstract class SpringCloudCircuitBreakerFilterFactoryTests extends BaseWe
 	}
 
 	@Test
+	public void filterFallbackForwardWithCORS() {
+		testClient.get().uri("/delay/3?a=b").header("Host", "www.circuitbreakerforward.org")
+				.header("Origin", "https://cors.withcircuitbreaker.org").exchange().expectStatus().isOk().expectBody()
+				.json("{\"from\":\"circuitbreakerfallbackcontroller3\"}");
+	}
+
+	@Test
 	public void filterStatusCodeFallback() {
 		testClient.get().uri("/status/500").header("Host", "www.circuitbreakerstatuscode.org").exchange().expectStatus()
 				.isOk().expectBody().json("{\"from\":\"statusCodeFallbackController\"}");


### PR DESCRIPTION
This prevents forwarded requests, such as those from circuit breaker fallbacks, from failing in CORS checks, which require a fully populated scheme and host.

Fixes gh-3350