### PR TITLE
Add Logging to YAML Properties Resolving(RouterFunctionHolderFactory)

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
@@ -16,12 +16,7 @@
 
 package org.springframework.cloud.gateway.server.mvc.config;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -244,7 +239,26 @@ public class RouterFunctionHolderFactory {
 			String operationName, Map<String, Object> operationArgs) {
 		return operations.getOrDefault(operationName, Collections.emptyList()).stream()
 				.map(operationMethod -> new NormalizedOperationMethod(operationMethod, operationArgs))
-				.filter(opeMethod -> matchOperation(opeMethod, operationArgs)).findFirst();
+				.filter(opeMethod -> {
+					boolean match = matchOperation(opeMethod, operationArgs);
+
+					if (!match) {
+
+						log.debug("Operation is not matched, args: "
+								+ opeMethod.getNormalizedArgs().toString() + ", params:"
+								+ Arrays.toString(
+								opeMethod.getParameters().stream().toArray()));
+
+					}
+					else {
+						log.debug("Operation is matched, args: "
+								+ opeMethod.getNormalizedArgs().toString() + ", params:"
+								+ Arrays.toString(
+								opeMethod.getParameters().stream().toArray()));
+					}
+
+					return match;
+				}).findFirst();
 	}
 
 	private static boolean matchOperation(NormalizedOperationMethod operationMethod, Map<String, Object> args) {


### PR DESCRIPTION
Hi, 

**Description**


1. In a raised issue(#3327), given yaml file to configure CircuitBreakerConfig seems to fail and produce an error below:
![image](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/f877a4b2-9696-42e9-9ab6-e6aa5af51158)

- given a Configuration Bean, the properties were bound successfully and CircuitBreaker was created successfully.
![image](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/109f59b7-ee19-4bb7-8306-8a61af080db3)


- in a situation where yaml file was passed on, CircuitBreaker failed to create.
![image](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/c53133d9-77a9-4005-92bf-c88991cf90fb)



2. Noticing yaml properties binding failures was painful without debugging statements. 
 
![LoggingOperationMismatch](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/736d0e1f-3034-481d-bdbe-9640830addd0)







Helps debugging #3327 
