### PR TITLE
Add Logging to YAML Properties Resolving(RouterFunctionHolderFactory)

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
@@ -16,7 +16,13 @@
 
 package org.springframework.cloud.gateway.server.mvc.config;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
@@ -16,12 +16,7 @@
 
 package org.springframework.cloud.gateway.server.mvc.config;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -233,6 +228,10 @@ public class RouterFunctionHolderFactory {
 			if (handlerFilterFunction != null) {
 				operationHandler.accept(handlerFilterFunction);
 			}
+			log.debug("Yaml Properties matched Operations, args: "
+					+ opMethod.getNormalizedArgs().toString() + ", params:"
+					+ Arrays.toString(
+					opMethod.getParameters().stream().toArray()));
 		}
 		else {
 			throw new IllegalArgumentException(String.format("Unable to find operation %s for %s with args %s",


### PR DESCRIPTION
Hi, 

**Description**


1. In a raised issue(#3327), given yaml file to configure CircuitBreakerConfig seems to fail and produce an error below:
![image](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/f877a4b2-9696-42e9-9ab6-e6aa5af51158)

- given a Configuration Bean, the properties were bound successfully and CircuitBreaker was created successfully.

![image](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/109f59b7-ee19-4bb7-8306-8a61af080db3)


- in a situation where yaml file was passed on, CircuitBreaker failed to create.

![image](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/c53133d9-77a9-4005-92bf-c88991cf90fb)



2. Noticing yaml properties binding failures was painful without debugging statements. 
 
![image](https://github.com/spring-cloud/spring-cloud-gateway/assets/89639413/85ac0e78-02ab-49e4-af0c-7079e22761cf)




Such Logging will provide a mean to evaluate failure in binding yaml properties.


Helps debugging #3327 