### PR TITLE
fix: add splitting of comma separated cache-control values

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -59,6 +60,8 @@ public class ResponseCacheManager {
 	private static final List<String> forbiddenCacheControlValues = Arrays.asList("private", "no-store");
 
 	private static final String VARY_WILDCARD = "*";
+
+	private static final Pattern CACHE_CONTROL_SPLITTER = Pattern.compile("\\s*,\\s*");
 
 	final CacheKeyGenerator cacheKeyGenerator;
 
@@ -193,8 +196,8 @@ public class ResponseCacheManager {
 	private boolean isCacheControlAllowed(HttpMessage request) {
 		HttpHeaders headers = request.getHeaders();
 		List<String> cacheControlHeader = headers.getOrEmpty(HttpHeaders.CACHE_CONTROL);
-
-		return cacheControlHeader.stream().noneMatch(forbiddenCacheControlValues::contains);
+		return cacheControlHeader.stream().flatMap(CACHE_CONTROL_SPLITTER::splitAsStream)
+				.noneMatch(forbiddenCacheControlValues::contains);
 	}
 
 	private static boolean hasRequestBody(ServerHttpRequest request) {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheGatewayFilterTest.java
@@ -102,6 +102,14 @@ class ResponseCacheGatewayFilterTest {
 		response.setStatusCode(HttpStatus.OK);
 
 		assertThat(cacheManagerToTest.isResponseCacheable(response)).isFalse();
+
+		headers = new HttpHeaders();
+		headers.add(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, max-age=0, must-revalidate");
+		response = new MockServerHttpResponse();
+		response.getHeaders().putAll(headers);
+		response.setStatusCode(HttpStatus.OK);
+
+		assertThat(cacheManagerToTest.isResponseCacheable(response)).isFalse();
 	}
 
 }


### PR DESCRIPTION
This PR is to address https://github.com/spring-cloud/spring-cloud-gateway/issues/3431