### PR TITLE
Keep encoded plus signs in query parameters intact

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunction.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunction.java
@@ -84,14 +84,12 @@ public class ProxyExchangeHandlerFunction
 	@Override
 	public ServerResponse handle(ServerRequest serverRequest) {
 		URI uri = uriResolver.apply(serverRequest);
-		boolean encoded = containsEncodedQuery(serverRequest.uri(), serverRequest.params());
 		// @formatter:off
 		URI url = UriComponentsBuilder.fromUri(serverRequest.uri())
 				.scheme(uri.getScheme())
 				.host(uri.getHost())
 				.port(uri.getPort())
-				.replaceQueryParams(serverRequest.params())
-				.build(encoded)
+				.build(true)
 				.toUri();
 		// @formatter:on
 
@@ -129,29 +127,6 @@ public class ProxyExchangeHandlerFunction
 			filtered = typed.apply(filtered, requestOrResponse);
 		}
 		return filtered;
-	}
-
-	private static boolean containsEncodedQuery(URI uri, MultiValueMap<String, String> params) {
-		String rawQuery = uri.getRawQuery();
-		boolean encoded = (rawQuery != null && rawQuery.contains("%"))
-				|| (uri.getRawPath() != null && uri.getRawPath().contains("%"));
-
-		// Verify if it is really fully encoded. Treat partial encoded as unencoded.
-		if (encoded) {
-			try {
-				UriComponentsBuilder.fromUri(uri).replaceQueryParams(params).build(true);
-				return true;
-			}
-			catch (IllegalArgumentException ignored) {
-				if (log.isTraceEnabled()) {
-					log.trace("Error in containsEncodedParts", ignored);
-				}
-			}
-
-			return false;
-		}
-
-		return false;
 	}
 
 	public interface URIResolver extends Function<ServerRequest, URI> {

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/ServerMvcIntegrationTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/ServerMvcIntegrationTests.java
@@ -700,6 +700,19 @@ public class ServerMvcIntegrationTests {
 	}
 
 	@Test
+	public void encodedPlusSignInQueryParamWorks() {
+		URI uri = URI.create("/get?myparam=123%2b456");
+		restClient.get().uri(uri).exchange().expectStatus().isOk().expectBody(Map.class)
+				.consumeWith(result -> {
+					Map responseBody = result.getResponseBody();
+					assertThat(responseBody).containsKey("args");
+					Map args = getMap(responseBody, "args");
+					assertThat(args).containsKey("myparam");
+					assertThat(args.get("myparam")).isEqualTo("123+456");
+				});
+	}
+
+	@Test
 	public void clientResponseBodyAttributeWorks() {
 		restClient.get().uri("/anything/readresponsebody").header("X-Foo", "fooval").exchange().expectStatus().isOk()
 				.expectBody(Map.class).consumeWith(res -> {


### PR DESCRIPTION
This change keeps encoded + sign intact in query parameters. Otherwise the plus sign gets decoded and is then interpreted as space character.