### PR TITLE
Added support for streaming response modification

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/FluxRewriteFunction.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/FluxRewriteFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.rewrite;
+
+import java.util.function.BiFunction;
+
+import reactor.core.publisher.Flux;
+
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * This interface is BETA and may be subject to change in a future release.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <R> the type of element signaled by the {@link Flux}
+ */
+public interface FluxRewriteFunction<T, R> extends BiFunction<ServerWebExchange, Flux<T>, Flux<R>> {
+
+}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/MonoRewriteFunction.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/MonoRewriteFunction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.rewrite;
+
+import java.util.function.BiFunction;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.web.server.ServerWebExchange;
+
+
+/**
+ * This interface is BETA and may be subject to change in a future release.
+ *
+ * @param <T> the type of the first argument to the function
+ * @param <R> the type of element signaled by the {@link Mono}
+ */
+public interface MonoRewriteFunction<T, R> extends BiFunction<ServerWebExchange, Mono<T>, Mono<R>> {
+
+}


### PR DESCRIPTION
### Description

This issue has been open for almost 3 years now, multiple PRs have been raised and been rejected / closed. This PR another attempt to fix this issue.
Spring cloud gateway ModifyResponse filter blocks the calls in case of streaming responses.

- https://github.com/spring-cloud/spring-cloud-gateway/issues/2775
- https://github.com/spring-cloud/spring-cloud-gateway/issues/2275

Fixes gh-2275

### FIx

- The fix introduces separate rewrite function to for modification of streaming and non streaming responses.
- To keep the changes backwards compatible the old rewrite function has not been removed and has been marked as deprecated

