### PR TITLE
Use getPath instead of getRawPath to prevent doulbe encoding of the URI

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
@@ -327,7 +327,7 @@ public abstract class BeforeFilterFunctions {
 			String path = request.uri().getPath();
 			String newPath = pattern.matcher(path).replaceAll(normalizedReplacement);
 
-			URI rewrittenUri = UriComponentsBuilder.fromUri(request.uri()).replacePath(newPath).build().toUri();
+			URI rewrittenUri = UriComponentsBuilder.fromUri(request.uri()).replacePath(newPath).encode().build().toUri();
 
 			ServerRequest modified = ServerRequest.from(request).uri(rewrittenUri).build();
 

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
@@ -324,7 +324,7 @@ public abstract class BeforeFilterFunctions {
 		Pattern pattern = Pattern.compile(regexp);
 		return request -> {
 			// TODO: original request url
-			String path = request.uri().getRawPath();
+			String path = request.uri().getPath();
 			String newPath = pattern.matcher(path).replaceAll(normalizedReplacement);
 
 			URI rewrittenUri = UriComponentsBuilder.fromUri(request.uri()).replacePath(newPath).build().toUri();

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
@@ -55,4 +55,28 @@ public class BeforeFilterFunctionsTests {
 		assertThat(modified.uri().getRawPath()).isEqualTo("/modified/path/with%20spaces");
 	}
 
+	@Test
+	public void rewritePathWithEnDash() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/get/path/with–en–dashes")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest modified = BeforeFilterFunctions.rewritePath("get", "modified").apply(request);
+
+		assertThat(modified.uri().getRawPath()).isEqualTo("/modified/path/with%E2%80%93en%E2%80%93dashes");
+	}
+
+	@Test
+	public void rewritePathWithEnDashAndSpace() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/get/path/with–en–dashes and spaces")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest modified = BeforeFilterFunctions.rewritePath("get", "modified").apply(request);
+
+		assertThat(modified.uri().getRawPath()).isEqualTo("/modified/path/with%E2%80%93en%E2%80%93dashes%20and%20spaces");
+	}
+
 }

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.server.mvc.filter;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.servlet.function.ServerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jens Mallien
+ */
+public class BeforeFilterFunctionsTests {
+
+	@Test
+	public void rewritePath() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/get")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest modified = BeforeFilterFunctions.rewritePath("get", "modified").apply(request);
+
+		assertThat(modified.uri().getRawPath()).isEqualTo("/modified");
+	}
+
+	@Test
+	public void rewritePathWithSpace() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/get/path/with spaces")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest modified = BeforeFilterFunctions.rewritePath("get", "modified").apply(request);
+
+		assertThat(modified.uri().getRawPath()).isEqualTo("/modified/path/with%20spaces");
+	}
+
+}


### PR DESCRIPTION
Use getPath instead of getRawPath to prevent doulbe encoding of the URI to fix issue #3482.