### PR TITLE
Remove PRAGMA HTTP header from cache

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
@@ -34,6 +34,7 @@ import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCache
 import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties.RequestOptions;
 import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CacheKeyGenerator;
 import org.springframework.cloud.gateway.filter.factory.cache.postprocessor.AfterCacheExchangeMutator;
+import org.springframework.cloud.gateway.filter.factory.cache.postprocessor.RemoveHeadersAfterCacheExchangeMutator;
 import org.springframework.cloud.gateway.filter.factory.cache.postprocessor.SetCacheDirectivesByMaxAgeAfterCacheExchangeMutator;
 import org.springframework.cloud.gateway.filter.factory.cache.postprocessor.SetMaxAgeHeaderAfterCacheExchangeMutator;
 import org.springframework.cloud.gateway.filter.factory.cache.postprocessor.SetResponseHeadersAfterCacheExchangeMutator;
@@ -80,6 +81,7 @@ public class ResponseCacheManager {
 		this.ignoreNoCacheUpdate = isSkipNoCacheUpdateActive(requestOptions);
 		this.afterCacheExchangeMutators = List.of(new SetResponseHeadersAfterCacheExchangeMutator(),
 				new SetStatusCodeAfterCacheExchangeMutator(),
+				new RemoveHeadersAfterCacheExchangeMutator(HttpHeaders.PRAGMA),
 				new SetMaxAgeHeaderAfterCacheExchangeMutator(configuredTimeToLive, Clock.systemDefaultZone(),
 						ignoreNoCacheUpdate),
 				new SetCacheDirectivesByMaxAgeAfterCacheExchangeMutator());

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/postprocessor/RemoveHeadersAfterCacheExchangeMutator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/postprocessor/RemoveHeadersAfterCacheExchangeMutator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache.postprocessor;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.cloud.gateway.filter.factory.cache.CachedResponse;
+import org.springframework.web.server.ServerWebExchange;
+
+/**
+ * Removes one or more HTTP headers from response. Assumes it is run after
+ * {@link SetResponseHeadersAfterCacheExchangeMutator}.
+ *
+ * @author Abel Salgado Romero
+ */
+public class RemoveHeadersAfterCacheExchangeMutator implements AfterCacheExchangeMutator {
+
+	private static final Log LOGGER = LogFactory.getLog(RemoveHeadersAfterCacheExchangeMutator.class);
+
+	private final String[] httpHeader;
+
+	public RemoveHeadersAfterCacheExchangeMutator(String... httpHeaders) {
+		this.httpHeader = httpHeaders;
+	}
+
+	@Override
+	public void accept(ServerWebExchange exchange, CachedResponse cachedResponse) {
+		for (String header : httpHeader) {
+			var previousValue = exchange.getResponse().getHeaders().remove(header);
+			if (previousValue != null) {
+				LOGGER.debug("HTTP Header value found in response, removing HTTP header " + header);
+			}
+		}
+	}
+
+}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
@@ -351,6 +351,25 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 				.jsonPath("$.headers." + CUSTOM_HEADER, "2");
 		}
 
+		@Test
+		void shouldNotReturnPragmaHeaderInNonCachedAndCachedResponses() {
+			String uri = "/" + UUID.randomUUID() + "/cache/headers";
+
+			testClient.get()
+				.uri(uri)
+				.header("Host", "www.localresponsecache.org")
+				.exchange()
+				.expectHeader()
+				.doesNotExist(HttpHeaders.PRAGMA);
+
+			testClient.get()
+				.uri(uri)
+				.header("Host", "www.localresponsecache.org")
+				.exchange()
+				.expectHeader()
+				.doesNotExist(HttpHeaders.PRAGMA);
+		}
+
 		void assertNonVaryHeaderInContent(String uri, String varyHeader, String varyHeaderValue, String nonVaryHeader,
 				String nonVaryHeaderValue, String expectedNonVaryResponse) {
 			testClient.get()

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGlobalFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGlobalFilterTests.java
@@ -30,6 +30,7 @@ import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -121,6 +122,25 @@ public class LocalResponseCacheGlobalFilterTests {
 				.expectBody()
 				.jsonPath("$.headers." + CUSTOM_HEADER)
 				.isEqualTo("1");
+		}
+
+		@Test
+		void shouldNotReturnPragmaHeaderInNonCachedAndCachedResponses() {
+			String uri = "/" + UUID.randomUUID() + "/global-cache/headers";
+
+			testClient.get()
+				.uri(uri)
+				.header("Host", "www.localresponsecache.org")
+				.exchange()
+				.expectHeader()
+				.doesNotExist(HttpHeaders.PRAGMA);
+
+			testClient.get()
+				.uri(uri)
+				.header("Host", "www.localresponsecache.org")
+				.exchange()
+				.expectHeader()
+				.doesNotExist(HttpHeaders.PRAGMA);
 		}
 
 		@EnableAutoConfiguration

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/postprocessor/RemoveHeaderAfterCacheExchangeMutatorTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/postprocessor/RemoveHeaderAfterCacheExchangeMutatorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache.postprocessor;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.gateway.filter.factory.cache.CachedResponse;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.web.server.ServerWebExchange;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpHeaders.CACHE_CONTROL;
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.HttpHeaders.EXPIRES;
+import static org.springframework.http.HttpHeaders.PRAGMA;
+
+/**
+ * @author Abel Salgado Romero
+ */
+class RemoveHeaderAfterCacheExchangeMutatorTest {
+
+	private static final String HTTP_HEADER_TO_REMOVE = "X-To-Remove";
+
+	@Test
+	void onlyHeaderToRemoveFromResponseIsRemoved() {
+		final ServerWebExchange inputExchange = setupExchange(Map.of(HTTP_HEADER_TO_REMOVE, "A-Value"));
+
+		final var mutator = new RemoveHeadersAfterCacheExchangeMutator(HTTP_HEADER_TO_REMOVE);
+		CachedResponse cachedResponse = new CachedResponse.Builder(HttpStatus.OK).build();
+
+		mutator.accept(inputExchange, cachedResponse);
+
+		assertThat(inputExchange.getResponse().getHeaders()).doesNotContainKey(HTTP_HEADER_TO_REMOVE)
+			.containsEntry(CACHE_CONTROL, List.of("max-age=60"))
+			.containsEntry(CONTENT_TYPE, List.of("application/octet-stream"))
+			.hasSize(2);
+	}
+
+	@Test
+	void multipleHeadersToRemoveFromResponseAreRemoved() {
+		final Map<String, String> headers = Map.of(HTTP_HEADER_TO_REMOVE, "A-Value", PRAGMA, "void", EXPIRES, "0");
+		final ServerWebExchange inputExchange = setupExchange(headers);
+
+		final var mutator = new RemoveHeadersAfterCacheExchangeMutator(HTTP_HEADER_TO_REMOVE, PRAGMA, EXPIRES);
+		CachedResponse cachedResponse = new CachedResponse.Builder(HttpStatus.OK).build();
+
+		mutator.accept(inputExchange, cachedResponse);
+
+		assertThat(inputExchange.getResponse().getHeaders()).doesNotContainKey(HTTP_HEADER_TO_REMOVE)
+			.doesNotContainKey(PRAGMA)
+			.doesNotContainKey(EXPIRES)
+			.containsEntry(CACHE_CONTROL, List.of("max-age=60"))
+			.containsEntry(CONTENT_TYPE, List.of("application/octet-stream"))
+			.hasSize(2);
+	}
+
+	@Test
+	void headersAreNotModifiedIfHeaderToRemoveIsEmpty() {
+		final ServerWebExchange inputExchange = setupExchange(Map.of());
+
+		final var mutator = new RemoveHeadersAfterCacheExchangeMutator(HTTP_HEADER_TO_REMOVE);
+		CachedResponse cachedResponse = new CachedResponse.Builder(HttpStatus.OK).build();
+
+		mutator.accept(inputExchange, cachedResponse);
+
+		assertThat(inputExchange.getResponse().getHeaders()).containsEntry(CACHE_CONTROL, List.of("max-age=60"))
+			.containsEntry(CONTENT_TYPE, List.of("application/octet-stream"))
+			.hasSize(2);
+	}
+
+	private ServerWebExchange setupExchange(Map<String, String> headersToAdd) {
+		HttpHeaders responseHeaders = new HttpHeaders();
+		responseHeaders.setCacheControl(CacheControl.maxAge(Duration.ofSeconds(60)));
+		responseHeaders.setContentType(MediaType.APPLICATION_OCTET_STREAM);
+		headersToAdd.forEach((k, v) -> responseHeaders.set(k, v));
+
+		MockServerHttpRequest httpRequest = MockServerHttpRequest.get("https://this").build();
+		MockServerWebExchange inputExchange = MockServerWebExchange.from(httpRequest);
+		MockServerHttpResponse httpResponse = inputExchange.getResponse();
+		httpResponse.setStatusCode(HttpStatus.OK);
+		httpResponse.getHeaders().putAll(responseHeaders);
+
+		return inputExchange;
+	}
+
+}


### PR DESCRIPTION
This header is deprecated and is unnecessary when using 'Cache-Control'. Currently SCG always returns 'Cache-Control' already.

The implementation adds `RemoveHeadersAfterCacheExchangeMutator` which helps remove headers that conflict with Cache features and are not necessary.
This has been implemented also thinking about the other [expire header](https://github.com/spring-cloud/spring-cloud-gateway/issues/3488). Simply adding expire to the same "Mutator" will sufice.

Closes #https://github.com/spring-cloud/spring-cloud-gateway/issues/3487