### PR TITLE
In RedisRateLimiter，when an error occurs in executing a Lua script, the log is printed as eror 

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiter.java
@@ -253,9 +253,7 @@ public class RedisRateLimiter extends AbstractRateLimiter<RedisRateLimiter.Confi
 			Flux<List<Long>> flux = this.redisTemplate.execute(this.script, keys, scriptArgs);
 			// .log("redisratelimiter", Level.FINER);
 			return flux.onErrorResume(throwable -> {
-				if (log.isDebugEnabled()) {
-					log.debug("Error calling rate limiter lua", throwable);
-				}
+				log.error("Error calling rate limiter lua", throwable);
 				return Flux.just(Arrays.asList(1L, -1L));
 			}).reduce(new ArrayList<Long>(), (longs, l) -> {
 				longs.addAll(l);


### PR DESCRIPTION
I think this is a mistake and the error log should be printed, otherwise it will make it difficult to troubleshoot the problem.
I encountered this problem, and if I printed the error log, I could quickly find and solve it