### PR TITLE
Remove EXPIRES HTTP header from cache

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/ResponseCacheManager.java
@@ -81,7 +81,7 @@ public class ResponseCacheManager {
 		this.ignoreNoCacheUpdate = isSkipNoCacheUpdateActive(requestOptions);
 		this.afterCacheExchangeMutators = List.of(new SetResponseHeadersAfterCacheExchangeMutator(),
 				new SetStatusCodeAfterCacheExchangeMutator(),
-				new RemoveHeadersAfterCacheExchangeMutator(HttpHeaders.PRAGMA),
+				new RemoveHeadersAfterCacheExchangeMutator(HttpHeaders.PRAGMA, HttpHeaders.EXPIRES),
 				new SetMaxAgeHeaderAfterCacheExchangeMutator(configuredTimeToLive, Clock.systemDefaultZone(),
 						ignoreNoCacheUpdate),
 				new SetCacheDirectivesByMaxAgeAfterCacheExchangeMutator());

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
@@ -353,6 +353,15 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 
 		@Test
 		void shouldNotReturnPragmaHeaderInNonCachedAndCachedResponses() {
+			shouldNotReturnHeader(HttpHeaders.PRAGMA);
+		}
+
+		@Test
+		void shouldNotReturnExpiresHeaderInNonCachedAndCachedResponses() {
+			shouldNotReturnHeader(HttpHeaders.EXPIRES);
+		}
+
+		private void shouldNotReturnHeader(String header) {
 			String uri = "/" + UUID.randomUUID() + "/cache/headers";
 
 			testClient.get()
@@ -360,14 +369,14 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 				.header("Host", "www.localresponsecache.org")
 				.exchange()
 				.expectHeader()
-				.doesNotExist(HttpHeaders.PRAGMA);
+				.doesNotExist(header);
 
 			testClient.get()
 				.uri(uri)
 				.header("Host", "www.localresponsecache.org")
 				.exchange()
 				.expectHeader()
-				.doesNotExist(HttpHeaders.PRAGMA);
+				.doesNotExist(header);
 		}
 
 		void assertNonVaryHeaderInContent(String uri, String varyHeader, String varyHeaderValue, String nonVaryHeader,

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGlobalFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGlobalFilterTests.java
@@ -126,6 +126,15 @@ public class LocalResponseCacheGlobalFilterTests {
 
 		@Test
 		void shouldNotReturnPragmaHeaderInNonCachedAndCachedResponses() {
+			shouldNotReturnHeader(HttpHeaders.PRAGMA);
+		}
+
+		@Test
+		void shouldNotReturnExpiresHeaderInNonCachedAndCachedResponses() {
+			shouldNotReturnHeader(HttpHeaders.EXPIRES);
+		}
+
+		private void shouldNotReturnHeader(String header) {
 			String uri = "/" + UUID.randomUUID() + "/global-cache/headers";
 
 			testClient.get()
@@ -133,14 +142,14 @@ public class LocalResponseCacheGlobalFilterTests {
 				.header("Host", "www.localresponsecache.org")
 				.exchange()
 				.expectHeader()
-				.doesNotExist(HttpHeaders.PRAGMA);
+				.doesNotExist(header);
 
 			testClient.get()
 				.uri(uri)
 				.header("Host", "www.localresponsecache.org")
 				.exchange()
 				.expectHeader()
-				.doesNotExist(HttpHeaders.PRAGMA);
+				.doesNotExist(header);
 		}
 
 		@EnableAutoConfiguration


### PR DESCRIPTION
This header conflicts and can cause confusion when 'Cache-Control + max-age' are set. And currently SCG always sets 'max-age' in 'Cache-Control' via '[SetMaxAgeHeaderAfterCacheExchangeMutator](https://github.com/spring-cloud/spring-cloud-gateway/blob/3835adc9e2a84f296bf187da1f5ec1dff125a52b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/postprocessor/SetMaxAgeHeaderAfterCacheExchangeMutator.java#L86)'.

Closes https://github.com/spring-cloud/spring-cloud-gateway/issues/3488