### PR TITLE
Add a note about retry filter behavior in documentation

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-mvc/filters/retry.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-mvc/filters/retry.adoc
@@ -69,6 +69,8 @@ NOTE: When using the retry filter with a `forward:` prefixed URL, the target end
 For example, if the target endpoint is an annotated controller, the target controller method should not return `ResponseEntity` with an error status code.
 Instead, it should throw an `Exception` or signal an error (for example, through a `Mono.error(ex)` return value), which the retry filter can be configured to handle by retrying.
 
+NOTE: When using the retry filter, it will retry all filters that come after it. Make sure the results of the filters following the retry filter are as expected when they are executed multiple times.
+
 // WARNING: When using the retry filter with any HTTP method with a body, the body will be cached and the gateway will become memory constrained. The body is cached in a request attribute defined by `ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR`. The type of the object is `org.springframework.core.io.buffer.DataBuffer`.
 
 A simplified "shortcut" notation can be added with a single `status` and `method`.

--- a/docs/modules/ROOT/pages/spring-cloud-gateway/gatewayfilter-factories/retry-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway/gatewayfilter-factories/retry-factory.adoc
@@ -51,6 +51,8 @@ NOTE: When using the retry filter with a `forward:` prefixed URL, the target end
 For example, if the target endpoint is an annotated controller, the target controller method should not return `ResponseEntity` with an error status code.
 Instead, it should throw an `Exception` or signal an error (for example, through a `Mono.error(ex)` return value), which the retry filter can be configured to handle by retrying.
 
+NOTE: When using the retry filter, it will retry all filters that come after it. Make sure the results of the filters following the retry filter are as expected when they are executed multiple times.
+
 WARNING: When using the retry filter with any HTTP method with a body, the body will be cached and the gateway will become memory constrained. The body is cached in a request attribute defined by `ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR`. The type of the object is `org.springframework.core.io.buffer.DataBuffer`.
 
 A simplified "shortcut" notation can be added with a single `status` and `method`.

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -38,8 +38,6 @@ import reactor.retry.RetryContext;
 import org.springframework.cloud.gateway.event.EnableBodyCachingEvent;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
-import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
-import org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter;
 import org.springframework.cloud.gateway.support.HasRouteId;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.cloud.gateway.support.TimeoutException;
@@ -168,7 +166,7 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 		}
 
 		GatewayFilter gatewayFilter = apply(retryConfig.getRouteId(), statusCodeRepeat, exceptionRetry);
-		GatewayFilter retryGatewayFilter = new GatewayFilter() {
+		return new GatewayFilter() {
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 				return gatewayFilter.filter(exchange, chain);
@@ -185,8 +183,6 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 					.toString();
 			}
 		};
-		return new OrderedGatewayFilter(retryGatewayFilter,
-				ReactiveLoadBalancerClientFilter.LOAD_BALANCER_CLIENT_FILTER_ORDER - 1);
 	}
 
 	private String getExceptionNameWithCause(Throwable exception) {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -38,6 +38,8 @@ import reactor.retry.RetryContext;
 import org.springframework.cloud.gateway.event.EnableBodyCachingEvent;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.OrderedGatewayFilter;
+import org.springframework.cloud.gateway.filter.ReactiveLoadBalancerClientFilter;
 import org.springframework.cloud.gateway.support.HasRouteId;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.cloud.gateway.support.TimeoutException;
@@ -166,7 +168,7 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 		}
 
 		GatewayFilter gatewayFilter = apply(retryConfig.getRouteId(), statusCodeRepeat, exceptionRetry);
-		return new GatewayFilter() {
+		GatewayFilter retryGatewayFilter = new GatewayFilter() {
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 				return gatewayFilter.filter(exchange, chain);
@@ -183,6 +185,8 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 					.toString();
 			}
 		};
+		return new OrderedGatewayFilter(retryGatewayFilter,
+				ReactiveLoadBalancerClientFilter.LOAD_BALANCER_CLIENT_FILTER_ORDER - 1);
 	}
 
 	private String getExceptionNameWithCause(Throwable exception) {


### PR DESCRIPTION
Currently, the priority of the GatewayFilter returned by RetryGatewayFilterFactory is not explicitly specified, which may lead to idempotency issues when used with other AbstractGatewayFilterFactory. For example, when AddRequestHeaderGatewayFilterFactory is configured after RetryGatewayFilterFactory, there may be issues with adding headers multiple times after a retry.
Perhaps it would be more appropriate for RetryGatewayFilterFactory to retry the ReactiveLoadBalancerClientFilter and the filters that follow. What do you think?