### PR TITLE
Adds a missing Shortcut annotation to dedupeResponseHeader

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/FilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/FilterFunctions.java
@@ -66,6 +66,7 @@ public interface FilterFunctions {
 		return ofResponseProcessor(AfterFilterFunctions.addResponseHeader(name, values));
 	}
 
+	@Shortcut
 	static HandlerFilterFunction<ServerResponse, ServerResponse> dedupeResponseHeader(String name) {
 		return ofResponseProcessor(AfterFilterFunctions.dedupeResponseHeader(name));
 	}


### PR DESCRIPTION
While the other flavor of the method is working (with second parameter), the variant with only one String is not working because of the missing annotation (fixes #3538).