### PR TITLE
Enable body caching in CircuitBreakerFilterFactory

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -224,7 +224,7 @@ Spring Cloud Build brings along the  `basepom:duplicate-finder-maven-plugin`, th
 [[duplicate-finder-configuration]]
 === Duplicate Finder configuration
 
-Duplicate finder is *enabled by default* and will run in the `verify` phase of your Maven build, but it will only take effect in your project if you add the `duplicate-finder-maven-plugin` to the `build` section of the projecst's `pom.xml`.
+Duplicate finder is *enabled by default* and will run in the `verify` phase of your Maven build, but it will only take effect in your project if you add the `duplicate-finder-maven-plugin` to the `build` section of the project's `pom.xml`.
 
 .pom.xml
 [source,xml]

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/AbstractGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/AbstractGatewayFilterFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import org.springframework.cloud.gateway.event.EnableBodyCachingEvent;
 import org.springframework.cloud.gateway.support.AbstractConfigurable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
@@ -41,6 +42,13 @@ public abstract class AbstractGatewayFilterFactory<C> extends AbstractConfigurab
 
 	protected ApplicationEventPublisher getPublisher() {
 		return this.publisher;
+	}
+
+	protected void enableBodyCaching(String routeId) {
+		if (routeId != null && getPublisher() != null) {
+			// send an event to enable caching
+			getPublisher().publishEvent(new EnableBodyCachingEvent(this, routeId));
+		}
 	}
 
 	@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RetryGatewayFilterFactory.java
@@ -35,7 +35,6 @@ import reactor.retry.RepeatContext;
 import reactor.retry.Retry;
 import reactor.retry.RetryContext;
 
-import org.springframework.cloud.gateway.event.EnableBodyCachingEvent;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.support.HasRouteId;
@@ -229,10 +228,7 @@ public class RetryGatewayFilterFactory extends AbstractGatewayFilterFactory<Retr
 	}
 
 	public GatewayFilter apply(String routeId, Repeat<ServerWebExchange> repeat, Retry<ServerWebExchange> retry) {
-		if (routeId != null && getPublisher() != null) {
-			// send an event to enable caching
-			getPublisher().publishEvent(new EnableBodyCachingEvent(this, routeId));
-		}
+		enableBodyCaching(routeId);
 		return (exchange, chain) -> {
 			trace("Entering retry-filter");
 

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
@@ -89,6 +89,7 @@ public abstract class SpringCloudCircuitBreakerFilterFactory
 
 	@Override
 	public GatewayFilter apply(Config config) {
+		enableBodyCaching(config.getRouteId());
 		ReactiveCircuitBreaker cb = reactiveCircuitBreakerFactory.create(config.getId());
 		Set<HttpStatus> statuses = config.getStatusCodes()
 			.stream()

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactory.java
@@ -89,7 +89,9 @@ public abstract class SpringCloudCircuitBreakerFilterFactory
 
 	@Override
 	public GatewayFilter apply(Config config) {
-		enableBodyCaching(config.getRouteId());
+		if (config.getFallbackUri() != null) {
+			enableBodyCaching(config.getRouteId());
+		}
 		ReactiveCircuitBreaker cb = reactiveCircuitBreakerFactory.create(config.getId());
 		Set<HttpStatus> statuses = config.getStatusCodes()
 			.stream()

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerFilterFactoryTests.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.BodyInserters;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
@@ -241,6 +242,13 @@ public abstract class SpringCloudCircuitBreakerFilterFactoryTests extends BaseWe
 			.isOk()
 			.expectHeader()
 			.valueEquals(ROUTE_ID_HEADER, "circuitbreaker_resume_without_error");
+	}
+
+	@Test
+	public void filterPostFallback() {
+		testClient.post().uri("/post").body(BodyInserters.fromValue("hello"))
+				.header("Host", "www.circuitbreakerfallbackpost.org").exchange().expectStatus()
+				.isOk().expectBody().json("{\"body\":\"hello\"}");
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/SpringCloudCircuitBreakerTestConfig.java
@@ -38,6 +38,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -66,6 +68,11 @@ public class SpringCloudCircuitBreakerTestConfig {
 	@GetMapping("/circuitbreakerFallbackController")
 	public Map<String, String> fallbackcontroller(@RequestParam("a") String a) {
 		return Collections.singletonMap("from", "circuitbreakerfallbackcontroller");
+	}
+
+	@PostMapping("/circuitbreakerPostFallbackController")
+	public Map<String, String> postFallbackController(@RequestBody String body) {
+		return Collections.singletonMap("body", body);
 	}
 
 	@GetMapping("/circuitbreakerUriFallbackController/**")

--- a/spring-cloud-gateway-server/src/test/resources/application.yml
+++ b/spring-cloud-gateway-server/src/test/resources/application.yml
@@ -105,6 +105,19 @@ spring:
               fallbackUri: forward:/circuitbreakerFallbackController
 
         # =====================================
+      - id: circuitbreaker_fallback_test_post
+        uri: ${test.uri}
+        predicates:
+          - Host=**.circuitbreakerfallbackpost.org
+        filters:
+          - name: CircuitBreaker
+            args:
+              name: fallbackcmd
+              statusCodes:
+                - 200
+              fallbackUri: forward:/circuitbreakerPostFallbackController
+
+        # =====================================
       - id: circuitbreaker_fallback_test_variables
         uri: ${test.uri}
         predicates:


### PR DESCRIPTION
When using the CircuitBreaker GatewayFilter, if a fallbackUri is set, the request with a body may fail to forward to the fallback due to the lack of body caching.