### PR TITLE
Fix the ClassCastException when CacheRequestBodyFilter is used with CircuitBreakerFilter.

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
@@ -67,10 +67,10 @@ public class CacheRequestBodyGatewayFilterFactory
 				}
 
 				return ServerWebExchangeUtils.cacheRequestBodyObject(exchange, config.getBodyClass(), messageReaders,
-						(serverHttpRequest, cachedBody) -> {
-							exchange.getAttributes().remove(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
-							return chain.filter(exchange.mutate().request(serverHttpRequest).build());
-						});
+					(serverHttpRequest, cachedBody) -> {
+						exchange.getAttributes().remove(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
+						return chain.filter(exchange.mutate().request(serverHttpRequest).build());
+					});
 			}
 
 			@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactory.java
@@ -24,13 +24,9 @@ import reactor.core.publisher.Mono;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.http.server.reactive.ServerHttpRequest;
-import org.springframework.util.Assert;
 import org.springframework.web.reactive.function.server.HandlerStrategies;
-import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
@@ -70,36 +66,11 @@ public class CacheRequestBodyGatewayFilterFactory
 					return chain.filter(exchange);
 				}
 
-				Object cachedBody = exchange.getAttribute(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR);
-				if (cachedBody != null) {
-					return chain.filter(exchange);
-				}
-
-				return ServerWebExchangeUtils.cacheRequestBodyAndRequest(exchange, (serverHttpRequest) -> {
-					final ServerRequest serverRequest = ServerRequest
-						.create(exchange.mutate().request(serverHttpRequest).build(), messageReaders);
-					return serverRequest.bodyToMono((config.getBodyClass())).doOnNext(objectValue -> {
-						Object previousCachedBody = exchange.getAttributes()
-							.put(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR, objectValue);
-						if (previousCachedBody != null) {
-							// store previous cached body
-							exchange.getAttributes().put(CACHED_ORIGINAL_REQUEST_BODY_BACKUP_ATTR, previousCachedBody);
-						}
-					}).then(Mono.defer(() -> {
-						ServerHttpRequest cachedRequest = exchange
-							.getAttribute(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
-						Assert.notNull(cachedRequest, "cache request shouldn't be null");
-						exchange.getAttributes().remove(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
-						return chain.filter(exchange.mutate().request(cachedRequest).build()).doFinally(s -> {
-							//
-							Object backupCachedBody = exchange.getAttributes()
-								.get(CACHED_ORIGINAL_REQUEST_BODY_BACKUP_ATTR);
-							if (backupCachedBody instanceof DataBuffer dataBuffer) {
-								DataBufferUtils.release(dataBuffer);
-							}
+				return ServerWebExchangeUtils.cacheRequestBodyObject(exchange, config.getBodyClass(), messageReaders,
+						(serverHttpRequest, cachedBody) -> {
+							exchange.getAttributes().remove(CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR);
+							return chain.filter(exchange.mutate().request(serverHttpRequest).build());
 						});
-					}));
-				});
 			}
 
 			@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
@@ -83,7 +83,7 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 				}
 
 				return ServerWebExchangeUtils.cacheRequestBodyObject(exchange, config.getInClass(), messageReaders,
-						(serverHttpRequest, bodyObject) -> Mono.just(config.predicate.test(bodyObject)));
+					(serverHttpRequest, bodyObject) -> Mono.just(config.predicate.test(bodyObject)));
 			}
 
 			@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
@@ -29,7 +29,6 @@ import org.springframework.cloud.gateway.handler.AsyncPredicate;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.http.codec.HttpMessageReader;
 import org.springframework.web.reactive.function.server.HandlerStrategies;
-import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -42,8 +41,6 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 	protected static final Log log = LogFactory.getLog(ReadBodyRoutePredicateFactory.class);
 
 	private static final String TEST_ATTRIBUTE = "read_body_predicate_test_attribute";
-
-	private static final String CACHE_REQUEST_BODY_OBJECT_KEY = "cachedRequestBodyObject";
 
 	private final List<HttpMessageReader<?>> messageReaders;
 
@@ -63,10 +60,7 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 		return new AsyncPredicate<ServerWebExchange>() {
 			@Override
 			public Publisher<Boolean> apply(ServerWebExchange exchange) {
-				Class inClass = config.getInClass();
-
-				Object cachedBody = exchange.getAttribute(CACHE_REQUEST_BODY_OBJECT_KEY);
-				Mono<?> modifiedBody;
+				Object cachedBody = exchange.getAttribute(ServerWebExchangeUtils.CACHE_REQUEST_BODY_OBJECT_KEY);
 				// We can only read the body from the request once, once that happens if
 				// we try to read the body again an exception will be thrown. The below
 				// if/else caches the body object as a request attribute in the
@@ -87,15 +81,9 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 					}
 					return Mono.just(false);
 				}
-				else {
-					return ServerWebExchangeUtils.cacheRequestBodyAndRequest(exchange,
-							(serverHttpRequest) -> ServerRequest
-								.create(exchange.mutate().request(serverHttpRequest).build(), messageReaders)
-								.bodyToMono(inClass)
-								.doOnNext(objectValue -> exchange.getAttributes()
-									.put(CACHE_REQUEST_BODY_OBJECT_KEY, objectValue))
-								.map(objectValue -> config.getPredicate().test(objectValue)));
-				}
+
+				return ServerWebExchangeUtils.cacheRequestBodyObject(exchange, config.getInClass(), messageReaders,
+						(serverHttpRequest, bodyObject) -> Mono.just(config.predicate.test(bodyObject)));
 			}
 
 			@Override

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -342,9 +342,9 @@ public final class ServerWebExchangeUtils {
 	public static <C, T> Mono<T> cacheRequestBodyObject(ServerWebExchange exchange, Class<C> bodyClass,
 			List<HttpMessageReader<?>> messageReaders, BiFunction<ServerHttpRequest, C, Mono<T>> function) {
 		return cacheRequestBodyAndRequest(exchange, (serverHttpRequest) -> ServerRequest
-				.create(exchange.mutate().request(serverHttpRequest).build(), messageReaders).bodyToMono(bodyClass)
-				.doOnNext(objectValue -> exchange.getAttributes().put(CACHE_REQUEST_BODY_OBJECT_KEY, objectValue))
-				.flatMap(cachedBody -> function.apply(serverHttpRequest, cachedBody)));
+			.create(exchange.mutate().request(serverHttpRequest).build(), messageReaders).bodyToMono(bodyClass)
+			.doOnNext(objectValue -> exchange.getAttributes().put(CACHE_REQUEST_BODY_OBJECT_KEY, objectValue))
+			.flatMap(cachedBody -> function.apply(serverHttpRequest, cachedBody)));
 	}
 
 	/**

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -20,14 +20,18 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
 import io.netty.buffer.Unpooled;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.http.codec.HttpMessageReader;
+import org.springframework.web.reactive.function.server.ServerRequest;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -174,6 +178,12 @@ public final class ServerWebExchangeUtils {
 	public static final String CACHED_REQUEST_BODY_ATTR = "cachedRequestBody";
 
 	/**
+	 * Cached request decoded body object key. Used when
+	 * {@link #cacheRequestBodyObject(ServerWebExchange, Class, List, BiFunction)}
+	 */
+	public static final String CACHE_REQUEST_BODY_OBJECT_KEY = "cachedRequestBodyObject";
+
+	/**
 	 * Gateway LoadBalancer {@link Response} attribute name.
 	 */
 	public static final String GATEWAY_LOADBALANCER_RESPONSE_ATTR = qualify("gatewayLoadBalancerResponse");
@@ -313,6 +323,28 @@ public final class ServerWebExchangeUtils {
 
 	public static Map<String, String> getUriTemplateVariables(ServerWebExchange exchange) {
 		return exchange.getAttributeOrDefault(URI_TEMPLATE_VARIABLES_ATTRIBUTE, new HashMap<>());
+	}
+
+	/**
+	 * Caches the request body, the decoded body object and the created {@link ServerHttpRequestDecorator} in
+	 * ServerWebExchange attributes. Those attributes are
+	 * {@link #CACHE_REQUEST_BODY_OBJECT_KEY} and
+	 * {@link #CACHED_REQUEST_BODY_ATTR} and
+	 * {@link #CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR} respectively.
+	 * @param exchange the available ServerWebExchange.
+	 * @param bodyClass the class of the body to be decoded
+	 * @param messageReaders the list of message readers for decoding the body.
+	 * @param function a function to apply on the decoded body and request.
+	 * @param <C> the class type of the decoded body.
+	 * @param <T> generic type for the return {@link Mono}.
+	 * @return Mono of type T created by the function parameter.
+	 */
+	public static <C, T> Mono<T> cacheRequestBodyObject(ServerWebExchange exchange, Class<C> bodyClass,
+			List<HttpMessageReader<?>> messageReaders, BiFunction<ServerHttpRequest, C, Mono<T>> function) {
+		return cacheRequestBodyAndRequest(exchange, (serverHttpRequest) -> ServerRequest
+				.create(exchange.mutate().request(serverHttpRequest).build(), messageReaders).bodyToMono(bodyClass)
+				.doOnNext(objectValue -> exchange.getAttributes().put(CACHE_REQUEST_BODY_OBJECT_KEY, objectValue))
+				.flatMap(cachedBody -> function.apply(serverHttpRequest, cachedBody)));
 	}
 
 	/**

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/support/ServerWebExchangeUtils.java
@@ -328,8 +328,8 @@ public final class ServerWebExchangeUtils {
 	/**
 	 * Caches the request body, the decoded body object and the created {@link ServerHttpRequestDecorator} in
 	 * ServerWebExchange attributes. Those attributes are
-	 * {@link #CACHE_REQUEST_BODY_OBJECT_KEY} and
 	 * {@link #CACHED_REQUEST_BODY_ATTR} and
+	 * {@link #CACHE_REQUEST_BODY_OBJECT_KEY} and
 	 * {@link #CACHED_SERVER_HTTP_REQUEST_DECORATOR_ATTR} respectively.
 	 * @param exchange the available ServerWebExchange.
 	 * @param bodyClass the class of the body to be decoded

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory;
 
+import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -119,6 +120,19 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 	}
 
 	@Test
+	public void cacheRequestBodyWithCircuitBreaker() {
+		testClient.post().uri("/post").header("Host", "www.cacherequestbodywithcircuitbreaker.org")
+				.bodyValue(BODY_VALUE).exchange().expectStatus().isOk().expectBody(Map.class)
+				.consumeWith(result -> {
+					Map<?, ?> response = result.getResponseBody();
+					assertThat(response).isNotNull();
+
+					String responseBody = (String) response.get("data");
+					assertThat(responseBody).isEqualTo(BODY_VALUE);
+				});
+	}
+
+	@Test
 	public void toStringFormat() {
 		CacheRequestBodyGatewayFilterFactory.Config config = new CacheRequestBodyGatewayFilterFactory.Config();
 		config.setBodyClass(String.class);
@@ -163,7 +177,19 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 								.cacheRequestBody(String.class)
 								.filter(new AssertCachedRequestBodyGatewayFilter(BODY_CACHED_EXISTS)))
 							.uri(uri))
-				.build();
+				.route("cache_request_body_with_circuitbreaker_test",
+						r -> r.path("/post")
+               .and()
+               .host("**.cacherequestbodywithcircuitbreaker.org")
+               .filters(f -> f.setHostHeader("www.cacherequestbody.org")
+								 .prefixPath("/httpbin")
+								 .cacheRequestBody(String.class)
+								 .filter(new AssertCachedRequestBodyGatewayFilter(BODY_VALUE))
+								 .filter(new CheckCachedRequestBodyReleasedGatewayFilter())
+								 .circuitBreaker(config -> config.setStatusCodes(Collections.singleton("200"))
+                   .setFallbackUri("/post")))
+						  .uri(uri))
+					.build();
 		}
 
 	}
@@ -181,7 +207,7 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 
 		@Override
 		public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-			String body = exchange.getAttribute(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR);
+			String body = exchange.getAttribute(ServerWebExchangeUtils.CACHE_REQUEST_BODY_OBJECT_KEY);
 			if (exceptNullBody) {
 				assertThat(body).isNull();
 			}
@@ -203,7 +229,7 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 
 		@Override
 		public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
-			exchange.getAttributes().put(ServerWebExchangeUtils.CACHED_REQUEST_BODY_ATTR, bodyToSetCache);
+			exchange.getAttributes().put(ServerWebExchangeUtils.CACHE_REQUEST_BODY_OBJECT_KEY, bodyToSetCache);
 			return chain.filter(exchange);
 		}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/CacheRequestBodyGatewayFilterFactoryTests.java
@@ -122,14 +122,14 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 	@Test
 	public void cacheRequestBodyWithCircuitBreaker() {
 		testClient.post().uri("/post").header("Host", "www.cacherequestbodywithcircuitbreaker.org")
-				.bodyValue(BODY_VALUE).exchange().expectStatus().isOk().expectBody(Map.class)
-				.consumeWith(result -> {
-					Map<?, ?> response = result.getResponseBody();
-					assertThat(response).isNotNull();
+			.bodyValue(BODY_VALUE).exchange().expectStatus().isOk().expectBody(Map.class)
+			.consumeWith(result -> {
+				Map<?, ?> response = result.getResponseBody();
+				assertThat(response).isNotNull();
 
-					String responseBody = (String) response.get("data");
-					assertThat(responseBody).isEqualTo(BODY_VALUE);
-				});
+				String responseBody = (String) response.get("data");
+				assertThat(responseBody).isEqualTo(BODY_VALUE);
+			});
 	}
 
 	@Test
@@ -179,17 +179,17 @@ public class CacheRequestBodyGatewayFilterFactoryTests extends BaseWebClientTest
 							.uri(uri))
 				.route("cache_request_body_with_circuitbreaker_test",
 						r -> r.path("/post")
-               .and()
-               .host("**.cacherequestbodywithcircuitbreaker.org")
-               .filters(f -> f.setHostHeader("www.cacherequestbody.org")
-								 .prefixPath("/httpbin")
-								 .cacheRequestBody(String.class)
-								 .filter(new AssertCachedRequestBodyGatewayFilter(BODY_VALUE))
-								 .filter(new CheckCachedRequestBodyReleasedGatewayFilter())
-								 .circuitBreaker(config -> config.setStatusCodes(Collections.singleton("200"))
-                   .setFallbackUri("/post")))
-						  .uri(uri))
-					.build();
+							 .and()
+							 .host("**.cacherequestbodywithcircuitbreaker.org")
+							 .filters(f -> f.setHostHeader("www.cacherequestbody.org")
+							 	.prefixPath("/httpbin")
+							 	.cacheRequestBody(String.class)
+							 	.filter(new AssertCachedRequestBodyGatewayFilter(BODY_VALUE))
+							 	.filter(new CheckCachedRequestBodyReleasedGatewayFilter())
+							 	.circuitBreaker(config -> config.setStatusCodes(Collections.singleton("200"))
+							 		.setFallbackUri("/post")))
+							 .uri(uri))
+				.build();
 		}
 
 	}


### PR DESCRIPTION
Currently, the `CacheRequestBodyFilter` overrides the `CACHED_REQUEST_BODY_ATTR` attribute with the decoded object. If the `fallbackUri` of the CircuitBreaker is routed to another route, passing through the `AdaptCachedBodyGlobalFilter` triggers a ClassCastException(see unit test). The `CacheRequestBodyFilter` behaves similarly to a `ReadBodyRoutePredicateFactory` without a predicate. The current modification places the decoded body into CACHE_REQUEST_BODY_OBJECT_KEY to distinguish the responsibilities.