### PR TITLE
Add adaptCachedBody function by default to each route in Gateway MVC.

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouterFunctionHolderFactory.java
@@ -154,6 +154,7 @@ public class RouterFunctionHolderFactory {
 			return next.handle(request);
 		});
 		builder.before(BeforeFilterFunctions.routeId(routeId));
+		builder.before(BeforeFilterFunctions.adaptCachedBody());
 
 		MultiValueMap<String, OperationMethod> handlerOperations = handlerDiscoverer.getOperations();
 		// TODO: cache?

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/GatewayRouterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/GatewayRouterFunctions.java
@@ -23,6 +23,7 @@ import org.springframework.web.servlet.function.RouterFunctions;
 import org.springframework.web.servlet.function.RouterFunctions.Builder;
 import org.springframework.web.servlet.function.ServerResponse;
 
+import static org.springframework.cloud.gateway.server.mvc.filter.BeforeFilterFunctions.adaptCachedBody;
 import static org.springframework.cloud.gateway.server.mvc.filter.BeforeFilterFunctions.routeId;
 
 public abstract class GatewayRouterFunctions {
@@ -35,7 +36,7 @@ public abstract class GatewayRouterFunctions {
 	}
 
 	public static Builder route(String routeId) {
-		Builder builder = RouterFunctions.route().before(routeId(routeId));
+		Builder builder = RouterFunctions.route().before(routeId(routeId)).before(adaptCachedBody());
 		return new GatewayRouterFunctionsBuilder(builder, routeId);
 	}
 


### PR DESCRIPTION
In Gateway MVC, when using the `readBody` predicate, it is necessary to manually add the `adaptCachedBody` function. The current modification adds `adaptCachedBody` by default to each route.