### PR TITLE
Restoring predicate consistency by removing 'Validated' and adding 'Notnull'.

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactory.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -65,6 +66,7 @@ public class BeforeRoutePredicateFactory extends AbstractRoutePredicateFactory<B
 
 	public static class Config {
 
+		@NotNull
 		private ZonedDateTime datetime;
 
 		public ZonedDateTime getDatetime() {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactory.java
@@ -24,7 +24,6 @@ import java.util.function.Predicate;
 import jakarta.validation.constraints.NotNull;
 
 import org.springframework.util.Assert;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -75,7 +74,6 @@ public class BetweenRoutePredicateFactory extends AbstractRoutePredicateFactory<
 		};
 	}
 
-	@Validated
 	public static class Config {
 
 		@NotNull

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactory.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 import jakarta.validation.constraints.NotEmpty;
 
 import org.springframework.http.HttpCookie;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -79,7 +78,6 @@ public class CookieRoutePredicateFactory extends AbstractRoutePredicateFactory<C
 		};
 	}
 
-	@Validated
 	public static class Config {
 
 		@NotEmpty

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactory.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 import jakarta.validation.constraints.NotEmpty;
 
 import org.springframework.util.StringUtils;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -90,7 +89,6 @@ public class HeaderRoutePredicateFactory extends AbstractRoutePredicateFactory<H
 		};
 	}
 
-	@Validated
 	public static class Config {
 
 		@NotEmpty

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/HostRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/HostRoutePredicateFactory.java
@@ -27,7 +27,6 @@ import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.PathMatcher;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -115,7 +114,6 @@ public class HostRoutePredicateFactory extends AbstractRoutePredicateFactory<Hos
 		};
 	}
 
-	@Validated
 	public static class Config {
 
 		private List<String> patterns = new ArrayList<>();

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactory.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.function.Predicate;
 
 import org.springframework.http.HttpMethod;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
 import static java.util.Arrays.stream;
@@ -67,7 +66,6 @@ public class MethodRoutePredicateFactory extends AbstractRoutePredicateFactory<M
 		};
 	}
 
-	@Validated
 	public static class Config {
 
 		private HttpMethod[] methods;

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
@@ -26,7 +26,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.http.server.PathContainer;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.pattern.PathPattern;
 import org.springframework.web.util.pattern.PathPattern.PathMatchInfo;
@@ -134,7 +133,6 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 		};
 	}
 
-	@Validated
 	public static class Config {
 
 		private List<String> patterns = new ArrayList<>();

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/QueryRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/QueryRoutePredicateFactory.java
@@ -23,7 +23,6 @@ import java.util.function.Predicate;
 import jakarta.validation.constraints.NotEmpty;
 
 import org.springframework.util.StringUtils;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
 /**
@@ -84,7 +83,6 @@ public class QueryRoutePredicateFactory extends AbstractRoutePredicateFactory<Qu
 		};
 	}
 
-	@Validated
 	public static class Config {
 
 		@NotEmpty

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactory.java
@@ -31,7 +31,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.cloud.gateway.support.ipresolver.RemoteAddressResolver;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.ShortcutConfigurable.ShortcutType.GATHER_LIST;
@@ -117,7 +116,6 @@ public class RemoteAddrRoutePredicateFactory
 		sources.add(new IpSubnetFilterRule(ipAddress, cidrPrefix, IpFilterRuleType.ACCEPT));
 	}
 
-	@Validated
 	public static class Config {
 
 		@NotEmpty

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/AfterRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/AfterRoutePredicateFactoryTests.java
@@ -18,8 +18,13 @@ package org.springframework.cloud.gateway.handler.predicate;
 
 import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.function.Predicate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.gateway.handler.predicate.AfterRoutePredicateFactory.Config;
@@ -97,6 +102,31 @@ public class AfterRoutePredicateFactoryTests {
 		config.setDatetime(ZonedDateTime.now());
 		Predicate predicate = new AfterRoutePredicateFactory().apply(config);
 		assertThat(predicate.toString()).contains("After: " + config.getDatetime());
+	}
+
+	@Test
+	public void testConfig() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			config.setDatetime(ZonedDateTime.now());
+
+			assertThat(validator.validate(config).isEmpty()).isTrue();
+		}
+	}
+
+	@Test
+	public void testConfigNullField() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			Set<ConstraintViolation<Config>> validate = validator.validate(config);
+
+			assertThat(validate.isEmpty()).isFalse();
+			assertThat(validate.size()).isEqualTo(1);
+		}
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/BeforeRoutePredicateFactoryTests.java
@@ -18,9 +18,16 @@ package org.springframework.cloud.gateway.handler.predicate;
 
 import java.time.ZonedDateTime;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.function.Predicate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.gateway.handler.predicate.BeforeRoutePredicateFactory.Config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.cloud.gateway.handler.predicate.BeforeRoutePredicateFactory.DATETIME_KEY;
@@ -85,17 +92,42 @@ public class BeforeRoutePredicateFactoryTests {
 
 		BeforeRoutePredicateFactory factory = new BeforeRoutePredicateFactory();
 
-		BeforeRoutePredicateFactory.Config config = bindConfig(map, factory);
+		Config config = bindConfig(map, factory);
 
 		return factory.apply(config).test(getExchange());
 	}
 
 	@Test
 	public void toStringFormat() {
-		BeforeRoutePredicateFactory.Config config = new BeforeRoutePredicateFactory.Config();
+		Config config = new Config();
 		config.setDatetime(ZonedDateTime.now());
 		Predicate predicate = new BeforeRoutePredicateFactory().apply(config);
 		assertThat(predicate.toString()).contains("Before: " + config.getDatetime());
+	}
+
+	@Test
+	public void testConfig() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			config.setDatetime(ZonedDateTime.now());
+
+			assertThat(validator.validate(config).isEmpty()).isTrue();
+		}
+	}
+
+	@Test
+	public void testConfigNullField() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			Set<ConstraintViolation<Config>> validate = validator.validate(config);
+
+			assertThat(validate.isEmpty()).isFalse();
+			assertThat(validate.size()).isEqualTo(1);
+		}
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/BetweenRoutePredicateFactoryTests.java
@@ -19,11 +19,17 @@ package org.springframework.cloud.gateway.handler.predicate;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.function.Predicate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.cloud.gateway.handler.predicate.BetweenRoutePredicateFactory.Config;
 import org.springframework.cloud.gateway.support.ConfigurationService;
 import org.springframework.cloud.gateway.support.StringToZonedDateTimeConverter;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
@@ -152,19 +158,45 @@ public class BetweenRoutePredicateFactoryTests {
 
 		BetweenRoutePredicateFactory factory = new BetweenRoutePredicateFactory();
 
-		BetweenRoutePredicateFactory.Config config = bindConfig(map, factory);
+		Config config = bindConfig(map, factory);
 
 		return factory.apply(config).test(getExchange());
 	}
 
 	@Test
 	public void toStringFormat() {
-		BetweenRoutePredicateFactory.Config config = new BetweenRoutePredicateFactory.Config();
+		Config config = new Config();
 		config.setDatetime1(ZonedDateTime.now());
 		config.setDatetime2(ZonedDateTime.now().plusHours(1));
 		Predicate predicate = new BetweenRoutePredicateFactory().apply(config);
 		assertThat(predicate.toString())
 			.contains("Between: " + config.getDatetime1() + " and " + config.getDatetime2());
+	}
+
+	@Test
+	public void testConfig() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			config.setDatetime1(ZonedDateTime.now());
+			config.setDatetime2(ZonedDateTime.now());
+
+			assertThat(validator.validate(config).isEmpty()).isTrue();
+		}
+	}
+
+	@Test
+	public void testConfigNullField() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			Set<ConstraintViolation<Config>> validate = validator.validate(config);
+
+			assertThat(validate.isEmpty()).isFalse();
+			assertThat(validate.size()).isEqualTo(2);
+		}
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/CookieRoutePredicateFactoryTests.java
@@ -16,8 +16,13 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.Set;
 import java.util.function.Predicate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.gateway.handler.predicate.CookieRoutePredicateFactory.Config;
@@ -62,6 +67,32 @@ public class CookieRoutePredicateFactoryTests extends BaseWebClientTests {
 		config.setRegexp("myregexp");
 		Predicate predicate = new CookieRoutePredicateFactory().apply(config);
 		assertThat(predicate.toString()).contains("Cookie: name=mycookie regexp=myregexp");
+	}
+
+	@Test
+	public void testConfig() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			config.setName("mycookie");
+			config.setRegexp("myregexp");
+
+			assertThat(validator.validate(config).isEmpty()).isTrue();
+		}
+	}
+
+	@Test
+	public void testConfigNullField() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			Set<ConstraintViolation<Config>> validate = validator.validate(config);
+
+			assertThat(validate.isEmpty()).isFalse();
+			assertThat(validate.size()).isEqualTo(2);
+		}
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/HeaderRoutePredicateFactoryTests.java
@@ -16,8 +16,13 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.Set;
 import java.util.function.Predicate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -104,6 +109,31 @@ public class HeaderRoutePredicateFactoryTests extends BaseWebClientTests {
 			.valueEquals(HANDLER_MAPPER_HEADER, RoutePredicateHandlerMapping.class.getSimpleName())
 			.expectHeader()
 			.valueEquals(ROUTE_ID_HEADER, "header_test_comma_separated");
+	}
+
+	@Test
+	public void testConfig() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			config.setHeader("myheader");
+
+			assertThat(validator.validate(config).isEmpty()).isTrue();
+		}
+	}
+
+	@Test
+	public void testConfigNullField() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			Set<ConstraintViolation<Config>> validate = validator.validate(config);
+
+			assertThat(validate.isEmpty()).isFalse();
+			assertThat(validate.size()).isEqualTo(1);
+		}
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/QueryRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/QueryRoutePredicateFactoryTests.java
@@ -16,8 +16,13 @@
 
 package org.springframework.cloud.gateway.handler.predicate;
 
+import java.util.Set;
 import java.util.function.Predicate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -85,6 +90,31 @@ public class QueryRoutePredicateFactoryTests extends BaseWebClientTests {
 		config.setRegexp("myregexp");
 		Predicate predicate = new QueryRoutePredicateFactory().apply(config);
 		assertThat(predicate.toString()).contains("Query: param=myparam regexp=myregexp");
+	}
+
+	@Test
+	public void testConfig() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			config.setParam("myparam");
+
+			assertThat(validator.validate(config).isEmpty()).isTrue();
+		}
+	}
+
+	@Test
+	public void testConfigNullField() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			Set<ConstraintViolation<Config>> validate = validator.validate(config);
+
+			assertThat(validate.isEmpty()).isFalse();
+			assertThat(validate.size()).isEqualTo(1);
+		}
 	}
 
 	@EnableAutoConfiguration

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/predicate/RemoteAddrRoutePredicateFactoryTests.java
@@ -17,8 +17,13 @@
 package org.springframework.cloud.gateway.handler.predicate;
 
 import java.time.Duration;
+import java.util.Set;
 import java.util.function.Predicate;
 
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -87,6 +92,31 @@ public class RemoteAddrRoutePredicateFactoryTests extends BaseWebClientTests {
 		config.setSources("1.2.3.4", "5.6.7.8");
 		Predicate predicate = new RemoteAddrRoutePredicateFactory().apply(config);
 		assertThat(predicate.toString()).contains("RemoteAddrs: [1.2.3.4, 5.6.7.8]");
+	}
+
+	@Test
+	public void testConfig() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			config.setSources("1.2.3.4", "5.6.7.8");
+
+			assertThat(validator.validate(config).isEmpty()).isTrue();
+		}
+	}
+
+	@Test
+	public void testConfigNullField() {
+		try(ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+			Validator validator = factory.getValidator();
+
+			Config config = new Config();
+			Set<ConstraintViolation<Config>> validate = validator.validate(config);
+
+			assertThat(validate.isEmpty()).isFalse();
+			assertThat(validate.size()).isEqualTo(1);
+		}
 	}
 
 	@EnableAutoConfiguration


### PR DESCRIPTION
I removed `@Validated` from all predicates because it wasn't working.
Added `@NotNull` to `BeforeRoutePredicateFactory.Config` similar to `AfterRoutePredicateFactory`.

And I added some tests to verify correct behavior before and after removing `@Validated` and adding `@NotNull`.

This is a PR for the https://github.com/spring-cloud/spring-cloud-gateway/issues/3478 issue.