### PR TITLE
Fix incorrect link in configuration-properties

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway/configuration-properties.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway/configuration-properties.adoc
@@ -2,4 +2,4 @@
 = Configuration properties
 :page-section-summary-toc: 1
 
-To see the list of all Spring Cloud Gateway related configuration properties, see link:appendix.html[the appendix].
+To see the list of all Spring Cloud Gateway related configuration properties, see link:../appendix.html[the appendix].


### PR DESCRIPTION
## Related Issue

#3500 [online-docs][4.1.5] 404 from link to properties

## Content of this PR

This PR fixes a 404 error caused by an incorrect path in configuration-properties.adoc.

## Modifications

The link is updated from <code>link:appendix.html</code> to <code>link:../appendix.html</code>.