### PR TITLE
Allow larger rate limits for extended time intervals

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterConfigTests.java
@@ -59,6 +59,14 @@ public class RedisRateLimiterConfigTests {
 	}
 
 	@Test
+	public void shouldThrowAnErrorWhenBurstCapacityExceedsMaxAllowed() {
+		long burstCapacity = Long.MAX_VALUE;
+
+		Assertions.assertThatThrownBy(() -> new RedisRateLimiter(10, burstCapacity))
+			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
 	public void redisRateConfiguredFromEnvironment() {
 		assertFilter("redis_rate_limiter_config_test", 10, 20, 1, false);
 	}


### PR DESCRIPTION
This PR updates RedisRateLimiter to support larger values for `burstCapacity` by changing its type from `int` to `long`, enabling greater flexibility for extended time intervals.
The changes include validation to ensure that the `burstCapacity` does not exceed the maximum allowed value that can be safely handled by Redis scripts, which is `2^53 - 1`.

Closes #3594 