### PR TITLE
Fix: ensure connections are disposed for filter exception scenarios

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
@@ -66,6 +66,7 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 		// until the NettyRoutingFilter is run
 		// @formatter:off
 		return chain.filter(exchange)
+				.doOnError(throwable -> cleanup(exchange))
 				.then(Mono.defer(() -> {
 					Connection connection = exchange.getAttribute(CLIENT_RESPONSE_CONN_ATTR);
 
@@ -98,8 +99,8 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 					return (isStreamingMediaType(contentType)
 							? response.writeAndFlushWith(body.map(Flux::just))
 							: response.writeWith(body));
-				})).doOnCancel(() -> cleanup(exchange))
-				.doOnError(throwable -> cleanup(exchange));
+				}))
+				.doOnCancel(() -> cleanup(exchange));
 		// @formatter:on
 	}
 


### PR DESCRIPTION
Hello,
I am running a service using Spring Cloud Gateway based on reactor-netty, and recently, I became interested in the `NettyWriteResponseFilter` filter.

I think that the `doOnError()` method for connection disposal should be placed before the `.then()` call, not after.
This is because `doOnError()` operates downstream and does not have significant meaning when placed after `.then()`.
Therefore, I propose moving the `doOnError()` configuration to a point before the `.then()` method.
Similarly, in the WebClientWriteResponseFilter filter, `doOnError()` is also set before `.then()` and handled in a comparable manner.
(As for `doOnCancel()`, since it operates upstream, it seems appropriate to set it after the `.then()` method.)

Thanks.