### PR TITLE
Fix: prevent duplicated encoding request parameters filter

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RewriteRequestParameterGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RewriteRequestParameterGatewayFilterFactory.java
@@ -26,10 +26,14 @@ import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.Assert;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 import static org.springframework.cloud.gateway.support.GatewayToStringStyler.filterToStringCreator;
+import static org.springframework.util.CollectionUtils.unmodifiableMultiValueMap;
 
 /**
  * @author Fredrich Ombico
@@ -59,14 +63,25 @@ public class RewriteRequestParameterGatewayFilterFactory
 				ServerHttpRequest req = exchange.getRequest();
 
 				UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUri(req.getURI());
-				if (req.getQueryParams().containsKey(config.getName())) {
-					uriComponentsBuilder.replaceQueryParam(config.getName(), config.getReplacement());
+
+				MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>(req.getQueryParams());
+				if (queryParams.containsKey(config.getName())) {
+					queryParams.remove(config.getName());
+					queryParams.add(config.getName(), config.getReplacement());
 				}
 
-				URI uri = uriComponentsBuilder.build().toUri();
-				ServerHttpRequest request = req.mutate().uri(uri).build();
+				try {
+					MultiValueMap<String, String> encodedQueryParams = UriUtils.encodeQueryParams(queryParams);
+					URI uri = uriComponentsBuilder.replaceQueryParams(unmodifiableMultiValueMap(encodedQueryParams))
+						.build(true)
+						.toUri();
 
-				return chain.filter(exchange.mutate().request(request).build());
+					ServerHttpRequest request = req.mutate().uri(uri).build();
+					return chain.filter(exchange.mutate().request(request).build());
+				}
+				catch (IllegalArgumentException ex) {
+					throw new IllegalStateException("Invalid URI query: \"" + queryParams + "\"");
+				}
 			}
 
 			@Override

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
@@ -123,4 +123,41 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 		assertThat(actualRequest.getQueryParams()).containsEntry("ccc", singletonList(",xyz"));
 	}
 
+
+	@Test
+	public void removeRequestParameterFilterShouldHandleEncodedParameterName() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+			.queryParam("foo", "bar")
+			.queryParam("baz[]", "qux")
+			.build();
+		exchange = MockServerWebExchange.from(request);
+		NameConfig config = new NameConfig();
+		config.setName("baz[]");
+		GatewayFilter filter = new RemoveRequestParameterGatewayFilterFactory().apply(config);
+
+		filter.filter(exchange, filterChain);
+
+		ServerHttpRequest actualRequest = captor.getValue().getRequest();
+		assertThat(actualRequest.getQueryParams()).doesNotContainKey("baz[]");
+		assertThat(actualRequest.getQueryParams()).containsEntry("foo", singletonList("bar"));
+	}
+
+	@Test
+	public void removeRequestParameterFilterShouldMaintainEncodedParameters() {
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
+			.queryParam("foo", "bar")
+			.queryParam("baz[]", "qux")
+			.build();
+		exchange = MockServerWebExchange.from(request);
+		NameConfig config = new NameConfig();
+		config.setName("foo");
+		GatewayFilter filter = new RemoveRequestParameterGatewayFilterFactory().apply(config);
+
+		filter.filter(exchange, filterChain);
+
+		ServerHttpRequest actualRequest = captor.getValue().getRequest();
+		assertThat(actualRequest.getQueryParams()).doesNotContainKey("foo");
+		assertThat(actualRequest.getQueryParams()).containsEntry("baz[]", singletonList("qux"));
+	}
+
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RemoveRequestParameterGatewayFilterFactoryTests.java
@@ -37,7 +37,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Thirunavukkarasu Ravichandran
  */
-public class RemoveRequestParameterGatewayFilterFactoryTests {
+class RemoveRequestParameterGatewayFilterFactoryTests {
 
 	private ServerWebExchange exchange;
 
@@ -46,7 +46,7 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 	private ArgumentCaptor<ServerWebExchange> captor;
 
 	@BeforeEach
-	public void setUp() {
+	void setUp() {
 		filterChain = mock(GatewayFilterChain.class);
 		captor = ArgumentCaptor.forClass(ServerWebExchange.class);
 		when(filterChain.filter(captor.capture())).thenReturn(Mono.empty());
@@ -54,7 +54,7 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 	}
 
 	@Test
-	public void removeRequestParameterFilterWorks() {
+	void removeRequestParameterFilterWorks() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
 			.queryParam("foo", singletonList("bar"))
 			.build();
@@ -70,7 +70,7 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 	}
 
 	@Test
-	public void removeRequestParameterFilterWorksWhenParamIsNotPresentInRequest() {
+	void removeRequestParameterFilterWorksWhenParamIsNotPresentInRequest() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost").build();
 		exchange = MockServerWebExchange.from(request);
 		NameConfig config = new NameConfig();
@@ -84,7 +84,7 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 	}
 
 	@Test
-	public void removeRequestParameterFilterShouldOnlyRemoveSpecifiedParam() {
+	void removeRequestParameterFilterShouldOnlyRemoveSpecifiedParam() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
 			.queryParam("foo", "bar")
 			.queryParam("abc", "xyz")
@@ -102,7 +102,7 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 	}
 
 	@Test
-	public void removeRequestParameterFilterShouldHandleRemainingParamsWhichRequiringEncoding() {
+	void removeRequestParameterFilterShouldHandleRemainingParamsWhichRequiringEncoding() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
 			.queryParam("foo", "bar")
 			.queryParam("aaa", "abc xyz")
@@ -123,9 +123,8 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 		assertThat(actualRequest.getQueryParams()).containsEntry("ccc", singletonList(",xyz"));
 	}
 
-
 	@Test
-	public void removeRequestParameterFilterShouldHandleEncodedParameterName() {
+	void removeRequestParameterFilterShouldHandleEncodedParameterName() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
 			.queryParam("foo", "bar")
 			.queryParam("baz[]", "qux")
@@ -143,7 +142,7 @@ public class RemoveRequestParameterGatewayFilterFactoryTests {
 	}
 
 	@Test
-	public void removeRequestParameterFilterShouldMaintainEncodedParameters() {
+	void removeRequestParameterFilterShouldMaintainEncodedParameters() {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost")
 			.queryParam("foo", "bar")
 			.queryParam("baz[]", "qux")

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RewriteRequestParameterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/RewriteRequestParameterGatewayFilterFactoryTests.java
@@ -71,9 +71,21 @@ class RewriteRequestParameterGatewayFilterFactoryTests {
 	}
 
 	@Test
-	void rewriteRequestParameterFilterWorksWithSpecialCharacters() {
+	void rewriteRequestParameterFilterWithSpecialCharactersInParameterValue() {
 		testRewriteRequestParameterFilter("campaign", "black friday~(1.A-B_C!)", "campaign=old&color=green",
 				Map.of("campaign", List.of("black friday~(1.A-B_C!)"), "color", List.of("green")));
+	}
+
+	@Test
+	void rewriteRequestParameterFilterWithSpecialCharactersInParameterName() {
+		testRewriteRequestParameterFilter("campaign[]", "red", "campaign%5B%5D=blue&color=green",
+				Map.of("campaign[]", List.of("red"), "color", List.of("green")));
+	}
+
+	@Test
+	void rewriteRequestParameterFilterKeepsOtherParamsEncoded() {
+		testRewriteRequestParameterFilter("color", "white", "campaign%5B%5D=blue&color=green",
+				Map.of("campaign[]", List.of("blue"), "color", List.of("white")));
 	}
 
 	private void testRewriteRequestParameterFilter(String name, String replacement, String query,


### PR DESCRIPTION
Hello.

I found that there is a case where the encoded query parameter in the `RewriteRequestParameterGatewayFilterFactory` and `RemoveRequestHeaderGatewayFilterFactory` factory filters encodes the `%` character again.

For example, if we apply the `RemoveRequestHeaderGatewayFilterFactory` filter to `http://localhost?foo%5B%5D=123&bar=456` to remove the **bar** parameter, `%` becomes an encoding target, and the query parameter is duplicated and encoded as `http://localhost?foo%255B%255D=123`.
I think I should keep the existing encoded query parameter as `http://localhost?foo%5B%5D=123`.

Therefore, I will explain the items processed for each filter in more detail.



## RewriteRequestParameterGatewayFilterFactory
### Reason
1.  Previously, it checked whether `config.getName()` existed in `ServerWebExchange.getRequest().getQueryParams()` and directly replaced `config.getReplacement()` in `UriComponentsBuilder`.
If the query parameter to be replaced is encoded, there is a problem that the `name` and `replacement` of `config` may not be replaced properly.
Even if we inject it by encoding it in config, it may be encoded twice as a result and it may not be found in `ServerWebExchange.getRequest().getQueryParams()`.
2. Encode not only query parameters but also other **segments**.
(since `UriComponentsBuilder.build()` encodes them by default) 
For example, if it is `http://localhost?foo=123#bar=baz%5B%5D`, it can be encoded once more up to the **fragment**, like `http://localhost?foo=123#bar=baz%255B%255D`.

### Solve
1. Modify to replace query parameters based on the return value of `ServerWebExchange.getRequest().getQueryParams()`.
(`ServerWebExchange.getRequest().getQueryParams()` internally returns **decoded query parameters**).

2. Encode only the query parameters and inject them into the `UriComponentsBuilder`, and do not attempt to encode other segments.

## RemoveRequestHeaderGatewayFilterFactory
1. The second reason for `RewriteRequestParameterGatewayFilterFactory` is the same. 
Modify it to encode only the query parameters segment.


Therefore, I processed it as follows in each filter.

