### PR TITLE
Fix: Ignore read-only headers in DedupeResponseHeaderGatewayFilterFactory

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactory.java
@@ -130,6 +130,9 @@ public class DedupeResponseHeaderGatewayFilterFactory
 		if (headers == null || names == null || strategy == null) {
 			return;
 		}
+		if (headers.getClass().getName().equals("org.springframework.http.ReadOnlyHttpHeaders")) {
+			return;
+		}
 		for (String name : names.split(" ")) {
 			dedupe(headers, name.trim(), strategy);
 		}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/DedupeResponseHeaderGatewayFilterFactoryUnitTests.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.gateway.filter.factory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -125,6 +127,16 @@ public class DedupeResponseHeaderGatewayFilterFactoryUnitTests {
 		config.setStrategy(Strategy.RETAIN_LAST);
 		GatewayFilter filter = new DedupeResponseHeaderGatewayFilterFactory().apply(config);
 		assertThat(filter.toString()).contains("myname").contains(Strategy.RETAIN_LAST.toString());
+	}
+
+	@Test
+	public void ignoreReadOnlyHeaders() {
+		var headers = new HttpHeaders();
+		headers.addAll(NAME_1, List.of("2", "3", "3", "4"));
+		config.setName(NAME_1);
+		config.setStrategy(Strategy.RETAIN_UNIQUE);
+		var filter = new DedupeResponseHeaderGatewayFilterFactory();
+		Assertions.assertDoesNotThrow(() -> filter.dedupe(HttpHeaders.readOnlyHttpHeaders(headers), config));
 	}
 
 }


### PR DESCRIPTION
This pull request includes one change to the `DedupeResponseHeaderGatewayFilterFactory` class which now ignores the headers if they are read-only.

**Reason:**

If the headers are read-only, the dedupe method throws UnsupportedOperationException

**Solve:**

If the headers are read-only, ignore it.

```java
if (headers.getClass().getName().equals("org.springframework.http.ReadOnlyHttpHeaders")) {
    return;
}
```

A try-catch block may be more suitable... 