### PR TITLE
Suggests to dispose connection when cancelled In NettyWriteResponseFilter

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -224,7 +224,7 @@ Spring Cloud Build brings along the  `basepom:duplicate-finder-maven-plugin`, th
 [[duplicate-finder-configuration]]
 === Duplicate Finder configuration
 
-Duplicate finder is *enabled by default* and will run in the `verify` phase of your Maven build, but it will only take effect in your project if you add the `duplicate-finder-maven-plugin` to the `build` section of the projecst's `pom.xml`.
+Duplicate finder is *enabled by default* and will run in the `verify` phase of your Maven build, but it will only take effect in your project if you add the `duplicate-finder-maven-plugin` to the `build` section of the project's `pom.xml`.
 
 .pom.xml
 [source,xml]

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
@@ -116,7 +116,7 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 			byteBuf.release();
 			return buffer;
 		}
-		throw new IllegalArgumentException("Unkown DataBufferFactory type " + bufferFactory.getClass());
+		throw new IllegalArgumentException("Unknown DataBufferFactory type " + bufferFactory.getClass());
 	}
 
 	private void cleanup(ServerWebExchange exchange) {


### PR DESCRIPTION
Hello.
I use spring-gateway, reactor-netty to operate the service.
While investing `"LEAK: ByteBuf.release() was not called before it's garbage-collected"`, I would like to ask for suggestions on fixing `NettyWriteResponseFilter`.

`NettyWriteResponseFilter` disposes only when **the connection channel is active**.

However, it seems that `FluxReceive` may result in unreleased memory references. ([ChannelOperations](https://github.com/reactor/reactor-netty/blob/864474ae24b72f2990b34b1124ab4e435c1b95d5/reactor-netty-core/src/main/java/reactor/netty/channel/ChannelOperations.java#L208-L220))
Therefore, I suggest modifying the configuration to always **dispose of the connection regardless of the channel status**.
(I understand that there is no redundant processing for dispose already inside the connection.)

![image](https://github.com/user-attachments/assets/870f045d-82af-47ed-8f01-e361dc1805c9)


For example, suppose that an incoming HTTP request was canceled while routing and responding.
Even though the `NioSocketChannel` channel is not active, a memory reference may remain in `receiverQueue` maintained in `FluxReceive`.

Actually, if delay 5 seconds with a custom GlobalFilter and generate a large number of HTTP cancels after 2 seconds of the total request time, "LEAK: ByteBuf.release() was not called before it's garbage-collected" occurred.

@violetagg 
hello.
What do you think about this?
