### PR TITLE
Prevent duplicated encoding of `setPath()`, `stripPrefix()` in mvc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -224,7 +224,7 @@ Spring Cloud Build brings along the  `basepom:duplicate-finder-maven-plugin`, th
 [[duplicate-finder-configuration]]
 === Duplicate Finder configuration
 
-Duplicate finder is *enabled by default* and will run in the `verify` phase of your Maven build, but it will only take effect in your project if you add the `duplicate-finder-maven-plugin` to the `build` section of the projecst's `pom.xml`.
+Duplicate finder is *enabled by default* and will run in the `verify` phase of your Maven build, but it will only take effect in your project if you add the `duplicate-finder-maven-plugin` to the `build` section of the project's `pom.xml`.
 
 .pom.xml
 [source,xml]

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
@@ -350,9 +350,11 @@ public abstract class BeforeFilterFunctions {
 		return request -> {
 			Map<String, Object> uriVariables = MvcUtils.getUriTemplateVariables(request);
 			URI uri = uriTemplate.expand(uriVariables);
-			String newPath = uri.getRawPath();
 
-			URI prefixedUri = UriComponentsBuilder.fromUri(request.uri()).replacePath(newPath).build().toUri();
+			URI prefixedUri = UriComponentsBuilder.fromUri(request.uri())
+				.replacePath(uri.getRawPath())
+				.build(true)
+				.toUri();
 			return ServerRequest.from(request).uri(prefixedUri).build();
 		};
 	}

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
@@ -45,6 +45,7 @@ import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriTemplate;
+import org.springframework.web.util.UriUtils;
 
 import static org.springframework.cloud.gateway.server.mvc.common.MvcUtils.CIRCUITBREAKER_EXECUTION_EXCEPTION_ATTR;
 import static org.springframework.util.CollectionUtils.unmodifiableMultiValueMap;
@@ -214,10 +215,12 @@ public abstract class BeforeFilterFunctions {
 			MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>(request.params());
 			queryParams.remove(name);
 
+			MultiValueMap<String, String> encodedQueryParams = UriUtils.encodeQueryParams(queryParams);
+
 			// remove from uri
 			URI newUri = UriComponentsBuilder.fromUri(request.uri())
-				.replaceQueryParams(unmodifiableMultiValueMap(queryParams))
-				.build()
+				.replaceQueryParams(unmodifiableMultiValueMap(encodedQueryParams))
+				.build(true)
 				.toUri();
 
 			// remove resolved params from request

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
@@ -409,7 +409,7 @@ public abstract class BeforeFilterFunctions {
 
 			URI prefixedUri = UriComponentsBuilder.fromUri(request.uri())
 				.replacePath(newPath.toString())
-				.build()
+				.build(true)
 				.toUri();
 			return ServerRequest.from(request).uri(prefixedUri).build();
 		};

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
@@ -157,4 +157,42 @@ class BeforeFilterFunctionsTests {
 		assertThat(result.uri().toString()).isEqualTo("http://localhost/new/path?foo%5B%5D=bar%5B%5D");
 	}
 
+	@Test
+	void stripPrefix() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/depth1/depth2/depth3")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.stripPrefix(2).apply(request);
+
+		assertThat(result.uri().toString()).isEqualTo("http://localhost/depth3");
+	}
+
+	@Test
+	void stripPrefixWithEncodedPath() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/depth1/depth2/depth3/é")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.stripPrefix(2).apply(request);
+
+		assertThat(result.uri().toString()).isEqualTo("http://localhost/depth3/%C3%A9");
+	}
+
+	@Test
+	void stripPrefixWithEncodedParameters() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/depth1/depth2/depth3")
+				.queryParam("baz[]", "qux[]")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.stripPrefix(2).apply(request);
+
+		assertThat(result.param("baz[]")).isPresent().hasValue("qux[]");
+		assertThat(result.uri().toString()).isEqualTo("http://localhost/depth3?baz%5B%5D=qux%5B%5D");
+	}
+
 }

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.server.mvc.filter;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.servlet.function.ServerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author raccoonback
+ */
+class BeforeFilterFunctionsTests {
+
+	@Test
+	void rewriteRequestParameter() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo", "bar")
+			.param("baz", "qux")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz=qux&foo=replacement");
+	}
+
+	@Test
+	void rewriteOnlyFirstRequestParameter() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo", "bar_1")
+			.param("foo", "bar_2")
+			.param("foo", "bar_3")
+			.param("baz", "qux")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz=qux&foo=replacement");
+	}
+
+	@Test
+	void rewriteEncodedRequestParameter() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo[]", "bar")
+			.param("baz", "qux")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo[]", "replacement[]").apply(request);
+
+		assertThat(result.param("foo[]")).isPresent().hasValue("replacement[]");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz=qux&foo%5B%5D=replacement%5B%5D");
+	}
+
+	@Test
+	void rewriteRequestParameterWithEncodedRemainParameters() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo", "bar")
+			.param("baz[]", "qux[]")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz%5B%5D=qux%5B%5D&foo=replacement");
+	}
+
+	@Test
+	void rewriteRequestParameterWithEncodedPath() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path/é/last")
+			.param("foo", "bar")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path/%C3%A9/last?foo=replacement");
+	}
+
+	@Test
+	void setPath() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/legacy/path")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.setPath("/new/path").apply(request);
+
+		assertThat(result.uri().toString()).isEqualTo("http://localhost/new/path");
+	}
+
+	@Test
+	void setEncodedPath() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/legacy/path")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.setPath("/new/é").apply(request);
+
+		assertThat(result.uri().toString()).isEqualTo("http://localhost/new/%C3%A9");
+	}
+
+	@Test
+	void setPathWithParameters() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/legacy/path")
+				.queryParam("foo", "bar")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.setPath("/new/path").apply(request);
+
+		assertThat(result.uri().toString()).isEqualTo("http://localhost/new/path?foo=bar");
+	}
+
+	@Test
+	void setPathWithEncodedParameters() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/legacy/path")
+				.queryParam("foo[]", "bar[]")
+				.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.setPath("/new/path").apply(request);
+
+		assertThat(result.uri().toString()).isEqualTo("http://localhost/new/path?foo%5B%5D=bar%5B%5D");
+	}
+
+}


### PR DESCRIPTION
## Motivation
There were issues with the `setPath()` and `stripPrefix()` methods where already encoded URIs were being double-encoded.

```java
[setPath()]
request uri: http://localhost/legacy/path

-> setPath("new é")

result: http://localhost/new/%25C3%25A9 

[setPath()]
request uri: http://localhost/depth1/depth2/depth3/é

-> stripPrefix(2)

result: http://localhost/depth3/%25C3%25A9 
```

Also, the `removeRequestParameter()` method was also double-encoding not only request parameters but also paths and other components.

```java
[removeRequestParameter()]

request uri: http://localhost/path/é/last?foo=bar

-> removeRequestParameter("foo")

result: http://localhost/path/%25C3%25A9/last
```

## Key Changes
- `setPath()` and `stripPrefix()` methods have been fixed to prevent double encoding.
```java
[setPath()]
request uri: http://localhost/legacy/path

-> setPath("new é")

result: http://localhost/new/%C3%A9

[setPath()]
request uri: http://localhost/depth1/depth2/depth3/é

-> stripPrefix(2)

result: http://localhost/depth3/%C3%A9
```

- `removeRequestParameter()` has been updated to ensure that **only request parameters are encoded**.
```java
[removeRequestParameter()]

request uri: http://localhost/path/é/last?foo=bar

-> removeRequestParameter("foo")

result: http://localhost/path/%C3%A9/last
```

## Reference
related with https://github.com/spring-cloud/spring-cloud-gateway/issues/3131