### PR TITLE
Add request temp file buffer (#3479)

### DIFF
--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -184,6 +184,8 @@
 |spring.cloud.gateway.server.webmvc.routes-map |  | Map of Routes.
 |spring.cloud.gateway.server.webmvc.streaming-buffer-size | `+++16384+++` | Buffer size for streaming media mime-types.
 |spring.cloud.gateway.server.webmvc.streaming-media-types |  | Mime-types that are streaming.
+|spring.cloud.gateway.mvc.file-buffer-enabled | true | Enables the temp file buffer.
+|spring.cloud.gateway.mvc.file-buffer-size-threshold | 1MB | The size threshold which a request will be written to disk.
 |spring.cloud.gateway.server.webmvc.transfer-encoding-normalization-request-headers-filter.enabled | `+++true+++` | Enables the transfer-encoding-normalization-request-headers-filter.
 |spring.cloud.gateway.server.webmvc.trusted-proxies |  | Regular expression defining proxies that are trusted when they appear in a Forwarded of X-Forwarded header.
 |spring.cloud.gateway.server.webmvc.use-framework-retry-filter | `+++false+++` | In the case where Spring Retry is on the classpath but you still want to use Spring Framework retry as your retry filter, set this property to true.

--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -185,8 +185,8 @@
 |spring.cloud.gateway.server.webmvc.routes-map |  | Map of Routes.
 |spring.cloud.gateway.server.webmvc.streaming-buffer-size | `+++16384+++` | Buffer size for streaming media mime-types.
 |spring.cloud.gateway.server.webmvc.streaming-media-types |  | Mime-types that are streaming.
-|spring.cloud.gateway.mvc.file-buffer-enabled | true | Enables the temp file buffer.
-|spring.cloud.gateway.mvc.file-buffer-size-threshold | 1MB | The size threshold which a request will be written to disk.
+|spring.cloud.gateway.server.webmvc.file-buffer.enabled | `+++false+++` | Enables the temp file buffer.
+|spring.cloud.gateway.server.webmvc.file-buffer.size-threshold | `+++1MB+++` | The size threshold which a request will be written to disk.
 |spring.cloud.gateway.server.webmvc.transfer-encoding-normalization-request-headers-filter.enabled | `+++true+++` | Enables the transfer-encoding-normalization-request-headers-filter.
 |spring.cloud.gateway.server.webmvc.trusted-proxies |  | Regular expression defining proxies that are trusted when they appear in a Forwarded of X-Forwarded header.
 |spring.cloud.gateway.server.webmvc.use-framework-retry-filter | `+++false+++` | In the case where Spring Retry is on the classpath but you still want to use Spring Framework retry as your retry filter, set this property to true.

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchange.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchange.java
@@ -75,4 +75,9 @@ public abstract class AbstractProxyExchange implements ProxyExchange {
 		return totalReadBytes;
 	}
 
+
+	protected boolean isWriteClientBodyToFile(Request request) {
+		return properties.isFileBufferEnabled() && request.getServerRequest().servletRequest().getContentLength() >= properties.getFileBufferSizeThreshold().toBytes();
+	}
+
 }

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchange.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchange.java
@@ -77,7 +77,7 @@ public abstract class AbstractProxyExchange implements ProxyExchange {
 
 
 	protected boolean isWriteClientBodyToFile(Request request) {
-		return properties.isFileBufferEnabled() && request.getServerRequest().servletRequest().getContentLength() >= properties.getFileBufferSizeThreshold().toBytes();
+		return properties.getFileBuffer().isEnabled() && request.getServerRequest().servletRequest().getContentLength() >= properties.getFileBuffer().getSizeThreshold().toBytes();
 	}
 
 }

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gateway.server.mvc.common;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -112,6 +113,11 @@ public abstract class MvcUtils {
 	 * Weight attribute name.
 	 */
 	public static final String WEIGHT_ATTR = qualify("routeWeight");
+
+	/**
+	 * Client request body temp file.
+	 */
+	public static final String CLIENT_BODY_TMP_ATTR = qualify("clientBodyTempFile");
 
 	private MvcUtils() {
 	}
@@ -347,6 +353,12 @@ public abstract class MvcUtils {
 		}
 		return result;
 	}
+
+	public static void setBodyTempFile(ServerRequest request, File file) {
+		request.attributes().put(GATEWAY_ROUTE_ID_ATTR, file);
+		request.servletRequest().setAttribute(GATEWAY_ROUTE_ID_ATTR, file);
+	}
+
 
 	private record ByteArrayInputMessage(ServerRequest request, ByteArrayInputStream body) implements HttpInputMessage {
 

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
@@ -355,8 +355,8 @@ public abstract class MvcUtils {
 	}
 
 	public static void setBodyTempFile(ServerRequest request, File file) {
-		request.attributes().put(GATEWAY_ROUTE_ID_ATTR, file);
-		request.servletRequest().setAttribute(GATEWAY_ROUTE_ID_ATTR, file);
+		request.attributes().put(CLIENT_BODY_TMP_ATTR, file);
+		request.servletRequest().setAttribute(CLIENT_BODY_TMP_ATTR, file);
 	}
 
 

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
@@ -133,90 +133,8 @@ public class GatewayMvcProperties {
 			.append("streamingMediaTypes", streamingMediaTypes)
 			.append("streamingBufferSize", streamingBufferSize)
 			.append("trustedProxies", trustedProxies)
-            .append("fileBuffer",fileBuffer)
+			.append("fileBuffer", fileBuffer)
 			.toString();
-	}
-
-	/**
-	 * @deprecated in favor of spring.http.client.
-	 */
-	@Deprecated
-	public static class HttpClient {
-
-		/** The HttpClient connect timeout. */
-		private Duration connectTimeout;
-
-		/** The HttpClient read timeout. */
-		private Duration readTimeout;
-
-		/** The name of the SSL bundle to use. */
-		private String sslBundle;
-
-		/** The HttpClient type. Defaults to JDK. */
-		private HttpClientType type = HttpClientType.JDK;
-
-		@Deprecated
-		@DeprecatedConfigurationProperty(replacement = "spring.http.client.connect-timeout", since = "4.2.0")
-		public Duration getConnectTimeout() {
-			return connectTimeout;
-		}
-
-		public void setConnectTimeout(Duration connectTimeout) {
-			this.connectTimeout = connectTimeout;
-		}
-
-		@Deprecated
-		@DeprecatedConfigurationProperty(replacement = "spring.http.client.read-timeout", since = "4.2.0")
-		public Duration getReadTimeout() {
-			return readTimeout;
-		}
-
-		public void setReadTimeout(Duration readTimeout) {
-			this.readTimeout = readTimeout;
-		}
-
-		@Deprecated
-		@DeprecatedConfigurationProperty(replacement = "spring.http.client.ssl.bundle", since = "4.2.0")
-		public String getSslBundle() {
-			return sslBundle;
-		}
-
-		public void setSslBundle(String sslBundle) {
-			this.sslBundle = sslBundle;
-		}
-
-		@Deprecated
-		public HttpClientType getType() {
-			return type;
-		}
-
-		public void setType(HttpClientType type) {
-			this.type = type;
-		}
-
-		@Override
-		public String toString() {
-			return new ToStringCreator(this).append("connectTimeout", connectTimeout)
-				.append("readTimeout", readTimeout)
-				.append("sslBundle", sslBundle)
-				.append("type", type)
-				.toString();
-		}
-
-	}
-
-	public enum HttpClientType {
-
-		/**
-		 * Use JDK HttpClient.
-		 */
-		JDK,
-
-		/**
-		 * Auto-detect the HttpClient.
-		 */
-		AUTODETECT
-
 	}
 	public static class FileBuffer {
 		/**
@@ -240,9 +158,8 @@ public class GatewayMvcProperties {
 		@Override
 		public String toString() {
 			return new ToStringCreator(this).append("enabled", enabled)
-				.append("sizeThreshold", sizeThreshold)
-				.toString();
+					.append("sizeThreshold", sizeThreshold)
+					.toString();
 		}
 	}
-
 }

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
@@ -28,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.style.ToStringCreator;
 import org.springframework.http.MediaType;
+import org.springframework.util.unit.DataSize;
 
 @ConfigurationProperties(GatewayMvcProperties.PREFIX)
 public class GatewayMvcProperties {
@@ -74,6 +75,16 @@ public class GatewayMvcProperties {
 	 * Framework retry as your retry filter, set this property to true.
 	 */
 	private boolean useFrameworkRetryFilter = false;
+
+	/**
+	 * Temp file buffer for request.
+	 */
+	private boolean fileBufferEnabled = true;
+
+	/**
+	 * The size threshold which a request will be written to disk.
+	 */
+	private DataSize fileBufferSizeThreshold =  DataSize.ofMegabytes(1L);
 
 	public List<RouteProperties> getRoutes() {
 		return routes;
@@ -123,6 +134,22 @@ public class GatewayMvcProperties {
 		this.trustedProxies = trustedProxies;
 	}
 
+	public boolean isFileBufferEnabled() {
+		return fileBufferEnabled;
+	}
+
+	public void setFileBufferEnabled(boolean fileBufferEnabled) {
+		this.fileBufferEnabled = fileBufferEnabled;
+	}
+
+	public DataSize getFileBufferSizeThreshold() {
+		return fileBufferSizeThreshold;
+	}
+
+	public void setFileBufferSizeThreshold(DataSize fileBufferSizeThreshold) {
+		this.fileBufferSizeThreshold = fileBufferSizeThreshold;
+	}
+
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("routes", routes)
@@ -130,6 +157,8 @@ public class GatewayMvcProperties {
 			.append("streamingMediaTypes", streamingMediaTypes)
 			.append("streamingBufferSize", streamingBufferSize)
 			.append("trustedProxies", trustedProxies)
+			.append("fileBufferEnabled", fileBufferEnabled)
+			.append("fileBufferSizeThreshold", fileBufferSizeThreshold)
 			.toString();
 	}
 

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
@@ -76,15 +76,7 @@ public class GatewayMvcProperties {
 	 */
 	private boolean useFrameworkRetryFilter = false;
 
-	/**
-	 * Temp file buffer for request.
-	 */
-	private boolean fileBufferEnabled = true;
-
-	/**
-	 * The size threshold which a request will be written to disk.
-	 */
-	private DataSize fileBufferSizeThreshold =  DataSize.ofMegabytes(1L);
+	private FileBuffer fileBuffer = new FileBuffer();
 
 	public List<RouteProperties> getRoutes() {
 		return routes;
@@ -134,22 +126,6 @@ public class GatewayMvcProperties {
 		this.trustedProxies = trustedProxies;
 	}
 
-	public boolean isFileBufferEnabled() {
-		return fileBufferEnabled;
-	}
-
-	public void setFileBufferEnabled(boolean fileBufferEnabled) {
-		this.fileBufferEnabled = fileBufferEnabled;
-	}
-
-	public DataSize getFileBufferSizeThreshold() {
-		return fileBufferSizeThreshold;
-	}
-
-	public void setFileBufferSizeThreshold(DataSize fileBufferSizeThreshold) {
-		this.fileBufferSizeThreshold = fileBufferSizeThreshold;
-	}
-
 	@Override
 	public String toString() {
 		return new ToStringCreator(this).append("routes", routes)
@@ -157,9 +133,116 @@ public class GatewayMvcProperties {
 			.append("streamingMediaTypes", streamingMediaTypes)
 			.append("streamingBufferSize", streamingBufferSize)
 			.append("trustedProxies", trustedProxies)
-			.append("fileBufferEnabled", fileBufferEnabled)
-			.append("fileBufferSizeThreshold", fileBufferSizeThreshold)
+            .append("fileBuffer",fileBuffer)
 			.toString();
+	}
+
+	/**
+	 * @deprecated in favor of spring.http.client.
+	 */
+	@Deprecated
+	public static class HttpClient {
+
+		/** The HttpClient connect timeout. */
+		private Duration connectTimeout;
+
+		/** The HttpClient read timeout. */
+		private Duration readTimeout;
+
+		/** The name of the SSL bundle to use. */
+		private String sslBundle;
+
+		/** The HttpClient type. Defaults to JDK. */
+		private HttpClientType type = HttpClientType.JDK;
+
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "spring.http.client.connect-timeout", since = "4.2.0")
+		public Duration getConnectTimeout() {
+			return connectTimeout;
+		}
+
+		public void setConnectTimeout(Duration connectTimeout) {
+			this.connectTimeout = connectTimeout;
+		}
+
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "spring.http.client.read-timeout", since = "4.2.0")
+		public Duration getReadTimeout() {
+			return readTimeout;
+		}
+
+		public void setReadTimeout(Duration readTimeout) {
+			this.readTimeout = readTimeout;
+		}
+
+		@Deprecated
+		@DeprecatedConfigurationProperty(replacement = "spring.http.client.ssl.bundle", since = "4.2.0")
+		public String getSslBundle() {
+			return sslBundle;
+		}
+
+		public void setSslBundle(String sslBundle) {
+			this.sslBundle = sslBundle;
+		}
+
+		@Deprecated
+		public HttpClientType getType() {
+			return type;
+		}
+
+		public void setType(HttpClientType type) {
+			this.type = type;
+		}
+
+		@Override
+		public String toString() {
+			return new ToStringCreator(this).append("connectTimeout", connectTimeout)
+				.append("readTimeout", readTimeout)
+				.append("sslBundle", sslBundle)
+				.append("type", type)
+				.toString();
+		}
+
+	}
+
+	public enum HttpClientType {
+
+		/**
+		 * Use JDK HttpClient.
+		 */
+		JDK,
+
+		/**
+		 * Auto-detect the HttpClient.
+		 */
+		AUTODETECT
+
+	}
+	public static class FileBuffer {
+		/**
+		 * Temp file buffer for request.
+		 */
+		private boolean enabled = false;
+
+		/**
+		 * The size threshold which a request will be written to disk.
+		 */
+		private DataSize sizeThreshold =  DataSize.ofMegabytes(1L);
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+		@Override
+		public String toString() {
+			return new ToStringCreator(this).append("enabled", enabled)
+				.append("sizeThreshold", sizeThreshold)
+				.toString();
+		}
 	}
 
 }

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
@@ -78,6 +78,10 @@ public class GatewayMvcProperties {
 
 	private FileBuffer fileBuffer = new FileBuffer();
 
+	public FileBuffer getFileBuffer() {
+		return fileBuffer;
+	}
+
 	public List<RouteProperties> getRoutes() {
 		return routes;
 	}
@@ -153,6 +157,14 @@ public class GatewayMvcProperties {
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public DataSize getSizeThreshold() {
+			return sizeThreshold;
+		}
+
+		public void setSizeThreshold(DataSize sizeThreshold) {
+			this.sizeThreshold = sizeThreshold;
 		}
 
 		@Override

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
@@ -59,7 +59,7 @@ public class RestClientProxyExchange extends AbstractProxyExchange {
 		}
 		return requestSpec.exchange((clientRequest, clientResponse) -> {
 			ServerResponse serverResponse = doExchange(request, clientResponse);
-			if(isWriteClientBodyToFile(request)){
+			if (isWriteClientBodyToFile(request)) {
 				clearTempFileIfExist(request);
 			}
 			return serverResponse;

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
@@ -59,7 +59,9 @@ public class RestClientProxyExchange extends AbstractProxyExchange {
 		}
 		return requestSpec.exchange((clientRequest, clientResponse) -> {
 			ServerResponse serverResponse = doExchange(request, clientResponse);
-			clearTempFileIfExist(request);
+			if(isWriteClientBodyToFile(request)){
+				clearTempFileIfExist(request);
+			}
 			return serverResponse;
 		}, false);
 	}

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
@@ -16,15 +16,19 @@
 
 package org.springframework.cloud.gateway.server.mvc.handler;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Objects;
 
 import org.springframework.cloud.gateway.server.mvc.common.AbstractProxyExchange;
 import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
 import org.springframework.cloud.gateway.server.mvc.config.GatewayMvcProperties;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.client.RestClient;
@@ -46,9 +50,25 @@ public class RestClientProxyExchange extends AbstractProxyExchange {
 			.uri(request.getUri())
 			.headers(httpHeaders -> httpHeaders.putAll(request.getHeaders()));
 		if (isBodyPresent(request)) {
-			requestSpec.body(outputStream -> copyBody(request, outputStream));
+			if (isWriteClientBodyToFile(request)) {
+				requestSpec.body(copyClientBodyToFile(request));
+			}
+			else {
+				requestSpec.body(outputStream -> copyBody(request, outputStream));
+			}
 		}
-		return requestSpec.exchange((clientRequest, clientResponse) -> doExchange(request, clientResponse), false);
+		return requestSpec.exchange((clientRequest, clientResponse) -> {
+			ServerResponse serverResponse = doExchange(request, clientResponse);
+			clearTempFileIfExist(request);
+			return serverResponse;
+		}, false);
+	}
+
+	private void clearTempFileIfExist(Request request) {
+		File tempFile = MvcUtils.getAttribute(request.getServerRequest(), MvcUtils.CLIENT_BODY_TMP_ATTR);
+		if (tempFile != null && tempFile.exists()) {
+			tempFile.delete();
+		}
 	}
 
 	private static boolean isBodyPresent(Request request) {
@@ -62,6 +82,23 @@ public class RestClientProxyExchange extends AbstractProxyExchange {
 
 	private static int copyBody(Request request, OutputStream outputStream) throws IOException {
 		return StreamUtils.copy(request.getServerRequest().servletRequest().getInputStream(), outputStream);
+	}
+
+	private static FileSystemResource copyClientBodyToFile(Request request) {
+		File bodyTempFile = null;
+		try {
+			// TODO: customize temp dir
+			bodyTempFile = File.createTempFile("gateway_client_body", ".tmp");
+			Files.copy(request.getServerRequest().servletRequest().getInputStream(), bodyTempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+		}
+		catch (IOException e) {
+			if (bodyTempFile != null && bodyTempFile.exists()) {
+				bodyTempFile.delete();
+			}
+			throw new UncheckedIOException(e);
+		}
+		MvcUtils.setBodyTempFile(request.getServerRequest(), bodyTempFile);
+		return new FileSystemResource(bodyTempFile);
 	}
 
 	private ServerResponse doExchange(Request request, ClientHttpResponse clientResponse) throws IOException {

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchange.java
@@ -46,30 +46,38 @@ public class RestClientProxyExchange extends AbstractProxyExchange {
 	@Override
 	public ServerResponse exchange(Request request) {
 		Objects.requireNonNull(request.getUri(), "uri cannot be null");
+		boolean writeClientBodyToFile = false;
 		RestClient.RequestBodySpec requestSpec = restClient.method(request.getMethod())
 			.uri(request.getUri())
 			.headers(httpHeaders -> httpHeaders.putAll(request.getHeaders()));
 		if (isBodyPresent(request)) {
-			if (isWriteClientBodyToFile(request)) {
+			writeClientBodyToFile = isWriteClientBodyToFile(request);
+			if (writeClientBodyToFile) {
 				requestSpec.body(copyClientBodyToFile(request));
 			}
 			else {
 				requestSpec.body(outputStream -> copyBody(request, outputStream));
 			}
 		}
-		return requestSpec.exchange((clientRequest, clientResponse) -> {
-			ServerResponse serverResponse = doExchange(request, clientResponse);
-			if (isWriteClientBodyToFile(request)) {
-				clearTempFileIfExist(request);
+		try {
+			return requestSpec.exchange((clientRequest, clientResponse) -> doExchange(request, clientResponse), false);
+		}
+		finally {
+			if (writeClientBodyToFile) {
+				clearTempFileIfExists(request);
 			}
-			return serverResponse;
-		}, false);
+		}
 	}
 
-	private void clearTempFileIfExist(Request request) {
+	private void clearTempFileIfExists(Request request) {
 		File tempFile = MvcUtils.getAttribute(request.getServerRequest(), MvcUtils.CLIENT_BODY_TMP_ATTR);
-		if (tempFile != null && tempFile.exists()) {
-			tempFile.delete();
+		if (tempFile != null) {
+			try {
+				Files.deleteIfExists(tempFile.toPath());
+			}
+			catch (IOException ignored) {
+				tempFile.deleteOnExit();
+			}
 		}
 	}
 


### PR DESCRIPTION
Add the feature of using temp file as intermediaries when forwarding large requests, which can effectively solve the OOM, and added two configs to control it: 
```
spring.cloud.gateway.mvc.file-buffer-enabled 
spring.cloud.gateway.mvc.file-buffer-size-threshold
```
I'm not sure if this solution is appropriate. It may cause some large requests to be slowed down.But I don’t have any other ideas at the moment. This is the solution our team uses. In addition, should the default value of file-buffer-enabled be true?