### PR TITLE
Support rewriting request parameters in mvc

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2013-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.server.mvc.filter;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.servlet.function.ServerRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author raccoonback
+ */
+class BeforeFilterFunctionsTests {
+
+	@Test
+	void rewriteRequestParameter() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo", "bar")
+			.param("baz", "qux")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz=qux&foo=replacement");
+	}
+
+	@Test
+	void rewriteOnlyFirstRequestParameter() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo", "bar_1")
+			.param("foo", "bar_2")
+			.param("foo", "bar_3")
+			.param("baz", "qux")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz=qux&foo=replacement");
+	}
+
+	@Test
+	void rewriteEncodedRequestParameter() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo[]", "bar")
+			.param("baz", "qux")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo[]", "replacement[]").apply(request);
+
+		assertThat(result.param("foo[]")).isPresent().hasValue("replacement[]");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz=qux&foo%5B%5D=replacement%5B%5D");
+	}
+
+	@Test
+	void rewriteRequestParameterWithEncodedRemainParameters() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path")
+			.param("foo", "bar")
+			.param("baz[]", "qux[]")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path?baz%5B%5D=qux%5B%5D&foo=replacement");
+	}
+
+	@Test
+	void rewriteRequestParameterWithEncodedPath() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/path/é/last")
+			.param("foo", "bar")
+			.buildRequest(null);
+
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ServerRequest result = BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);
+
+		assertThat(result.param("foo")).isPresent().hasValue("replacement");
+		assertThat(result.uri().toString()).hasToString("http://localhost/path/%C3%A9/last?foo=replacement");
+	}
+
+}


### PR DESCRIPTION
## Pull Request Description
Hello,

Currently, **Spring Cloud Gateway** provides a feature to replace HTTP Request Query Parameters through [`RewriteRequestParameterGatewayFilterFactory`](https://github.com/spring-cloud/spring-cloud-gateway/blob/main/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/RewriteRequestParameterGatewayFilterFactory.java).
This Pull Request introduces the same functionality in **spring-cloud-gateway-server-mvc**, enabling developers to easily modify or replace Query Parameters in the MVC environment.

### Motivation
the `rewriteRequestParameter` function provides a simple and concise way to modify Query Parameters, as shown below:

```java
// Request URI: http://localhost/path?foo=bar

-> BeforeFilterFunctions.rewriteRequestParameter("foo", "replacement").apply(request);

// ServerRequest URI result: http://localhost/path?foo=replacement

```

This approach consolidates the process of replacing a Query Parameter into a single method call, improving code clarity and reducing boilerplate.

### Current Limitation 

Currently, achieving the same result in the MVC environment requires two separate operations: **removing** and then **adding** the Query Parameter:

```java
// Request URI: http://localhost/path?foo=bar

-> ServerRequest result = BeforeFilterFunctions.removeRequestParameter("foo")
                .andThen(BeforeFilterFunctions.addRequestParameter("foo", "replacement"))
                .apply(request);

// ServerRequest URI result: http://localhost/path?foo=replacement

```

### Proposed Solution
By introducing the `rewriteRequestParameter` method in MVC, developers can seamlessly handle both the **removal** and **addition** of Query Parameters in a single operation. This enhancement will:

- Simplify code by reducing multi-step operations to a single method call.
- Improve maintainability and readability for Query Parameter modification logic.

I look forward to your feedback and suggestions on this improvement. 
Thanks!

