### PR TITLE
Fix UnsupportedOperationException for duplicate keys in AddRequestHeader with ModifyRequestBody

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyRequestBodyGatewayFilterFactory.java
@@ -75,7 +75,7 @@ public class ModifyRequestBodyGatewayFilterFactory
 
 				BodyInserter bodyInserter = BodyInserters.fromPublisher(modifiedBody, config.getOutClass());
 				HttpHeaders headers = new HttpHeaders();
-				headers.putAll(exchange.getRequest().getHeaders());
+				headers.addAll(exchange.getRequest().getHeaders());
 
 				// the new content type will be computed by bodyInserter
 				// and then set in the request decorator


### PR DESCRIPTION
Hi @spencergibb,

I recently discovered an issue when using `ModifyRequestBodyGatewayFilterFactory` and `AddRequestHeaderGatewayFilterFactory` together. If `ModifyRequestBody` is executed first, the header value will be a `List` of type `unmodifiable`. If `AddRequestHeader` then tries to add a key that already exists, it will throw an `UnsupportedOperationException`.

I tried modifying putAll to addAll in ModifyRequestBodyGatewayFilterFactory, and this is likely to resolve the issue.