### PR TITLE
Refactor header appending logic for better readability

### DIFF
--- a/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
+++ b/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR refactors the logic for adding headers in the `appendXForwarded` and `appendForwarded` methods.

Additionally
upon reviewing both the original and refactored code, I noticed that in `appendXForwarded`, the result of `headers.getFirst()` is **only checked for null**. 
Wouldn't it be better to use **StringUtils.hasText()** instead, to ensure not only that the value is non-null but also that it contains text? What do you think about this approach?