### PR TITLE
ensure generateId executes on the scheduler thread specified by publishOn

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/CompositeRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/CompositeRouteDefinitionLocator.java
@@ -65,7 +65,7 @@ public class CompositeRouteDefinitionLocator implements RouteDefinitionLocator {
 	}
 
 	protected Mono<String> randomId() {
-		return Mono.fromSupplier(idGenerator::generateId).map(UUID::toString).publishOn(Schedulers.boundedElastic());
+		return Mono.fromSupplier(idGenerator::generateId).publishOn(Schedulers.boundedElastic()).map(UUID::toString);
 	}
 
 }


### PR DESCRIPTION
Hello @spencergibb, I recently came across this code, which is intended to prevent the execution of `uuid generate` on the main thread. However, after applying the `map` function, the publisher returned by `publishOn` is no longer a `MonoSubscribeOnCallable`, but rather a `MonoPublishOn`. As a result, the first execution of `idGenerator::generateId` actually still occurs on the thread that subscribes to it.
https://github.com/spring-cloud/spring-cloud-gateway/blob/0affb76a1ac4be209c2c47d3c435dfe66d4fc6fe/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/route/CompositeRouteDefinitionLocator.java#L67-L69