### PR TITLE
Fix keyStore bug in GatewayAutoConfiguration

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -16,9 +16,11 @@
 
 package org.springframework.cloud.gateway.config;
 
+import java.io.IOException;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -359,10 +361,12 @@ public class GatewayAutoConfiguration {
 	@ConditionalOnMissingBean(GrpcSslConfigurer.class)
 	@ConditionalOnClass(name = "io.grpc.Channel")
 	public GrpcSslConfigurer grpcSslConfigurer(HttpClientProperties properties, SslBundles bundles)
-			throws KeyStoreException, NoSuchAlgorithmException {
+			throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
 		TrustManagerFactory trustManagerFactory = TrustManagerFactory
 			.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-		trustManagerFactory.init(KeyStore.getInstance(KeyStore.getDefaultType()));
+		KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
+		keyStore.load(null);
+		trustManagerFactory.init(keyStore);
 
 		return new GrpcSslConfigurer(properties.getSsl(), bundles);
 	}


### PR DESCRIPTION
Fixes  `java.security.KeyStoreException: Uninitialized keystore.`
Per JDK documentation keystore should be initialized before use.

[JDK 21 Javadoc](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/KeyStore.html#load(java.io.InputStream,char%5B%5D))

`Before a keystore can be accessed, it must be loaded (unless it was already loaded during instantiation).

    KeyStore ks = KeyStore.getInstance(KeyStore.getDefaultType());

    // get user password and file input stream
    char[] password = getPassword();

    try (FileInputStream fis = new FileInputStream("keyStoreName")) {
        ks.load(fis, password);
    }
 
To create an empty keystore using the above load method, pass null as the InputStream argument.`

We noticed this behavior on BouncyCastle crypto provider, but standard JDK implementation just [ignores](https://github.com/openjdk/jdk/blob/5cd4fe63768715ec7be32e248e05e611ea9b557d/src/java.base/share/classes/sun/security/validator/TrustStoreUtil.java#L72) that exception.

`Caused by: java.security.KeyStoreException: Uninitialized keystore
	at java.base/java.security.KeyStore.aliases(Unknown Source)
	at org.bouncycastle.fips.tls/org.bouncycastle.jsse.provider.ProvTrustManagerFactorySpi.getTrustAnchors(ProvTrustManagerFactorySpi.java:249)
	at org.bouncycastle.fips.tls/org.bouncycastle.jsse.provider.ProvTrustManagerFactorySpi.engineInit(ProvTrustManagerFactorySpi.java:186)
	at java.base/javax.net.ssl.TrustManagerFactory.init(Unknown Source)
	at org.springframework.cloud.gateway.config.GatewayAutoConfiguration.grpcSslConfigurer(GatewayAutoConfiguration.java:360)`