### PR TITLE
Fix punctuation error in secureheaders-factory.adoc

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/secureheaders-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/secureheaders-factory.adoc
@@ -10,7 +10,7 @@ The following headers (shown with their default values) are added:
 * `X-Frame-Options (DENY)`
 * `X-Content-Type-Options (nosniff)`
 * `Referrer-Policy (no-referrer)`
-* `Content-Security-Policy (default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline)'`
+* `Content-Security-Policy (default-src 'self' https:; font-src 'self' https: data:; img-src 'self' https: data:; object-src 'none'; script-src https:; style-src 'self' https: 'unsafe-inline')`
 * `X-Download-Options (noopen)`
 * `X-Permitted-Cross-Domain-Policies (none)`
 


### PR DESCRIPTION
This commit addresses a minor punctuation error found in secureheaders-factory.adoc. 