### PR TITLE
prevent NullPointerException when pattern is null

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/predicate/GatewayRequestPredicates.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/predicate/GatewayRequestPredicates.java
@@ -272,7 +272,12 @@ public abstract class GatewayRequestPredicates {
 
 		@Override
 		public void accept(RequestPredicates.Visitor visitor) {
-			visitor.header(name, pattern.pattern());
+			if (pattern != null) {
+				visitor.header(name, pattern.pattern());
+			}
+			else {
+				visitor.header(name, "");
+			}
 		}
 
 		@Override


### PR DESCRIPTION
If CookieRequestPredicate#pattern be null then it causes NullPointerException