### PR TITLE
fix checkstyle

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java
@@ -25,8 +25,8 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Maps;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -200,7 +200,7 @@ public class GatewayControllerEndpointTests {
 			.expectBody(ResponseEntity.class)
 			.consumeWith(result -> {
 				HttpStatusCode httpStatus = result.getStatus();
-				Assertions.assertEquals(HttpStatus.OK, httpStatus);
+				Assertions.assertThat(httpStatus).isEqualTo(HttpStatus.OK);
 			});
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.gateway.filter;
 
 import java.net.URI;
 
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Mono;
@@ -64,7 +64,7 @@ public class RouteToRequestUrlFilterTests {
 
 	@Test
 	public void invalidHost() {
-		Assertions.assertThrows(IllegalStateException.class, () -> {
+		Assertions.catchThrowableOfType(IllegalStateException.class, () -> {
 			MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost/getb").build();
 			testFilter(request, "lb://my_host");
 		});

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterUnitTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterUnitTests.java
@@ -17,8 +17,8 @@
 package org.springframework.cloud.gateway.filter.ratelimit;
 
 import io.lettuce.core.RedisException;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -78,7 +78,8 @@ public class RedisRateLimiterUnitTests {
 
 	@Test
 	public void shouldThrowWhenNotInitialized() {
-		Assertions.assertThrows(IllegalStateException.class, () -> redisRateLimiter.isAllowed(ROUTE_ID, REQUEST_ID));
+		Assertions.catchThrowableOfType(IllegalStateException.class,
+				() -> redisRateLimiter.isAllowed(ROUTE_ID, REQUEST_ID));
 	}
 
 	@Test

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/AsyncPredicateTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/AsyncPredicateTest.java
@@ -18,7 +18,7 @@ package org.springframework.cloud.gateway.handler;
 
 import java.util.function.Predicate;
 
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
@@ -110,12 +110,12 @@ public class AsyncPredicateTest {
 
 		@DisplayName("predicate must have been tested")
 		public void assertTested() {
-			Assertions.assertTrue(tested);
+			Assertions.assertThat(tested).isTrue();
 		}
 
 		@DisplayName("predicate must not have been tested")
 		public void assertUntested() {
-			Assertions.assertFalse(tested);
+			Assertions.assertThat(tested).isFalse();
 		}
 
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gateway.handler;
 
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
@@ -57,8 +57,9 @@ public class RoutePredicateHandlerMappingTests {
 		final Mono<Route> routeMono = mapping.lookupRoute(Mockito.mock(ServerWebExchange.class));
 
 		StepVerifier.create(routeMono.map(Route::getId)).expectNext("routeTrue").verifyComplete();
-		Assertions.assertTrue(capturedOutput.getOut().contains("Error applying predicate for route: routeFail"));
-		Assertions.assertTrue(capturedOutput.getOut().contains("java.lang.IllegalStateException: boom"));
+		Assertions.assertThat(capturedOutput.getOut().contains("Error applying predicate for route: routeFail"))
+			.isTrue();
+		Assertions.assertThat(capturedOutput.getOut().contains("java.lang.IllegalStateException: boom")).isTrue();
 	}
 
 	@Test
@@ -89,11 +90,13 @@ public class RoutePredicateHandlerMappingTests {
 
 		StepVerifier.create(routeMono.map(Route::getId)).expectNext("routeTrue").verifyComplete();
 
-		Assertions.assertTrue(capturedOutput.getOut().contains("Error applying predicate for route: routeError"));
-		Assertions.assertTrue(capturedOutput.getOut().contains("java.lang.IllegalStateException: boom1"));
+		Assertions.assertThat(capturedOutput.getOut().contains("Error applying predicate for route: routeError"))
+			.isTrue();
+		Assertions.assertThat(capturedOutput.getOut().contains("java.lang.IllegalStateException: boom1")).isTrue();
 
-		Assertions.assertTrue(capturedOutput.getOut().contains("Error applying predicate for route: routeFail"));
-		Assertions.assertTrue(capturedOutput.getOut().contains("java.lang.IllegalStateException: boom2"));
+		Assertions.assertThat(capturedOutput.getOut().contains("Error applying predicate for route: routeFail"))
+			.isTrue();
+		Assertions.assertThat(capturedOutput.getOut().contains("java.lang.IllegalStateException: boom2")).isTrue();
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/ConfigurationServiceTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/ConfigurationServiceTests.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import jakarta.validation.constraints.Max;
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.context.properties.bind.BindException;
@@ -37,7 +37,7 @@ public class ConfigurationServiceTests {
 	public void validationOnCreateWorks() {
 		Map<String, Object> map = Collections.singletonMap("config.value", 11);
 
-		Assertions.assertThrows(BindException.class, () -> ConfigurationService
+		Assertions.catchThrowableOfType(BindException.class, () -> ConfigurationService
 			.bindOrCreate(Bindable.of(ValidatedConfig.class), map, "config", getValidator(), null));
 	}
 
@@ -57,7 +57,7 @@ public class ConfigurationServiceTests {
 
 		ValidatedConfig config = new ValidatedConfig();
 
-		Assertions.assertThrows(BindException.class, () -> ConfigurationService
+		Assertions.catchThrowableOfType(BindException.class, () -> ConfigurationService
 			.bindOrCreate(Bindable.ofInstance(config), map, "config", getValidator(), null));
 
 	}

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/CustomBlockHoundIntegrationTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/CustomBlockHoundIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.gateway.test;
 
-import org.junit.jupiter.api.Assertions;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
@@ -34,7 +34,7 @@ public class CustomBlockHoundIntegrationTest {
 	// Disable this test for now flaky on GitHub Actions
 	@Disabled
 	public void shouldThrowErrorForBlockingCallWithCustomBlockHoundIntegration() {
-		Assertions.assertThrows(RuntimeException.class, () -> Mono.fromCallable(() -> {
+		Assertions.catchThrowableOfType(RuntimeException.class, () -> Mono.fromCallable(() -> {
 			Thread.sleep(1);
 			return null;
 		}).subscribeOn(Schedulers.parallel()).block());


### PR DESCRIPTION
```
[INFO] --- checkstyle:3.6.0:check (checkstyle-validation) @ spring-cloud-gateway-server ---
[INFO] Starting audit...
Error:  /home/runner/work/spring-cloud-gateway/spring-cloud-gateway/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/actuate/GatewayControllerEndpointTests.java:29: Please use AssertJ imports. [RegexpSinglelineJava]
Error:  /home/runner/work/spring-cloud-gateway/spring-cloud-gateway/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMappingTests.java:19: Please use AssertJ imports. [RegexpSinglelineJava]
Error:  /home/runner/work/spring-cloud-gateway/spring-cloud-gateway/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/handler/AsyncPredicateTest.java:21: Please use AssertJ imports. [RegexpSinglelineJava]
Error:  /home/runner/work/spring-cloud-gateway/spring-cloud-gateway/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/support/ConfigurationServiceTests.java:23: Please use AssertJ imports. [RegexpSinglelineJava]
Error:  /home/runner/work/spring-cloud-gateway/spring-cloud-gateway/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterUnitTests.java:21: Please use AssertJ imports. [RegexpSinglelineJava]
Error:  /home/runner/work/spring-cloud-gateway/spring-cloud-gateway/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/RouteToRequestUrlFilterTests.java:21: Please use AssertJ imports. [RegexpSinglelineJava]
Error:  /home/runner/work/spring-cloud-gateway/spring-cloud-gateway/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/test/CustomBlockHoundIntegrationTest.java:19: Please use AssertJ imports. [RegexpSinglelineJava]
```