### PR TITLE
Support sharding in RedisRateLimiter 

### DIFF
--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -193,7 +193,7 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 	@Test
 	public void keysUseRedisKeyHashTagsWithShard() {
 		assertThat(RedisRateLimiter.getKeys("1", "routeId", "13")).containsExactly(
-				"request_rate_limiter.{1.routeId.13}.tokens", "request_rate_limiter.{1.routeId.13}.timestamp");
+				"request_rate_limiter.{routeId.1.13}.tokens", "request_rate_limiter.{routeId.1.13}.timestamp");
 	}
 
 	@Test

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -106,17 +106,17 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 		String id = UUID.randomUUID().toString();
 
 		int shard = 3;
-		int replenishRate = 10*shard;
+		int replenishRate = 10 * shard;
 		int burstCapacity = 2 * replenishRate;
 		int requestedTokens = 1;
 
 		String routeId = "myroute";
 		rateLimiter.getConfig()
-				.put(routeId,
-						new RedisRateLimiter.Config().setBurstCapacity(burstCapacity)
-								.setReplenishRate(replenishRate)
-								.setRequestedTokens(requestedTokens)
-								.setShards(shard));
+			.put(routeId,
+					new RedisRateLimiter.Config().setBurstCapacity(burstCapacity)
+						.setReplenishRate(replenishRate)
+						.setRequestedTokens(requestedTokens)
+						.setShards(shard));
 
 		checkLimitEnforced(id, replenishRate, burstCapacity, requestedTokens, routeId);
 	}
@@ -186,8 +186,8 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 
 	@Test
 	public void keysUseRedisKeyHashTags() {
-		assertThat(RedisRateLimiter.getKeys("1", "routeId", null)).containsExactly("request_rate_limiter.{routeId.1}.tokens",
-				"request_rate_limiter.{routeId.1}.timestamp");
+		assertThat(RedisRateLimiter.getKeys("1", "routeId", null))
+			.containsExactly("request_rate_limiter.{routeId.1}.tokens", "request_rate_limiter.{routeId.1}.timestamp");
 	}
 
 	@Test
@@ -203,7 +203,7 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 		for (int i = 0; i < 100; i++) {
 			String shard = rateLimiter.getShard(shards);
 			assertThat(shard).isNotNull();
-			assertThat(shard).isEqualTo(String.valueOf(i%shards));
+			assertThat(shard).isEqualTo(String.valueOf(i % shards));
 		}
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/ratelimit/RedisRateLimiterTests.java
@@ -53,6 +53,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  * @author Ronny Bräunlich
  * @author Denis Cutic
  * @author Andrey Muchnik
+ * @author Fangzhou Liu
  */
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = { "spring.cloud.gateway.function.enabled=false" })
 @DirtiesContext
@@ -165,8 +166,8 @@ public class RedisRateLimiterTests extends BaseWebClientTests {
 
 	@Test
 	public void keysUseRedisKeyHashTags() {
-		assertThat(RedisRateLimiter.getKeys("1", "routeId")).containsExactly("request_rate_limiter.{routeId.1}.tokens",
-				"request_rate_limiter.{routeId.1}.timestamp");
+		assertThat(RedisRateLimiter.getKeys("1", "routeId", null))
+			.containsExactly("request_rate_limiter.{routeId.1}.tokens", "request_rate_limiter.{routeId.1}.timestamp");
 	}
 
 	@Test


### PR DESCRIPTION
Problem Statement:​​
The current implementation of RedisRateLimiter uses a single Redis key for rate limiting counters.  This leads to a hot key problem in Redis clusters, where massive requests concentrate on a single Redis shard.  The resulting excessive load on individual shards cannot be alleviated through horizontal cluster scaling, creating a performance bottleneck.

​​Proposed Solution:​​
This PR introduces a shards configuration parameter to address the hot key issue.  Key enhancements include:

- Sharded Key Generation:​​ Splits the rate limiting counter into multiple Redis keys using configurable shards
- ​​Load Balancing:​​ Implements round-robin distribution to evenly balance requests across shards
- ​​Cluster Scalability:​​ Enables true horizontal scaling of Redis clusters by eliminating single-shard pressure