### PR TITLE
Preserve original encoding of query parameters in `ProxyExchangeHandlerFunction`

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,11 +41,14 @@ import org.springframework.http.HttpInputMessage;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.util.StreamUtils;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.servlet.support.RequestContextUtils;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 import static org.springframework.web.servlet.function.RouterFunctions.URI_TEMPLATE_VARIABLES_ATTRIBUTE;
 
@@ -261,6 +265,17 @@ public abstract class MvcUtils {
 		LinkedHashSet<URI> urls = (LinkedHashSet<URI>) request.attributes()
 			.computeIfAbsent(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, s -> new LinkedHashSet<>());
 		urls.add(url);
+	}
+
+	public static MultiValueMap<String, String> encodeQueryParams(MultiValueMap<String, String> params) {
+		MultiValueMap<String, String> encodedQueryParams = new LinkedMultiValueMap<>(params.size());
+		for (Map.Entry<String, List<String>> entry : params.entrySet()) {
+			for (String value : entry.getValue()) {
+				encodedQueryParams.add(UriUtils.encode(entry.getKey(), StandardCharsets.UTF_8),
+						UriUtils.encode(value, StandardCharsets.UTF_8));
+			}
+		}
+		return CollectionUtils.unmodifiableMultiValueMap(encodedQueryParams);
 	}
 
 	private record ByteArrayInputMessage(ServerRequest request, ByteArrayInputStream body) implements HttpInputMessage {

--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunction.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunction.java
@@ -36,7 +36,6 @@ import org.springframework.web.servlet.function.HandlerFunction;
 import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.servlet.function.ServerResponse;
 import org.springframework.web.util.UriComponentsBuilder;
-import org.springframework.web.util.UriUtils;
 
 /**
  * @author raccoonback
@@ -139,7 +138,7 @@ public class ProxyExchangeHandlerFunction
 		boolean encoded = containsEncodedQuery(serverRequest.uri(), serverRequest.params());
 		MultiValueMap<String, String> params = serverRequest.params();
 		if (!encoded) {
-			params = UriUtils.encodeQueryParams(serverRequest.params());
+			params = MvcUtils.encodeQueryParams(serverRequest.params());
 		}
 		return params;
 	}

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunctionTest.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunctionTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2025-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.server.mvc.handler;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.gateway.server.mvc.common.AbstractProxyExchange;
+import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
+import org.springframework.cloud.gateway.server.mvc.config.GatewayMvcProperties;
+import org.springframework.cloud.gateway.server.mvc.filter.HttpHeadersFilter.RequestHttpHeadersFilter;
+import org.springframework.cloud.gateway.server.mvc.filter.HttpHeadersFilter.ResponseHttpHeadersFilter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author raccoonback
+ */
+class ProxyExchangeHandlerFunctionTest {
+
+	@Test
+	void keepOriginalEncodingOfQueryParameter() {
+		TestProxyExchange proxyExchange = new TestProxyExchange();
+		ProxyExchangeHandlerFunction function = new ProxyExchangeHandlerFunction(proxyExchange, new ObjectProvider<>() {
+			@Override
+			public Stream<RequestHttpHeadersFilter> stream() {
+				return Stream.of((httpHeaders, serverRequest) -> new HttpHeaders());
+			}
+		}, new ObjectProvider<>() {
+			@Override
+			public Stream<ResponseHttpHeadersFilter> stream() {
+				return Stream.of((httpHeaders, serverRequest) -> new HttpHeaders());
+			}
+		});
+
+		function.onApplicationEvent(null);
+
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders
+			.get("http://localhost/é?foo=value1 value2&bar=value3=")
+			.buildRequest(null);
+		servletRequest.setAttribute(MvcUtils.GATEWAY_REQUEST_URL_ATTR, URI.create("http://localhost:8080"));
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		function.handle(request);
+
+		URI uri = proxyExchange.getRequest().getUri();
+
+		assertThat(uri).hasToString("http://localhost:8080/%C3%A9?foo=value1%20value2&bar=value3%3D")
+			.hasPath("/é")
+			.hasParameter("foo", "value1 value2")
+			.hasParameter("bar", "value3=");
+	}
+
+	private class TestProxyExchange extends AbstractProxyExchange {
+
+		private Request request;
+
+		protected TestProxyExchange() {
+			super(new GatewayMvcProperties());
+		}
+
+		@Override
+		public ServerResponse exchange(Request request) {
+			this.request = request;
+
+			return ServerResponse.ok().build();
+		}
+
+		public Request getRequest() {
+			return request;
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunctionTest.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunctionTest.java
@@ -22,6 +22,7 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.cloud.gateway.server.mvc.common.AbstractProxyExchange;
 import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
@@ -46,13 +47,56 @@ class ProxyExchangeHandlerFunctionTest {
 		TestProxyExchange proxyExchange = new TestProxyExchange();
 		ProxyExchangeHandlerFunction function = new ProxyExchangeHandlerFunction(proxyExchange, new ObjectProvider<>() {
 			@Override
-			public Stream<RequestHttpHeadersFilter> stream() {
+			public RequestHttpHeadersFilter getObject() throws BeansException {
+				return null;
+			}
+
+			@Override
+			public RequestHttpHeadersFilter getObject(Object... args) throws BeansException {
+				return null;
+			}
+
+			@Override
+			public RequestHttpHeadersFilter getIfAvailable() throws BeansException {
+				return null;
+			}
+
+			@Override
+			public RequestHttpHeadersFilter getIfUnique() throws BeansException {
+				return null;
+			}
+
+			@Override
+			public Stream<RequestHttpHeadersFilter> orderedStream() {
 				return Stream.of((httpHeaders, serverRequest) -> new HttpHeaders());
 			}
+
 		}, new ObjectProvider<>() {
+
 			@Override
-			public Stream<ResponseHttpHeadersFilter> stream() {
+			public ResponseHttpHeadersFilter getObject() throws BeansException {
+				return null;
+			}
+
+			@Override
+			public ResponseHttpHeadersFilter getObject(Object... args) throws BeansException {
+				return null;
+			}
+
+			@Override
+			public ResponseHttpHeadersFilter getIfAvailable() throws BeansException {
+				return null;
+			}
+
+			@Override
+			public ResponseHttpHeadersFilter getIfUnique() throws BeansException {
+				return null;
+			}
+
+			@Override
+			public Stream<ResponseHttpHeadersFilter> orderedStream() {
 				return Stream.of((httpHeaders, serverRequest) -> new HttpHeaders());
+
 			}
 		});
 

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunctionTest.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunctionTest.java
@@ -103,7 +103,7 @@ class ProxyExchangeHandlerFunctionTest {
 		function.onApplicationEvent(null);
 
 		MockHttpServletRequest servletRequest = MockMvcRequestBuilders
-			.get("http://localhost/é?foo=value1 value2&bar=value3=")
+			.get("http://localhost/é?foo=value1 value2&bar=value3=&qux=value4+")
 			.buildRequest(null);
 		servletRequest.setAttribute(MvcUtils.GATEWAY_REQUEST_URL_ATTR, URI.create("http://localhost:8080"));
 		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
@@ -112,10 +112,11 @@ class ProxyExchangeHandlerFunctionTest {
 
 		URI uri = proxyExchange.getRequest().getUri();
 
-		assertThat(uri).hasToString("http://localhost:8080/%C3%A9?foo=value1%20value2&bar=value3%3D")
+		assertThat(uri).hasToString("http://localhost:8080/%C3%A9?foo=value1%20value2&bar=value3%3D&qux=value4%2B")
 			.hasPath("/é")
 			.hasParameter("foo", "value1 value2")
-			.hasParameter("bar", "value3=");
+			.hasParameter("bar", "value3=")
+			.hasParameter("qux", "value4+");
 	}
 
 	private class TestProxyExchange extends AbstractProxyExchange {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterTests.java
@@ -113,7 +113,8 @@ class NettyRoutingFilterTests extends BaseWebClientTests {
 		this.context.publishEvent(new EnvironmentChangeEvent(this.context,
 				Collections.singleton("spring.cloud.gateway.httpclient.connect-timeout")));
 		Route route = routeLocator.getRoutes()
-				.filter(r -> r.getId().equals("refreshable_configuration_test")).blockLast();
+			.filter(r -> r.getId().equals("refreshable_configuration_test"))
+			.blockLast();
 		assertThat(route).isNotNull();
 		HttpClient httpClient = nettyRoutingFilter.getHttpClient(route, null);
 		HttpClientConfig configuration = httpClient.configuration();


### PR DESCRIPTION
## Description
This PR improves `ProxyExchangeHandlerFunction` to ensure that the original encoding of query parameters is preserved when proxying requests.

The return value of `ServerRequest.params()` is already decoded, so reconstructing the query using it results in the loss of the original encoding information.
To preserve the original encoded state, this PR removes the unnecessary query parameter replacement performed in `ProxyExchangeHandlerFunction.handle()`.


For example.
```
[AS-IS]
"http://localhost/path?foo=A&bar=B%3D" -> "http://localhost/path?foo=A&bar=B="

[TO-BE]
"http://localhost/path?foo=A&bar=B%3D" -> "http://localhost/path?foo=A&bar=B%3D"
```

## Related issue
- https://github.com/spring-cloud/spring-cloud-gateway/issues/3759