### PR TITLE
Fix '+' character in query parameters is not encoded when rewrite query parameter in mvc

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctions.java
@@ -351,7 +351,7 @@ public abstract class BeforeFilterFunctions {
 				queryParams.add(name, replacement);
 			}
 
-			MultiValueMap<String, String> encodedQueryParams = UriUtils.encodeQueryParams(queryParams);
+			MultiValueMap<String, String> encodedQueryParams = MvcUtils.encodeQueryParams(queryParams);
 			URI rewrittenUri = UriComponentsBuilder.fromUri(request.uri())
 				.replaceQueryParams(unmodifiableMultiValueMap(encodedQueryParams))
 				.build(true)


### PR DESCRIPTION
## Description

When a '+' character is included in an HTTP query parameter, it is currently interpreted as a space in cases where the `BeforeFilterFunctions.rewriteRequestParameter()` is applied. This may result in the parameter being misinterpreted on the server side compared to its original intent.

In this PR, we have applied precise encoding based on `StandardCharsets.UTF_8` or replaced the use of `UriUtils.encodeQueryParams()` with a `MvcUtils.encodeQueryParams()` custom utility to ensure that the '+' character is correctly encoded as %2B.

Changes:
- Replacing '+' with '%2B' after standard encoding
- Added corresponding unit test


(The `BeforeFilterFunctions.rewriteRequestParameter()` method is only present in the `main` branch.)


For example.

[AS-IS]
"http://localhost/path?foo=A&bar=B%2B" -> "http://localhost/path?foo=A&bar=B= " (The value of the `'B'` query parameter is encoded as a **space**.)

[TO-BE]
"http://localhost/path?foo=A&bar=B%2B" -> "http://localhost/path?foo=A&bar=B%2B"