### PR TITLE
Add enable options to keygenerator (#3429)

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gateway.config;
 
+import java.util.List;
+
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
 import org.apache.commons.logging.Log;
@@ -36,6 +38,10 @@ import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCache
 import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheUtils;
 import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheManagerFactory;
 import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CacheKeyGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CookiesKeyValueGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.HeaderKeyValueGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.KeyValueGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.UriKeyValueGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -85,8 +91,25 @@ public class LocalResponseCacheAutoConfiguration {
 	}
 
 	@Bean
-	public CacheKeyGenerator cacheKeyGenerator() {
-		return new CacheKeyGenerator();
+	public UriKeyValueGenerator uriKeyValueGenerator(LocalResponseCacheProperties cacheProperties) {
+		return new UriKeyValueGenerator(cacheProperties.getEnableUriKeyGenerator());
+	}
+
+	@Bean
+	public HeaderKeyValueGenerator headerKeyValueGenerator(LocalResponseCacheProperties cacheProperties) {
+		return new HeaderKeyValueGenerator(cacheProperties.getEnableHeaderKeyGenerator(), "Authorization", ";");
+	}
+
+	@Bean
+	public CookiesKeyValueGenerator cookiesKeyValueGenerator(LocalResponseCacheProperties cacheProperties) {
+		return new CookiesKeyValueGenerator(cacheProperties.getEnableCookiesKeyGenerator(), ";");
+	}
+
+	@Bean
+	public CacheKeyGenerator cacheKeyGenerator(UriKeyValueGenerator uriGenerator,
+			HeaderKeyValueGenerator headerGenerator, CookiesKeyValueGenerator cookiesGenerator) {
+		List<KeyValueGenerator> defaultGenerators = List.of(uriGenerator, headerGenerator, cookiesGenerator);
+		return new CacheKeyGenerator(defaultGenerators);
 	}
 
 	/**

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheProperties.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheProperties.java
@@ -42,6 +42,12 @@ public class LocalResponseCacheProperties {
 
 	private RequestOptions request = new RequestOptions();
 
+	private boolean enableCookiesKeyGenerator = true;
+
+	private boolean enableHeaderKeyGenerator = true;
+
+	private boolean enableUriKeyGenerator = true;
+
 	public DataSize getSize() {
 		return size;
 	}
@@ -74,10 +80,35 @@ public class LocalResponseCacheProperties {
 		this.request = request;
 	}
 
+	public boolean getEnableCookiesKeyGenerator() {
+		return enableCookiesKeyGenerator;
+	}
+
+	public void setEnableCookiesKeyGenerator(boolean enableCookiesKeyGenerator) {
+		this.enableCookiesKeyGenerator = enableCookiesKeyGenerator;
+	}
+
+	public boolean getEnableHeaderKeyGenerator() {
+		return enableHeaderKeyGenerator;
+	}
+
+	public void setEnableHeaderKeyGenerator(boolean enableHeaderKeyGenerator) {
+		this.enableHeaderKeyGenerator = enableHeaderKeyGenerator;
+	}
+
+	public boolean getEnableUriKeyGenerator() {
+		return enableUriKeyGenerator;
+	}
+
+	public void setEnableUriKeyGenerator(boolean enableUriKeyGenerator) {
+		this.enableUriKeyGenerator = enableUriKeyGenerator;
+	}
+
 	@Override
 	public String toString() {
 		return "LocalResponseCacheProperties{" + "size=" + size + ", timeToLive=" + timeToLive + ", request=" + request
-				+ '}';
+				+ ", enableCookiesKeyGenerator=" + enableCookiesKeyGenerator + ", enableHeaderKeyGenerator="
+				+ enableHeaderKeyGenerator + ", enableUriKeyGenerator=" + enableUriKeyGenerator + '}';
 	}
 
 	public static class RequestOptions {

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/CacheKeyGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/CacheKeyGenerator.java
@@ -32,6 +32,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
  * @author Marta Medio
  * @author Ignacio Lozano
  * @author Simone Gerevini
+ * @author Dong Hyeon Lee
  */
 public class CacheKeyGenerator {
 
@@ -80,7 +81,7 @@ public class CacheKeyGenerator {
 		Stream<KeyValueGenerator> keyValueGenerators = getKeyValueGenerators(varyHeaders);
 
 		final ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
-		keyValueGenerators.map(generator -> generator.apply(request)).map(String::getBytes).forEach(bytes -> {
+		keyValueGenerators.filter(KeyValueGenerator::isEnabled).map(generator -> generator.apply(request)).map(String::getBytes).forEach(bytes -> {
 			byteOutputStream.writeBytes(bytes);
 			byteOutputStream.writeBytes(KEY_SEPARATOR_BYTES);
 		});

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/CookiesKeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/CookiesKeyValueGenerator.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.HttpCookie;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.CollectionUtils;
@@ -28,10 +29,14 @@ import org.springframework.util.MultiValueMap;
 /**
  * @author Marta Medio
  * @author Ignacio Lozano
+ * @author Dong Hyeon Lee
  */
+@ConfigurationProperties("spring.cloud.gateway.server.webflux.cookies")
 class CookiesKeyValueGenerator implements KeyValueGenerator {
 
 	private final String valueSeparator;
+
+	private boolean enabled = true;
 
 	CookiesKeyValueGenerator(String valueSeparator) {
 		this.valueSeparator = Objects.requireNonNull(valueSeparator);
@@ -49,6 +54,16 @@ class CookiesKeyValueGenerator implements KeyValueGenerator {
 				.collect(Collectors.joining(valueSeparator));
 		}
 		return cookiesData;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
 	}
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/CookiesKeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/CookiesKeyValueGenerator.java
@@ -20,7 +20,6 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.HttpCookie;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.CollectionUtils;
@@ -31,14 +30,14 @@ import org.springframework.util.MultiValueMap;
  * @author Ignacio Lozano
  * @author Dong Hyeon Lee
  */
-@ConfigurationProperties("spring.cloud.gateway.server.webflux.cookies")
-class CookiesKeyValueGenerator implements KeyValueGenerator {
+public class CookiesKeyValueGenerator implements KeyValueGenerator {
 
 	private final String valueSeparator;
 
 	private boolean enabled = true;
 
-	CookiesKeyValueGenerator(String valueSeparator) {
+	public CookiesKeyValueGenerator(boolean enabled, String valueSeparator) {
+		this.enabled = enabled;
 		this.valueSeparator = Objects.requireNonNull(valueSeparator);
 	}
 
@@ -65,5 +64,4 @@ class CookiesKeyValueGenerator implements KeyValueGenerator {
 	public void setEnabled(boolean enabled) {
 		this.enabled = enabled;
 	}
-
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/HeaderKeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/HeaderKeyValueGenerator.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
@@ -27,12 +28,16 @@ import org.springframework.util.StringUtils;
 /**
  * @author Marta Medio
  * @author Ignacio Lozano
+ * @author Dong Hyeon Lee
  */
+@ConfigurationProperties("spring.cloud.gateway.server.webflux.header")
 class HeaderKeyValueGenerator implements KeyValueGenerator {
 
 	private final String header;
 
 	private final String valueSeparator;
+
+	private boolean enabled = true;
 
 	HeaderKeyValueGenerator(String header, String valueSeparator) {
 		this.valueSeparator = valueSeparator;
@@ -60,4 +65,13 @@ class HeaderKeyValueGenerator implements KeyValueGenerator {
 		return value == null ? Stream.empty() : value.stream();
 	}
 
+	@Override
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/HeaderKeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/HeaderKeyValueGenerator.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.util.StringUtils;
@@ -30,8 +29,7 @@ import org.springframework.util.StringUtils;
  * @author Ignacio Lozano
  * @author Dong Hyeon Lee
  */
-@ConfigurationProperties("spring.cloud.gateway.server.webflux.header")
-class HeaderKeyValueGenerator implements KeyValueGenerator {
+public class HeaderKeyValueGenerator implements KeyValueGenerator {
 
 	private final String header;
 
@@ -39,7 +37,8 @@ class HeaderKeyValueGenerator implements KeyValueGenerator {
 
 	private boolean enabled = true;
 
-	HeaderKeyValueGenerator(String header, String valueSeparator) {
+	public HeaderKeyValueGenerator(boolean enabled, String header, String valueSeparator) {
+		this.enabled = enabled;
 		this.valueSeparator = valueSeparator;
 		if (!StringUtils.hasText(header)) {
 			throw new IllegalArgumentException("The parameter cannot be empty or null");

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/KeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/KeyValueGenerator.java
@@ -23,6 +23,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
  *
  * @author Marta Medio
  * @author Ignacio Lozano
+ * @author Dong Hyeon Lee
  */
 interface KeyValueGenerator {
 
@@ -38,5 +39,9 @@ interface KeyValueGenerator {
 	}
 
 	String getKeyValue(ServerHttpRequest request);
+
+	boolean isEnabled();
+
+	void setEnabled(boolean enabled);
 
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/KeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/KeyValueGenerator.java
@@ -25,7 +25,7 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
  * @author Ignacio Lozano
  * @author Dong Hyeon Lee
  */
-interface KeyValueGenerator {
+public interface KeyValueGenerator {
 
 	/*
 	 * Calls getKeyValue() and guards against null.

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/UriKeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/UriKeyValueGenerator.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter.factory.cache.keygenerator;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 
 /**
@@ -23,12 +24,25 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
  *
  * @author Marta Medio
  * @author Ignacio Lozano
+ * @author Dong Hyeon Lee
  */
+@ConfigurationProperties("spring.cloud.gateway.server.webflux.uri")
 public class UriKeyValueGenerator implements KeyValueGenerator {
+
+	private boolean enabled = true;
 
 	@Override
 	public String getKeyValue(ServerHttpRequest request) {
 		return request.getURI().toString();
 	}
 
+	@Override
+	public boolean isEnabled() {
+		return this.enabled;
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
 }

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/UriKeyValueGenerator.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/UriKeyValueGenerator.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.gateway.filter.factory.cache.keygenerator;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 
 /**
@@ -26,10 +25,13 @@ import org.springframework.http.server.reactive.ServerHttpRequest;
  * @author Ignacio Lozano
  * @author Dong Hyeon Lee
  */
-@ConfigurationProperties("spring.cloud.gateway.server.webflux.uri")
 public class UriKeyValueGenerator implements KeyValueGenerator {
 
 	private boolean enabled = true;
+
+	public UriKeyValueGenerator(boolean enabled) {
+		this.enabled = enabled;
+	}
 
 	@Override
 	public String getKeyValue(ServerHttpRequest request) {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/CacheKeyGeneratorTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/CacheKeyGeneratorTest.java
@@ -25,6 +25,10 @@ import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CacheKeyGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CookiesKeyValueGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.HeaderKeyValueGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.KeyValueGenerator;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.UriKeyValueGenerator;
 import org.springframework.http.HttpCookie;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
@@ -38,7 +42,10 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
  */
 class CacheKeyGeneratorTest {
 
-	final CacheKeyGenerator cacheKeyGenerator = new CacheKeyGenerator();
+	List<KeyValueGenerator> defaultGenerators = List.of(new UriKeyValueGenerator(true),
+			new HeaderKeyValueGenerator(true, "Authorization", ";"), new CookiesKeyValueGenerator(true, ";"));
+
+	final CacheKeyGenerator cacheKeyGenerator = new CacheKeyGenerator(defaultGenerators);
 
 	@Test
 	public void shouldGenerateSameKeyForSameUri() {

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/DefaultKeyValueGeneratorTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/DefaultKeyValueGeneratorTests.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.filter.factory.cache.keygenerator;
 
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.http.HttpCookie;
@@ -29,8 +30,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Ignacio Lozano
+ * @author Dong Hyeon Lee
  */
 class DefaultKeyValueGeneratorTests {
+
+	@BeforeEach
+	void enableAllGenerators() {
+		CacheKeyGenerator.DEFAULT_KEY_VALUE_GENERATORS
+				.forEach(generator -> generator.setEnabled(true));
+	}
 
 	@Test
 	void uriAuthorizationAndCookiesArePresent() {
@@ -72,10 +80,35 @@ class DefaultKeyValueGeneratorTests {
 		assertThat(result).isEqualTo(uri + ";" + "" + ";" + "");
 	}
 
+	@Test
+	void isEnabledFalse(){
+		String uri = "http://myuri";
+		HttpHeaders headers = new HttpHeaders();
+		String authorization = "my-auth";
+		headers.set("Authorization", authorization);
+		String cookieName = "my-cookie";
+		String cookieValue = "cookie-value";
+		HttpCookie cookie = new HttpCookie(cookieName, cookieValue);
+		MockServerHttpRequest request = MockServerHttpRequest.get(uri).cookie(cookie).headers(headers).build();
+
+		String result = applyDisabled(request);
+
+		assertThat(result).isEqualTo("");
+	}
+
 	public String apply(ServerHttpRequest request) {
 		return CacheKeyGenerator.DEFAULT_KEY_VALUE_GENERATORS.stream()
+			.filter(KeyValueGenerator::isEnabled)
 			.map(generator -> generator.apply(request))
 			.collect(Collectors.joining(CacheKeyGenerator.KEY_SEPARATOR));
+	}
+
+	public String applyDisabled(ServerHttpRequest request) {
+		return CacheKeyGenerator.DEFAULT_KEY_VALUE_GENERATORS.stream()
+				.peek(generator -> generator.setEnabled(false))
+				.filter(KeyValueGenerator::isEnabled)
+				.map(generator -> generator.apply(request))
+				.collect(Collectors.joining(CacheKeyGenerator.KEY_SEPARATOR));
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/DefaultKeyValueGeneratorTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/DefaultKeyValueGeneratorTests.java
@@ -36,8 +36,7 @@ class DefaultKeyValueGeneratorTests {
 
 	@BeforeEach
 	void enableAllGenerators() {
-		CacheKeyGenerator.DEFAULT_KEY_VALUE_GENERATORS
-				.forEach(generator -> generator.setEnabled(true));
+		CacheKeyGenerator.DEFAULT_KEY_VALUE_GENERATORS.forEach(generator -> generator.setEnabled(true));
 	}
 
 	@Test
@@ -81,7 +80,7 @@ class DefaultKeyValueGeneratorTests {
 	}
 
 	@Test
-	void isEnabledFalse(){
+	void isEnabledFalse() {
 		String uri = "http://myuri";
 		HttpHeaders headers = new HttpHeaders();
 		String authorization = "my-auth";
@@ -105,10 +104,10 @@ class DefaultKeyValueGeneratorTests {
 
 	public String applyDisabled(ServerHttpRequest request) {
 		return CacheKeyGenerator.DEFAULT_KEY_VALUE_GENERATORS.stream()
-				.peek(generator -> generator.setEnabled(false))
-				.filter(KeyValueGenerator::isEnabled)
-				.map(generator -> generator.apply(request))
-				.collect(Collectors.joining(CacheKeyGenerator.KEY_SEPARATOR));
+			.peek(generator -> generator.setEnabled(false))
+			.filter(KeyValueGenerator::isEnabled)
+			.map(generator -> generator.apply(request))
+			.collect(Collectors.joining(CacheKeyGenerator.KEY_SEPARATOR));
 	}
 
 }

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/HeaderKeyValueGeneratorTest.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/keygenerator/HeaderKeyValueGeneratorTest.java
@@ -44,7 +44,7 @@ class HeaderKeyValueGeneratorTest {
 	@Test
 	void exceptionIsThrown_whenConstructorHeaderIsNull() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
-			.isThrownBy(() -> new HeaderKeyValueGenerator(null, SEPARATOR));
+			.isThrownBy(() -> new HeaderKeyValueGenerator(true, null, SEPARATOR));
 	}
 
 	@Test
@@ -53,7 +53,7 @@ class HeaderKeyValueGeneratorTest {
 		headers.set(HEADER_NAME, SINGLE_HEADER_VALUE);
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://this").headers(headers).build();
 
-		String result = new HeaderKeyValueGenerator(HEADER_NAME, SEPARATOR).apply(request);
+		String result = new HeaderKeyValueGenerator(true, HEADER_NAME, SEPARATOR).apply(request);
 
 		assertThat(result).isEqualTo(HEADER_NAME + "=" + SINGLE_HEADER_VALUE);
 	}
@@ -64,7 +64,7 @@ class HeaderKeyValueGeneratorTest {
 		headers.put(HEADER_NAME, List.of(VALUE1, VALUE2));
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://this").headers(headers).build();
 
-		String result = new HeaderKeyValueGenerator(HEADER_NAME, SEPARATOR).apply(request);
+		String result = new HeaderKeyValueGenerator(true, HEADER_NAME, SEPARATOR).apply(request);
 
 		assertThat(result).isEqualTo(HEADER_NAME + "=" + VALUE1 + SEPARATOR + VALUE2);
 	}
@@ -75,7 +75,7 @@ class HeaderKeyValueGeneratorTest {
 		headers.put(HEADER_NAME, List.of(VALUE2, VALUE1));
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://this").headers(headers).build();
 
-		String result = new HeaderKeyValueGenerator(HEADER_NAME, SEPARATOR).apply(request);
+		String result = new HeaderKeyValueGenerator(true, HEADER_NAME, SEPARATOR).apply(request);
 
 		assertThat(result).isEqualTo(HEADER_NAME + "=" + VALUE1 + SEPARATOR + VALUE2);
 	}


### PR DESCRIPTION
issue #3429 (Add customization options to ResponseCacheGatewayFilter)

- Add enable options to keygenerator
     - register KeyValueGenerator as a Spring bean 

Users can easily turn keygenerator on and off with yaml.
<img width="611" alt="image" src="https://github.com/user-attachments/assets/c2d1a86c-3eac-4da6-bd4b-e5166028e9ab" />

I have written test code and verified via a PostConstruct method that the YAML values are being loaded correctly. I also confirmed this with curl. Below is an example of calling /hello and /hello2 with curl when all key generators are disabled.
<img width="549" alt="image" src="https://github.com/user-attachments/assets/4d89a547-1c60-42b6-80d0-faf94acda1b5" />

