### PR TITLE
Fix NPE when ServerHttpRequest.getMethod() is null in MethodRoutePredicateFactory

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/MethodRoutePredicateFactory.java
@@ -56,6 +56,9 @@ public class MethodRoutePredicateFactory extends AbstractRoutePredicateFactory<M
 			@Override
 			public boolean test(ServerWebExchange exchange) {
 				HttpMethod requestMethod = exchange.getRequest().getMethod();
+				if (requestMethod == null) {
+                	return false;
+          		}
 				return stream(config.getMethods()).anyMatch(httpMethod -> httpMethod == requestMethod);
 			}
 


### PR DESCRIPTION
#### Issue
When Spring Cloud Gateway receives a request with an unknown or unsupported HTTP method (such as a raw CONNECT request), `ServerHttpRequest.getMethod()` returns `null`. The current implementation of `MethodRoutePredicateFactory` does not check for this case, which can result in a `NullPointerException` when the code tries to compare or operate on the method. This leads to a 500 Internal Server Error and exposes internal error details to clients.

#### Resolution
This PR adds a null check for the HTTP method in the `GatewayPredicate` implementation in `MethodRoutePredicateFactory`. If the method is `null`, the predicate now gracefully rejects the request (returns `false`), preventing the server from throwing an exception and instead handling unsupported or malformed HTTP methods safely. This improves the robustness of the gateway and avoids leaking internal error information.

**Fixes:**
- Prevents `NullPointerException` in `MethodRoutePredicateFactory`.
- Returns a safe response instead of 500 Internal Server Error for requests with unsupported/unknown HTTP methods.