### PR TITLE
#3948 Fix MediaType comparison to support values with parameters

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchangeTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchangeTests.java
@@ -69,6 +69,22 @@ public class AbstractProxyExchangeTests {
 		verify(outputStream, times(4)).flush();
 	}
 
+    @Test
+    public void copyResponseBodyForTextEventStreamWithParameter() throws IOException {
+        MockClientHttpResponse mockResponse = new MockClientHttpResponse(new byte[0], 200);
+        MediaType mediaType = MediaType.parseMediaType(MediaType.TEXT_EVENT_STREAM_VALUE + ";charset=UTF-8");
+        mockResponse.getHeaders().setContentType(mediaType);
+
+        InputStream inputStream = mock(InputStream.class);
+        when(inputStream.read(any())).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(-1);
+        OutputStream outputStream = mock(OutputStream.class);
+
+        int result = new TestProxyExchange().copyResponseBody(mockResponse, inputStream, outputStream);
+
+        assertThat(result).isEqualTo(3);
+        verify(outputStream, times(4)).flush();
+    }
+
 	@Test
 	public void copyResponseBodyWithoutContentType() throws IOException {
 		MockClientHttpResponse mockResponse = new MockClientHttpResponse(new byte[0], 200);


### PR DESCRIPTION
AbstractProxyExchange compares response `MediaType` with configured `StreamingMediaTypes` using `equals` method that takes into account MediaType parameters (indirectly using contains method in a List).

In this code:
```java
if (properties.getStreamingMediaTypes().contains(clientResponse.getHeaders().getContentType())) {
```
a response with content type `text/event-stream;charset=utf-8` is not considered as a streaming media type

A better way of comparing MediaType without considering parameters is using MediaType::equalsTypeAndSubtype method.

The specification of Server-Sent Events implicitly states that the ContentType is `text/event-stream` and that the charset is UTF-8, but some servers are including it explicitly in their response, breaking the streaming feature in Spring Cloud Gateway. 
