### PR TITLE
Fix media type comparison for streaming responses

### DIFF
--- a/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchange.java
+++ b/spring-cloud-gateway-server-mvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchange.java
@@ -19,9 +19,11 @@ package org.springframework.cloud.gateway.server.mvc.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.List;
 
 import org.springframework.cloud.gateway.server.mvc.config.GatewayMvcProperties;
 import org.springframework.cloud.gateway.server.mvc.handler.ProxyExchange;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.Assert;
 import org.springframework.util.StreamUtils;
@@ -42,7 +44,7 @@ public abstract class AbstractProxyExchange implements ProxyExchange {
 
 		int transferredBytes;
 
-		if (properties.getStreamingMediaTypes().contains(clientResponse.getHeaders().getContentType())) {
+		if (isStreamingMediaType(properties.getStreamingMediaTypes(), clientResponse.getHeaders().getContentType())) {
 			transferredBytes = copyResponseBodyWithFlushing(inputStream, outputStream);
 		}
 		else {
@@ -50,6 +52,15 @@ public abstract class AbstractProxyExchange implements ProxyExchange {
 		}
 
 		return transferredBytes;
+	}
+
+	private static boolean isStreamingMediaType(List<MediaType> streamingMediaTypes, MediaType mediaType) {
+		for (var streamingMediaType : streamingMediaTypes) {
+			if (streamingMediaType.equalsTypeAndSubtype(mediaType)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private int copyResponseBodyWithFlushing(InputStream inputStream, OutputStream outputStream) throws IOException {

--- a/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchangeTests.java
+++ b/spring-cloud-gateway-server-mvc/src/test/java/org/springframework/cloud/gateway/server/mvc/common/AbstractProxyExchangeTests.java
@@ -70,6 +70,22 @@ public class AbstractProxyExchangeTests {
 	}
 
 	@Test
+	public void copyResponseBodyForTextEventStreamWithParameter() throws IOException {
+		MockClientHttpResponse mockResponse = new MockClientHttpResponse(new byte[0], 200);
+		MediaType mediaType = MediaType.parseMediaType(MediaType.TEXT_EVENT_STREAM_VALUE + ";charset=UTF-8");
+		mockResponse.getHeaders().setContentType(mediaType);
+
+		InputStream inputStream = mock(InputStream.class);
+		when(inputStream.read(any())).thenReturn(1).thenReturn(1).thenReturn(1).thenReturn(-1);
+		OutputStream outputStream = mock(OutputStream.class);
+
+		int result = new TestProxyExchange().copyResponseBody(mockResponse, inputStream, outputStream);
+
+		assertThat(result).isEqualTo(3);
+		verify(outputStream, times(4)).flush();
+	}
+
+	@Test
 	public void copyResponseBodyWithoutContentType() throws IOException {
 		MockClientHttpResponse mockResponse = new MockClientHttpResponse(new byte[0], 200);
 


### PR DESCRIPTION
Improves the media type comparison logic for determining when to use streaming response handling by implementing proper type and subtype matching instead of relying on exact media type equality.

This fix addresses scenarios where streaming responses include charset or other parameters in their Content-Type headers, ensuring they are properly handled with the streaming copy mechanism that includes appropriate flushing.

## Problem
The previous implementation used `List.contains()` to check if a response's content type matches any of the configured streaming media types. This approach failed when the actual media type included parameters (e.g., text/event-stream;charset=UTF-8) because it relied on exact MediaType object equality rather than semantic type/subtype matching.

## Solution
* Replaced the direct contains() check with a new `isStreamingMediaType()` helper method
* Implemented proper media type comparison using `MediaType.equalsTypeAndSubtype()`
* Added comprehensive test coverage for media types with parameters