### PR TITLE
fix: remove duplicate logger

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -50,8 +50,6 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 
 	private Integer serverPort;
 
-	private final Log logger = LogFactory.getLog(getClass());
-
 	private boolean forwardedByEnabled = false;
 
 	/**
@@ -206,7 +204,7 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 			addForwardedBy(forwarded, InetAddress.getLocalHost());
 		}
 		catch (UnknownHostException e) {
-			this.logger.warn("Can not resolve host address, skipping Forwarded 'by' header", e);
+			log.warn("Can not resolve host address, skipping Forwarded 'by' header", e);
 		}
 	}
 


### PR DESCRIPTION
The `ForwardedHeadersFilter` class currently defines two Logger instances:

one is a static member
https://github.com/spring-cloud/spring-cloud-gateway/blob/348ad0cef166a08faa004f023cc7a3b28df5c773/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java#L49

and the other is an instance member
https://github.com/spring-cloud/spring-cloud-gateway/blob/348ad0cef166a08faa004f023cc7a3b28df5c773/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java#L53

Having both is redundant and can cause confusion.
This PR removes the instance-level Logger and uses the static one consistently.