### PR TITLE
Fix bytecode ordering dependency in GatewayAutoConfigurationTests

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
@@ -117,6 +117,8 @@ public class GatewayAutoConfigurationTests {
 	@Test
 	public void nettyHttpClientConfigured() {
 		new ReactiveWebApplicationContextRunner()
+			.withClassLoader(new org.springframework.boot.test.context.FilteredClassLoader(
+					org.springframework.cloud.gateway.test.TestEnableWebfluxSecurityAutoConfiguration.class))
 			.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class, MetricsAutoConfiguration.class,
 					SimpleMetricsExportAutoConfiguration.class, GatewayAutoConfiguration.class,
 					HttpClientCustomizedConfig.class, ServerPropertiesConfig.class))


### PR DESCRIPTION
## Problem

Found this while running NonDex on the test suite. When running the test suite with certain bytecode reordering patterns, 
`GatewayAutoConfigurationTests.nettyHttpClientConfigured` fails because Spring Boot 
cannot resolve metadata for `TestEnableWebfluxSecurityAutoConfiguration`.

The issue occurs because:

1. The test context auto-discovers all autoconfiguration classes in the classpath
2. Spring Boot's `AutoConfigurationSorter` tries to read metadata for `TestEnableWebfluxSecurityAutoConfiguration`
3. Due to bytecode reordering, the class file becomes temporarily inaccessible during classpath scanning
4. This results in a `FileNotFoundException` that breaks the test

## Solution

Use Spring Boot's `FilteredClassLoader` to explicitly exclude `TestEnableWebfluxSecurityAutoConfiguration` 
from the test's classloader. This prevents Spring Boot from trying to discover and load metadata for 
the test-only autoconfiguration, while keeping all other functionality intact.

The change is minimal:
- Adds `.withClassLoader(new FilteredClassLoader(...))` to exclude the problematic class
- No changes to test logic or assertions
- No changes to production code

## Why This Matters

This type of issue indicates a hidden dependency on bytecode ordering within the test setup. 
By fixing it, we:

- Ensure consistent test behavior across different execution environments
- Prevent intermittent CI/CD failures that are hard to debug
- Make the test more robust to future changes in classloading order
