### PR TITLE
Fixing undeterministic behavior in shouldApplyConnectTimeoutPerRoute(…

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
@@ -40,7 +40,6 @@ import org.springframework.web.server.ServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.data.Offset.offset;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
@@ -133,7 +132,8 @@ public class NettyRoutingFilterIntegrationTests extends BaseWebClientTests {
 
 		// default connect timeout is 45 sec, this test verifies that it is possible to
 		// reduce timeout via config
-		assertThat(System.currentTimeMillis() - currentTimeMillisBeforeCall).isCloseTo(5, offset(100L));
+		long duration = System.currentTimeMillis() - currentTimeMillisBeforeCall;
+		assertThat(duration).isLessThan(5000L);
 	}
 
 	@Test


### PR DESCRIPTION
**Deflake shouldApplyConnectTimeoutPerRoute by relaxing timing assertion**

While running the Spring Cloud Gateway tests locally, I consistently saw
flaky failures in `NettyRoutingFilterIntegrationTests.shouldApplyConnectTimeoutPerRoute()`.

The original test asserted that the duration of the request was
approximately `5 ms ± 100 ms`:


``` java
assertThat(System.currentTimeMillis() - currentTimeMillisBeforeCall)
    .isCloseTo(5, offset(100L)); 
```


In practice, this is highly environment-dependent. On slower machines,
under CI load, or with occasional GC / scheduling pauses, the call can
easily take more than 100 ms even though the behavior is still correct.
This leads to undeterministic test results.

This PR updates the test to assert only that the call completes
significantly faster than the default 45 second connect timeout, which
still validates the behavior without relying on a very tight timing
window:

```
long duration = System.currentTimeMillis() - currentTimeMillisBeforeCall;
assertThat(duration).isLessThan(5000L);
```



**Summary of changes**

NettyRoutingFilterIntegrationTests.shouldApplyConnectTimeoutPerRoute():
```

Replace strict isCloseTo(5, offset(100L)) assertion with
assertThat(duration).isLessThan(5000L).
```


**Motivation**

I found flakiness in this test when running the suite: the HTTP call
would succeed with the expected Connection refused error, but the
timing assertion would intermittently fail due to normal timing jitter.
Relaxing the assertion keeps the intent of verifying that the per-route
connect timeout is applied (and is much shorter than the default), while
making the test robust across different environments.