### PR TITLE
fixing NettyRoutingFilterIntegrationTests

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/test/resources/application-netty-routing-filter.yml
+++ b/spring-cloud-gateway-server-webflux/src/test/resources/application-netty-routing-filter.yml
@@ -4,11 +4,12 @@ test:
 
 my.timeout: 3000
 
-server:
-  error:
-    include-message: always
 
 spring:
+  web:
+    error:
+      include-message: always
+      
   profiles:
     group:
       - logging

--- a/spring-cloud-gateway-server-webflux/src/test/resources/application.yml
+++ b/spring-cloud-gateway-server-webflux/src/test/resources/application.yml
@@ -4,11 +4,12 @@ test:
   #  uri: http://${test.hostport}
   uri: lb://testservice
 
-server:
-  error:
-    include-message: always
 
 spring:
+  web:
+    error:
+      include-message: always
+      
   profiles:
     group:
       - logging


### PR DESCRIPTION
**Fix NettyRoutingFilter tests by migrating error message config to Spring Boot 4 key**

While running the Spring Cloud Gateway server WebFlux tests on the current
Spring Boot 4 / Spring Cloud 2025 snapshot, I hit failures in
`NettyRoutingFilterIntegrationTests.shouldApplyGlobalResponseTimeoutForInvalidRouteTimeoutValue()`.

This test asserts that the error response body contains a top-level
message field with the timeout text:
```

.expectBody()
    .jsonPath("$.status")
    .isEqualTo(String.valueOf(HttpStatus.GATEWAY_TIMEOUT.value()))
    .jsonPath("$.message")
    .isEqualTo("Response took longer than timeout: PT3S");
```


However, after the upgrade, the legacy configuration key:
```
server:
  error:
    include-message: always
```


is no longer supported. Spring Boot now expects the new
spring.web.error.include-message property and ignores the old key,
emitting a migration warning. As a result, the default behavior is to
omit the message attribute from the error JSON, causing the JsonPath
assertion on `$.message` to fail even though the gateway behavior is
otherwise correct.

This PR updates the test configuration to use the new property so that
the error message field is once again included in the response body
and the tests can validate the timeout message as intended.

**Summary of changes**

spring-cloud-gateway-server-webflux/src/test/resources/application-netty-routing-filter.yml
spring-cloud-gateway-server-webflux/src/test/resources/application.yml:

```
- server:
-   error:
-     include-message: always
+ spring:
+   web:
+     error:
+       include-message: always
```



**Motivation**

After the Spring Boot / Spring Cloud upgrade, the deprecated
`server.error.include-message key` is no longer honored and triggers a
migration warning. This silently changes the shape of the error JSON by
removing the message field, breaking tests that assert on that field.

Migrating the configuration to `spring.web.error.include-message`
restores the previous behavior (making the error message available to
clients and tests), keeps the tests stable across environments, and
removes the “configuration keys that are no longer supported” warnings
from the test logs.