### PR TITLE
fixing rewriteEncodedRequestParameter

### DIFF
--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
@@ -129,7 +129,7 @@ class BeforeFilterFunctionsTests {
 		assertThat(result.param("foo[]")).isPresent().hasValue("replacement[]");
 		assertThat(result.param("quux")).isPresent().hasValue("corge+");
 		assertThat(result.uri().toString())
-			.hasToString("http://localhost/path?quux=corge%2B&baz=qux&foo%5B%5D=replacement%5B%5D");
+			.contains("http://localhost/path?", "quux=corge%2B", "baz=qux", "foo%5B%5D=replacement%5B%5D");
 	}
 
 	@Test


### PR DESCRIPTION
**Deflake rewriteEncodedRequestParameter by relaxing URI ordering assertion**

While running the Spring Cloud Gateway MVC tests with [NonDex](https://github.com/TestingResearchIllinois/NonDex), I observed non-deterministic failures in `BeforeFilterFunctionsTests.rewriteEncodedRequestParameter()`.

The original test asserted that the entire URI string, including query
parameters and their ordering, exactly matched a hard-coded value:

```
assertThat(result.uri().toString())
    .hasToString("http://localhost/path?quux=corge%2B&baz=qux&foo%5B%5D=replacement%5B%5D");
```


However, the order of query parameters is not guaranteed. NonDex
specifically randomizes iteration order to surface this kind of
order-dependence. Under some executions, the URI would contain the same
parameters and encodings, but in a different order, causing the
hasToString assertion to fail even though the behavior was correct.

This PR updates the test to verify that the URI contains the expected
path and query fragments independently of their order:

```
assertThat(result.uri().toString())
    .contains("http://localhost/path?",
        "quux=corge%2B",
        "baz=qux",
        "foo%5B%5D=replacement%5B%5D");
```


**Summary of changes**

spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java:

```
// Before:
assertThat(result.uri().toString())
    .hasToString("http://localhost/path?quux=corge%2B&baz=qux&foo%5B%5D=replacement%5B%5D");

// After:
assertThat(result.uri().toString())
    .contains("http://localhost/path?",
        "quux=corge%2B",
        "baz=qux",
        "foo%5B%5D=replacement%5B%5D");
```


**Motivation**

With NonDex enabled, rewriteEncodedRequestParameter would sometimes
fail solely because the query parameter ordering in the resulting URI
differed from the hard-coded string, despite all parameters being
present and correctly encoded. Relaxing the assertion to check for the
presence of the expected path and query fragments (rather than enforcing
a single canonical ordering) keeps the test focused on the real
contract—rewriting and encoding of request parameters—while making it
robust across different environments and iteration orders.