### PR TITLE
docs: fix CORS config paths to use server.webflux prefix

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/cors-configuration.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/cors-configuration.adoc
@@ -17,17 +17,19 @@ The following example configures CORS:
 spring:
   cloud:
     gateway:
-      globalcors:
-        cors-configurations:
-          '[/**]':
-            allowedOrigins: "https://docs.spring.io"
-            allowedMethods:
-            - GET
+      server:
+        webflux:
+          globalcors:
+            cors-configurations:
+              '[/**]':
+                allowedOrigins: "https://docs.spring.io"
+                allowedMethods:
+                - GET
 ----
 
 In the preceding example, CORS requests are allowed from requests that originate from `docs.spring.io` for all GET requested paths.
 
-To provide the same CORS configuration to requests that are not handled by some gateway route predicate, set the `spring.cloud.gateway.globalcors.add-to-simple-url-handler-mapping` property  to `true`.
+To provide the same CORS configuration to requests that are not handled by some gateway route predicate, set the `spring.cloud.gateway.server.webflux.globalcors.add-to-simple-url-handler-mapping` property  to `true`.
 This is useful when you try to support CORS preflight requests and your route predicate does not evaluate to `true` because the HTTP method is `options`.
 
 [[route-cors-configuration]]
@@ -44,18 +46,20 @@ NOTE: If no `Path` predicate is present in the route '/**' will be applied.
 spring:
   cloud:
     gateway:
-      routes:
-      - id: cors_route
-        uri: https://example.org
-        predicates:
-        - Path=/service/**
-        metadata:
-          cors:
-            allowedOrigins: '*'
-            allowedMethods:
-              - GET
-              - POST
-            allowedHeaders: '*'
-            maxAge: 30
+      server:
+        webflux:
+          routes:
+          - id: cors_route
+            uri: https://example.org
+            predicates:
+            - Path=/service/**
+            metadata:
+              cors:
+                allowedOrigins: '*'
+                allowedMethods:
+                  - GET
+                  - POST
+                allowedHeaders: '*'
+                maxAge: 30
 ----
 


### PR DESCRIPTION
docs: fix CORS configuration paths in webflux documentation

Update the CORS configuration examples to use the correct property
paths under spring.cloud.gateway.server.webflux instead of the
incorrect spring.cloud.gateway paths.

Changes:
- Global CORS configuration now uses 
  spring.cloud.gateway.server.webflux.globalcors
- Property reference updated to 
  spring.cloud.gateway.server.webflux.globalcors.add-to-simple-url-handler-mapping
- Route CORS configuration example updated to use 
  spring.cloud.gateway.server.webflux.routes for consistency

This aligns the documentation with the actual implementation where
GatewayProperties.PREFIX is "spring.cloud.gateway.server.webflux"
and GlobalCorsProperties uses GatewayProperties.PREFIX + ".globalcors".