### PR TITLE
Remove spring-boot-properties-migrator from starters (#4022)

### DIFF
--- a/spring-cloud-starter-gateway-server-webflux/pom.xml
+++ b/spring-cloud-starter-gateway-server-webflux/pom.xml
@@ -33,10 +33,5 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
 		</dependency>
-		<!-- TODO: temporary, remove for 5.0 -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-properties-migrator</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/spring-cloud-starter-gateway-server-webmvc/pom.xml
+++ b/spring-cloud-starter-gateway-server-webmvc/pom.xml
@@ -33,10 +33,5 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
-		<!-- TODO: temporary, remove for 5.0 -->
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-properties-migrator</artifactId>
-		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
## Description
As discussed in #4022, this PR removes the `spring-boot-properties-migrator` dependency from the following starter modules:
- `spring-cloud-starter-gateway-server-webflux`
- `spring-cloud-starter-gateway-server-webmvc`

These modules should not have a forced dependency on the migrator tool, as it is intended for temporary migration use and can cause unexpected property overrides in production environments (especially with list-based properties like routes).

## Related Issue
Fixes #4022

## Motivation and Context
The `spring-boot-properties-migrator` was added as a temporary measure (marked with TODO for 5.0). Removing it now aligns with the goal of keeping new starters production-ready and giving users the choice to add it manually if needed, as stated in the release notes.

## How Has This Been Tested?
- Verified that the dependency is removed using `mvn dependency:tree`.
- Executed `./mvnw clean install -DskipTests` to ensure the build remains stable after removal.

/cc @ryanjbaxter @spencergibb