### PR TITLE
GH-4025: Fix Gzip decompression logic for byte[] in ModifyResponseBodyGatewayFilterFactory

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/rewrite/ModifyResponseBodyGatewayFilterFactory.java
@@ -264,12 +264,6 @@ public class ModifyResponseBodyGatewayFilterFactory
 		}
 
 		private <T> Mono<T> extractBody(ServerWebExchange exchange, ClientResponse clientResponse, Class<T> inClass) {
-			// if inClass is byte[] then just return body, otherwise check if
-			// decoding required
-			if (byte[].class.isAssignableFrom(inClass)) {
-				return clientResponse.bodyToMono(inClass);
-			}
-
 			List<String> encodingHeaders = exchange.getResponse().getHeaders().getOrEmpty(HttpHeaders.CONTENT_ENCODING);
 			for (String encoding : encodingHeaders) {
 				MessageBodyDecoder decoder = messageBodyDecoders.get(encoding);
@@ -289,10 +283,6 @@ public class ModifyResponseBodyGatewayFilterFactory
 		private Mono<DataBuffer> writeBody(ServerHttpResponse httpResponse, CachedBodyOutputMessage message,
 				Class<?> outClass) {
 			Mono<DataBuffer> response = DataBufferUtils.join(message.getBody());
-			if (byte[].class.isAssignableFrom(outClass)) {
-				return response;
-			}
-
 			List<String> encodingHeaders = httpResponse.getHeaders().getOrEmpty(HttpHeaders.CONTENT_ENCODING);
 			for (String encoding : encodingHeaders) {
 				MessageBodyEncoder encoder = messageBodyEncoders.get(encoding);


### PR DESCRIPTION
Fixes GH-4025

## Description
This PR addresses an issue where ModifyResponseBodyGatewayFilterFactory fails to handle Gzipped responses correctly when the configuration is set to use byte[].class.

## Root Cause:
Currently, there is an optimization logic in extractBody and writeBody methods that explicitly skips decompression/compression if the target class is byte[]:
``` java
if (byte[].class.isAssignableFrom(inClass)) {
    return clientResponse.bodyToMono(inClass);
}
```
While this might have been intended for performance, it prevents users from modifying the actual payload logic when the response is Gzipped, as the filter passes raw compressed bytes to the rewrite function. This leads to parsing errors when the user code expects decompressed data.

## Changes
Removed the `if (byte[].class.isAssignableFrom(inClass))` check in both extractBody and writeBody methods.
Now, the filter consistently checks the Content-Encoding header and performs decompression/compression regardless of the target class type.

## Verification
Added a new test case testModificationOfResponseBodyBytes in ModifyResponseBodyGatewayFilterFactoryGzipTests.
Verified that Gzipped responses are correctly decompressed, modified as strings, and recompressed even when inClass and outClass are set to byte[].