### PR TITLE
[doc] Fix broken link to GatewayFilter

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/glossary.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/glossary.adoc
@@ -6,6 +6,6 @@
 It is defined by an ID, a destination URI, a collection of predicates, and a collection of filters. A route is matched if the aggregate predicate is true.
 * *Predicate*: This is a https://docs.oracle.com/javase/8/docs/api/java/util/function/Predicate.html[Java 8 Function Predicate]. The input type is a https://docs.spring.io/spring/docs/5.0.x/javadoc-api/org/springframework/web/server/ServerWebExchange.html[Spring Framework `ServerWebExchange`].
 This lets you match on anything from the HTTP request, such as headers or parameters.
-* *Filter*: These are instances of https://github.com/spring-cloud/spring-cloud-gateway/blob/main/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/GatewayFilter.java[`GatewayFilter`] that have been constructed with a specific factory.
+* *Filter*: These are instances of https://github.com/spring-cloud/spring-cloud-gateway/blob/main/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/GatewayFilter.java[`GatewayFilter`] that have been constructed with a specific factory.
 Here, you can modify requests and responses before or after sending the downstream request.
 


### PR DESCRIPTION
The Spring Cloud Gateway Server WebFlux > Glossary page had a broken link to the GatewayFilter source code file in GitHub that showed a 404 Page not Found.

The link is now fixed and references the correct URL.