### PR TITLE
Append SecureHeaders CSP value when upstream already provides CSP

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/secureheaders-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/secureheaders-factory.adoc
@@ -5,6 +5,9 @@ The `SecureHeaders` `GatewayFilter` factory adds a number of headers to the resp
 
 The following headers (shown with their default values) are added:
 
+NOTE: If a `Content-Security-Policy` header is already present (for example, from an upstream service), the value configured by `SecureHeaders` is appended as an additional `Content-Security-Policy` header value.
+Other secure headers are only added when absent.
+
 * `X-Xss-Protection:1 (mode=block`)
 * `Strict-Transport-Security (max-age=631138519`)
 * `X-Frame-Options (DENY)`

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -143,8 +143,8 @@ public class SecureHeadersGatewayFilterFactory
 		addHeaderIfEnabled(responseHeaders, headersToAddToResponse, SecureHeadersProperties.REFERRER_POLICY_HEADER,
 				config.getReferrerPolicyHeaderValue());
 
-		addHeaderIfEnabled(responseHeaders, headersToAddToResponse,
-				SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER, config.getContentSecurityPolicyHeaderValue());
+		addContentSecurityPolicyHeaderIfEnabled(responseHeaders, headersToAddToResponse,
+				config.getContentSecurityPolicyHeaderValue());
 
 		addHeaderIfEnabled(responseHeaders, headersToAddToResponse, SecureHeadersProperties.X_DOWNLOAD_OPTIONS_HEADER,
 				config.getDownloadOptionsHeaderValue());
@@ -191,6 +191,18 @@ public class SecureHeadersGatewayFilterFactory
 		if (headerValue != null && headersToAdd.contains(headerName.toLowerCase(Locale.ROOT))) {
 			if (!headers.containsHeader(headerName)) {
 				headers.add(headerName, headerValue);
+			}
+		}
+	}
+
+	private void addContentSecurityPolicyHeaderIfEnabled(HttpHeaders headers, Set<String> headersToAdd,
+			@Nullable String headerValue) {
+		if (headerValue != null && headersToAdd
+			.contains(SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER.toLowerCase(Locale.ROOT))) {
+			if (!headers.containsHeader(SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER)
+					|| !headers.getOrEmpty(SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER)
+						.contains(headerValue)) {
+				headers.add(SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER, headerValue);
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- append the configured `SecureHeaders` `Content-Security-Policy` value even when the upstream response already contains a CSP header
- keep existing non-CSP secure headers behavior unchanged (still only added when absent)
- document this behavior in the SecureHeaders GatewayFilter docs

## Why
This makes CSP behavior consistent with the expected combined policy effect when both upstream services and Spring Cloud Gateway contribute CSP directives, while preserving existing behavior for other secure headers.

Closes #4065

## Tests
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH="$JAVA_HOME/bin:$PATH" ./mvnw -pl spring-cloud-gateway-server-webflux -Dtest=SecureHeadersGatewayFilterFactoryUnitTests,SecureHeadersGatewayFilterFactoryTests test`
