### PR TITLE
Fix ForwardRoutingFilter missing original request URL attribute

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilter.java
@@ -30,6 +30,7 @@ import org.springframework.web.reactive.DispatcherHandler;
 import org.springframework.web.server.ServerWebExchange;
 
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.addOriginalRequestUrl;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.handle;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.isAlreadyRouted;
 
@@ -72,6 +73,9 @@ public class ForwardRoutingFilter implements GlobalFilter, Ordered {
 		if (log.isTraceEnabled()) {
 			log.trace("Forwarding to URI: " + requestUrl);
 		}
+
+		addOriginalRequestUrl(exchange, exchange.getRequest().getURI());
+
 		DispatcherHandler handler = getDispatcherHandler();
 		Objects.requireNonNull(handler, "DispatcherHandler must not be null");
 		return handle(handler, exchange);

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/ForwardRoutingFilterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.gateway.filter;
 
 import java.net.URI;
+import java.util.LinkedHashSet;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ALREADY_ROUTED_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ORIGINAL_REQUEST_URL_ATTR;
 import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
 
 /**
@@ -96,6 +98,17 @@ public class ForwardRoutingFilterTests {
 		verifyNoMoreInteractions(chain);
 		verify(dispatcherHandler).handle(
 				assertArg(exchange -> assertThat(exchange.getAttributes().get(GATEWAY_ALREADY_ROUTED_ATTR)).isNull()));
+	}
+
+	@Test
+	public void shouldAddOriginalRequestUrlAttributeWhenForwarding() {
+		URI uri = UriComponentsBuilder.fromUriString("forward://endpoint").build().toUri();
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri);
+
+		forwardRoutingFilter.filter(exchange, chain);
+
+		LinkedHashSet<URI> uris = exchange.getRequiredAttribute(GATEWAY_ORIGINAL_REQUEST_URL_ATTR);
+		assertThat(uris).containsExactly(exchange.getRequest().getURI());
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

When a route uses `forward:` URI, `ForwardRoutingFilter` forwarded the exchange without adding the original request URL into `GATEWAY_ORIGINAL_REQUEST_URL_ATTR`.
This caused handlers/controllers receiving the forwarded `ServerWebExchange` to miss the documented original URL attribute.

This change adds the original incoming request URI before dispatching to `DispatcherHandler`.

## Changes

- In `ForwardRoutingFilter`, call `addOriginalRequestUrl(exchange, exchange.getRequest().getURI())` before `handle(...)`.
- Add unit test `shouldAddOriginalRequestUrlAttributeWhenForwarding` in `ForwardRoutingFilterTests`.

## Testing

- `./mvnw -pl spring-cloud-gateway-server-webflux -Dtest=ForwardRoutingFilterTests test`
- `./mvnw -pl spring-cloud-gateway-server-webflux -Dtest=ForwardRoutingFilterTests,ForwardRoutingFilterStaticIntegrationTests test`

Both passed locally on JDK 21.

Fixes #4053
