### PR TITLE
Fix ReadBodyRoutePredicateFactory for empty request bodies

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactory.java
@@ -98,7 +98,8 @@ public class ReadBodyRoutePredicateFactory extends AbstractRoutePredicateFactory
 								.doOnNext(objectValue -> exchange.getAttributes()
 									.put(CACHE_REQUEST_BODY_OBJECT_KEY, objectValue))
 								.map(objectValue -> config.getPredicate() != null
-										&& config.getPredicate().test(objectValue)));
+										&& config.getPredicate().test(objectValue))
+								.defaultIfEmpty(config.getPredicate() != null && config.getPredicate().test(null)));
 				}
 			}
 

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactoryUnitTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/handler/predicate/ReadBodyRoutePredicateFactoryUnitTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.handler.predicate;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+import org.springframework.cloud.gateway.handler.predicate.ReadBodyRoutePredicateFactory.Config;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+
+class ReadBodyRoutePredicateFactoryUnitTests {
+
+	private final ReadBodyRoutePredicateFactory factory = new ReadBodyRoutePredicateFactory();
+
+	@Test
+	void emptyBodyShouldStillEvaluatePredicate() {
+		Config config = new Config().setPredicate(String.class, body -> body == null);
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/test").build());
+
+		StepVerifier.create(Mono.from(factory.applyAsync(config).apply(exchange))).expectNext(true).verifyComplete();
+	}
+
+	@Test
+	void emptyBodyShouldReturnFalseWhenPredicateRejectsNull() {
+		Config config = new Config().setPredicate(String.class, body -> body != null);
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.post("/test").build());
+
+		StepVerifier.create(Mono.from(factory.applyAsync(config).apply(exchange))).expectNext(false).verifyComplete();
+	}
+
+}


### PR DESCRIPTION
## Summary
- make `ReadBodyRoutePredicateFactory` emit a boolean even when request body is empty
- evaluate the configured predicate with `null` when `bodyToMono(...)` is empty, instead of returning an empty publisher
- add unit tests covering empty-body behavior for predicates that accept/reject `null`

Fixes #4035.
