### PR TITLE
Rename micrometer tags to follow recommended naming convention

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayHttpTagsProvider.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayHttpTagsProvider.java
@@ -54,7 +54,7 @@ public class GatewayHttpTagsProvider implements GatewayTagsProvider {
 			}
 		}
 
-		return Tags.of("outcome", outcome, "status", status, "httpStatusCode", httpStatusCodeStr, "httpMethod",
+		return Tags.of("outcome", outcome, "status", status, "http.status.code", httpStatusCodeStr, "http.method",
 				httpMethod);
 	}
 

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayRouteTagsProvider.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayRouteTagsProvider.java
@@ -33,7 +33,7 @@ public class GatewayRouteTagsProvider implements GatewayTagsProvider {
 		Route route = exchange.getAttribute(GATEWAY_ROUTE_ATTR);
 
 		if (route != null) {
-			return Tags.of("routeId", route.getId(), "routeUri", route.getUri().toString());
+			return Tags.of("route.id", route.getId(), "route.uri", route.getUri().toString());
 		}
 
 		return Tags.empty();

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilterCustomTagsTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilterCustomTagsTests.java
@@ -59,10 +59,10 @@ class GatewayMetricsFilterCustomTagsTests extends BaseWebClientTests {
 		// default tags
 		assertMetricsContainsTag("outcome", HttpStatus.Series.SUCCESSFUL.name());
 		assertMetricsContainsTag("status", HttpStatus.OK.name());
-		assertMetricsContainsTag("httpStatusCode", String.valueOf(HttpStatus.OK.value()));
-		assertMetricsContainsTag("httpMethod", HttpMethod.GET.toString());
-		assertMetricsContainsTag("routeId", "default_path_to_httpbin");
-		assertMetricsContainsTag("routeUri", testUri);
+		assertMetricsContainsTag("http.status.code", String.valueOf(HttpStatus.OK.value()));
+		assertMetricsContainsTag("http.method", HttpMethod.GET.toString());
+		assertMetricsContainsTag("route.id", "default_path_to_httpbin");
+		assertMetricsContainsTag("route.uri", testUri);
 
 		// custom tags
 		assertMetricsContainsTag("custom1", "tag1");

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/GatewayMetricsFilterTests.java
@@ -60,10 +60,10 @@ public class GatewayMetricsFilterTests extends BaseWebClientTests {
 		testClient.get().uri("/headers").exchange().expectStatus().isOk();
 		assertMetricsContainsTag("outcome", HttpStatus.Series.SUCCESSFUL.name());
 		assertMetricsContainsTag("status", HttpStatus.OK.name());
-		assertMetricsContainsTag("httpStatusCode", String.valueOf(HttpStatus.OK.value()));
-		assertMetricsContainsTag("httpMethod", HttpMethod.GET.toString());
-		assertMetricsContainsTag("routeId", "default_path_to_httpbin");
-		assertMetricsContainsTag("routeUri", testUri);
+		assertMetricsContainsTag("http.status.code", String.valueOf(HttpStatus.OK.value()));
+		assertMetricsContainsTag("http.method", HttpMethod.GET.toString());
+		assertMetricsContainsTag("route.id", "default_path_to_httpbin");
+		assertMetricsContainsTag("route.uri", testUri);
 	}
 
 	@Test
@@ -71,10 +71,10 @@ public class GatewayMetricsFilterTests extends BaseWebClientTests {
 		testClient.get().uri("/badtargeturi").exchange().expectStatus().is5xxServerError();
 		assertMetricsContainsTag("outcome", HttpStatus.Series.SERVER_ERROR.name());
 		assertMetricsContainsTag("status", HttpStatus.INTERNAL_SERVER_ERROR.name());
-		assertMetricsContainsTag("httpStatusCode", String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR.value()));
-		assertMetricsContainsTag("httpMethod", HttpMethod.GET.toString());
-		assertMetricsContainsTag("routeId", "default_path_to_httpbin");
-		assertMetricsContainsTag("routeUri", testUri);
+		assertMetricsContainsTag("http.status.code", String.valueOf(HttpStatus.INTERNAL_SERVER_ERROR.value()));
+		assertMetricsContainsTag("http.method", HttpMethod.GET.toString());
+		assertMetricsContainsTag("route.id", "default_path_to_httpbin");
+		assertMetricsContainsTag("route.uri", testUri);
 	}
 
 	@Test
@@ -87,10 +87,10 @@ public class GatewayMetricsFilterTests extends BaseWebClientTests {
 		assertThat(response.getStatusCode().value()).isEqualTo(432);
 		assertMetricsContainsTag("outcome", "CUSTOM");
 		assertMetricsContainsTag("status", "432");
-		assertMetricsContainsTag("routeId", "test_custom_http_status_metrics");
-		assertMetricsContainsTag("routeUri", testUri);
-		assertMetricsContainsTag("httpStatusCode", "432");
-		assertMetricsContainsTag("httpMethod", HttpMethod.POST.toString());
+		assertMetricsContainsTag("route.id", "test_custom_http_status_metrics");
+		assertMetricsContainsTag("route.uri", testUri);
+		assertMetricsContainsTag("http.status.code", "432");
+		assertMetricsContainsTag("http.method", HttpMethod.POST.toString());
 	}
 
 	private void assertMetricsContainsTag(String tagKey, String tagValue) {

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayHttpTagsProviderTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayHttpTagsProviderTests.java
@@ -41,7 +41,7 @@ public class GatewayHttpTagsProviderTests {
 	private static final String ROUTE_URI = "http://gatewaytagsprovider.org:80";
 
 	private static final Tags DEFAULT_TAGS = Tags.of("outcome", OK.series().name(), "status", OK.name(),
-			"httpStatusCode", String.valueOf(OK.value()), "httpMethod", "GET");
+			"http.status.code", String.valueOf(OK.value()), "http.method", "GET");
 
 	@Test
 	public void httpTags() {
@@ -59,7 +59,7 @@ public class GatewayHttpTagsProviderTests {
 
 		Tags tags = tagsProvider.apply(exchange);
 		assertThat(tags)
-			.isEqualTo(Tags.of("outcome", "CUSTOM", "status", "499", "httpMethod", "GET", "httpStatusCode", "499"));
+			.isEqualTo(Tags.of("outcome", "CUSTOM", "status", "499", "http.method", "GET", "http.status.code", "499"));
 	}
 
 	@Test
@@ -68,7 +68,7 @@ public class GatewayHttpTagsProviderTests {
 
 		Tags tags = tagsProvider.apply(exchange);
 		assertThat(tags)
-			.isEqualTo(Tags.of("outcome", "CUSTOM", "status", "CUSTOM", "httpStatusCode", "NA", "httpMethod", "GET"));
+			.isEqualTo(Tags.of("outcome", "CUSTOM", "status", "CUSTOM", "http.status.code", "NA", "http.method", "GET"));
 	}
 
 	@Test

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayRouteTagsProviderTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/support/tagsprovider/GatewayRouteTagsProviderTests.java
@@ -40,7 +40,7 @@ public class GatewayRouteTagsProviderTests {
 
 	private static final Route ROUTE = Route.async().id(ROUTE_ID).uri(ROUTE_URI).predicate(swe -> true).build();
 
-	private static final Tags DEFAULT_TAGS = Tags.of("routeId", ROUTE_ID, "routeUri", ROUTE_URI);
+	private static final Tags DEFAULT_TAGS = Tags.of("route.id", ROUTE_ID, "route.uri", ROUTE_URI);
 
 	@Test
 	public void routeTags() {


### PR DESCRIPTION
Rename camelCase tag names to lowercase dot notation in `GatewayHttpTagsProvider` and `GatewayRouteTagsProvider` as recommended by the Micrometer documentation.

- `httpStatusCode` -> `http.status.code`
- `httpMethod` -> `http.method`
- `routeId` -> `route.id`
- `routeUri` -> `route.uri`

Closes #3434