### PR TITLE
Add cache metrics support for LocalResponseCache

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/local-cache-response-filter.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/local-cache-response-filter.adoc
@@ -54,4 +54,24 @@ NOTE: To enable this feature, add `com.github.ben-manes.caffeine:caffeine` and `
 
 WARNING: If your project creates custom `CacheManager` beans, it will either need to be marked with `@Primary` or injected using `@Qualifier`.
 
+[[local-cache-response-filter-metrics]]
+== Metrics
+
+To expose cache metrics, add `spring-boot-starter-actuator` (and a Micrometer registry implementation such as `micrometer-registry-prometheus`) as project dependencies.
+When `spring.cloud.gateway.server.webflux.metrics.enabled` is `true` (the default), the gateway emits the standard Micrometer cache meters for every route-level cache created by the `LocalResponseCache` filter:
+
+* `cache.size`
+* `cache.gets` (with `result` tag of `hit` or `miss`)
+* `cache.puts`
+* `cache.evictions`
+
+Each meter is tagged with `cache=<routeId>-cache`, so a route declared with id `my-route` is observable via `cache.size{cache=my-route-cache}`.
+The gauges continue to reflect the current cache after a route refresh; the underlying Caffeine instance may be replaced by the gateway, but the meter binding stays valid.
+
+NOTE: Meters are only registered when a `MeterRegistry` bean is present on the application context.
+
+NOTE: Set `spring.cloud.gateway.server.webflux.metrics.enabled=false` to opt out.
+
+NOTE: `cache.puts` is sourced from Caffeine's `loadCount` and is incremented only by `LoadingCache`-style automatic loads. Because `LocalResponseCache` is populated by the response-cache filter without a `CacheLoader`, this meter remains at `0` in normal use; cache activity is best observed via `cache.size`, `cache.gets`, and `cache.evictions`.
+
 

--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/global-filters.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/global-filters.adoc
@@ -94,6 +94,15 @@ NOTE: To enable this feature, add `com.github.ben-manes.caffeine:caffeine` and `
 
 WARNING: If your project creates custom `CacheManager` beans, it will either need to be marked with `@Primary` or injected using `@Qualifier`.
 
+When `spring-boot-starter-actuator` is on the classpath and `spring.cloud.gateway.server.webflux.metrics.enabled` is `true` (the default), the global cache exposes the following standard Micrometer cache meters, tagged with `cache=response-cache`:
+
+* `cache.size`
+* `cache.gets` (with `result` tag of `hit` or `miss`)
+* `cache.puts`
+* `cache.evictions`
+
+See xref:spring-cloud-gateway-server-webflux/gatewayfilter-factories/local-cache-response-filter.adoc#local-cache-response-filter-metrics[the LocalResponseCache filter docs] for the per-route equivalent.
+
 [[forward-routing-filter]]
 == Forward Routing Filter
 

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheAutoConfiguration.java
@@ -18,8 +18,6 @@ package org.springframework.cloud.gateway.config;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.Weigher;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -53,8 +51,6 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnEnabledFilter(LocalResponseCacheGatewayFilterFactory.class)
 public class LocalResponseCacheAutoConfiguration {
 
-	private static final Log LOGGER = LogFactory.getLog(LocalResponseCacheAutoConfiguration.class);
-
 	private static final String RESPONSE_CACHE_NAME = "response-cache";
 
 	/* for testing */ static final String RESPONSE_CACHE_MANAGER_NAME = "gatewayCacheManager";
@@ -86,7 +82,7 @@ public class LocalResponseCacheAutoConfiguration {
 			ObjectProvider<CacheMetricsListener> metricsListenerProvider) {
 		CacheMetricsListener listener = metricsListenerProvider.getIfAvailable(() -> CacheMetricsListener.NOOP);
 		return new LocalResponseCacheGatewayFilterFactory(responseCacheManagerFactory, properties.getTimeToLive(),
-				properties.getSize(), properties.getRequest(), listener);
+				properties.getSize(), properties.getRequest(), new CaffeineCacheManager(), listener);
 	}
 
 	@Bean

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.config;
+
+import java.util.Collections;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.micrometer.metrics.autoconfigure.CompositeMeterRegistryAutoConfiguration;
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory.CacheMetricsListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Auto-configuration for LocalResponseCache metrics. Registers Caffeine cache metrics
+ * with the {@link MeterRegistry} when both the cache infrastructure and Micrometer are
+ * available.
+ *
+ * @author LivingLikeKrillin
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass({ Caffeine.class, CaffeineCacheManager.class, MeterRegistry.class, MetricsAutoConfiguration.class })
+@ConditionalOnBean(MeterRegistry.class)
+@ConditionalOnProperty(name = GatewayProperties.PREFIX + ".metrics.enabled", matchIfMissing = true)
+@AutoConfigureAfter({ LocalResponseCacheAutoConfiguration.class, MetricsAutoConfiguration.class,
+		CompositeMeterRegistryAutoConfiguration.class })
+public class LocalResponseCacheMetricsAutoConfiguration {
+
+	@Bean
+	CacheMetricsListener localResponseCacheMetricsListener(MeterRegistry meterRegistry) {
+		return (cache, cacheName) -> CaffeineCacheMetrics.monitor(meterRegistry, cache, cacheName,
+				Collections.emptyList());
+	}
+
+}

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
@@ -33,13 +33,6 @@ import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCache
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Auto-configuration for LocalResponseCache metrics. Registers Caffeine cache metrics
- * with the {@link MeterRegistry} when both the cache infrastructure and Micrometer are
- * available.
- *
- * @author LivingLikeKrillin
- */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass({ Caffeine.class, CaffeineCacheManager.class, MeterRegistry.class, MetricsAutoConfiguration.class })
 @ConditionalOnBean(MeterRegistry.class)
@@ -49,7 +42,7 @@ import org.springframework.context.annotation.Configuration;
 public class LocalResponseCacheMetricsAutoConfiguration {
 
 	@Bean
-	CacheMetricsListener localResponseCacheMetricsListener(MeterRegistry meterRegistry) {
+	public CacheMetricsListener localResponseCacheMetricsListener(MeterRegistry meterRegistry) {
 		return (cache, cacheName) -> CaffeineCacheMetrics.monitor(meterRegistry, cache, cacheName,
 				Collections.emptyList());
 	}

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
@@ -32,16 +32,19 @@ import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory.CacheMetricsListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.DispatcherHandler;
 
 @Configuration(proxyBeanMethods = false)
-@ConditionalOnClass({ Caffeine.class, CaffeineCacheManager.class, MeterRegistry.class, MetricsAutoConfiguration.class })
-@ConditionalOnBean(MeterRegistry.class)
-@ConditionalOnProperty(name = GatewayProperties.PREFIX + ".metrics.enabled", matchIfMissing = true)
+@ConditionalOnProperty(name = GatewayProperties.PREFIX + ".enabled", matchIfMissing = true)
 @AutoConfigureAfter({ LocalResponseCacheAutoConfiguration.class, MetricsAutoConfiguration.class,
 		CompositeMeterRegistryAutoConfiguration.class })
+@ConditionalOnClass({ DispatcherHandler.class, Caffeine.class, CaffeineCacheManager.class, MeterRegistry.class,
+		MetricsAutoConfiguration.class })
 public class LocalResponseCacheMetricsAutoConfiguration {
 
 	@Bean
+	@ConditionalOnBean(MeterRegistry.class)
+	@ConditionalOnProperty(name = GatewayProperties.PREFIX + ".metrics.enabled", matchIfMissing = true)
 	public CacheMetricsListener localResponseCacheMetricsListener(MeterRegistry meterRegistry) {
 		return (cache, cacheName) -> CaffeineCacheMetrics.monitor(meterRegistry, cache, cacheName,
 				Collections.emptyList());

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfiguration.java
@@ -16,11 +16,17 @@
 
 package org.springframework.cloud.gateway.config;
 
-import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.cache.CacheMeterBinder;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -34,6 +40,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.DispatcherHandler;
 
+/**
+ * Auto-configuration that exposes cache statistics for {@code LocalResponseCache} as
+ * Micrometer meters. Registers a {@link CacheMetricsListener} that binds each Caffeine
+ * cache to the {@link MeterRegistry} the first time it is created and rebinds the
+ * underlying reference on subsequent route refreshes so the gauges keep tracking the
+ * current cache instance.
+ */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(name = GatewayProperties.PREFIX + ".enabled", matchIfMissing = true)
 @AutoConfigureAfter({ LocalResponseCacheAutoConfiguration.class, MetricsAutoConfiguration.class,
@@ -46,8 +59,97 @@ public class LocalResponseCacheMetricsAutoConfiguration {
 	@ConditionalOnBean(MeterRegistry.class)
 	@ConditionalOnProperty(name = GatewayProperties.PREFIX + ".metrics.enabled", matchIfMissing = true)
 	public CacheMetricsListener localResponseCacheMetricsListener(MeterRegistry meterRegistry) {
-		return (cache, cacheName) -> CaffeineCacheMetrics.monitor(meterRegistry, cache, cacheName,
-				Collections.emptyList());
+		return new SwappableCacheMetricsListener(meterRegistry);
+	}
+
+	/**
+	 * Listener that binds each cache name to the registry once and swaps the underlying
+	 * cache reference on subsequent invocations.
+	 *
+	 * <p>
+	 * {@link MeterRegistry} silently drops duplicate registrations - calling
+	 * {@code CaffeineCacheMetrics.monitor(...)} a second time with a new cache instance
+	 * returns the existing meter, leaving the gauges bound to the original (already
+	 * replaced) cache. Because {@code LocalResponseCacheGatewayFilterFactory.apply} is
+	 * re-invoked on every route refresh and builds a new Caffeine cache each time, naive
+	 * registration would leave the metrics permanently tracking a discarded cache and
+	 * reporting {@code NaN} once it is garbage-collected.
+	 */
+	static class SwappableCacheMetricsListener implements CacheMetricsListener {
+
+		private final MeterRegistry registry;
+
+		private final Map<String, AtomicReference<Cache<?, ?>>> refsByCacheName = new ConcurrentHashMap<>();
+
+		SwappableCacheMetricsListener(MeterRegistry registry) {
+			this.registry = registry;
+		}
+
+		@Override
+		public void onCacheCreated(Cache<?, ?> cache, String cacheName) {
+			refsByCacheName.computeIfAbsent(cacheName, name -> {
+				AtomicReference<Cache<?, ?>> ref = new AtomicReference<>(cache);
+				new SwappableCaffeineCacheMetrics(ref, name, Tags.empty()).bindTo(registry);
+				return ref;
+			}).set(cache);
+		}
+
+	}
+
+	/**
+	 * Cache meter binder bound to a mutable {@link AtomicReference} so the registered
+	 * gauges always read whichever Caffeine cache instance is currently set on the
+	 * reference. Exposes the standard {@link CacheMeterBinder} meter set
+	 * ({@code cache.size}, {@code cache.gets}, {@code cache.puts},
+	 * {@code cache.evictions}); Caffeine-specific meters are intentionally omitted to
+	 * keep the refresh-safe path simple.
+	 */
+	static class SwappableCaffeineCacheMetrics extends CacheMeterBinder<AtomicReference<Cache<?, ?>>> {
+
+		SwappableCaffeineCacheMetrics(AtomicReference<Cache<?, ?>> ref, String cacheName, Iterable<Tag> tags) {
+			super(ref, cacheName, tags);
+		}
+
+		@Override
+		protected @Nullable Long size() {
+			Cache<?, ?> c = current();
+			return c != null ? c.estimatedSize() : null;
+		}
+
+		@Override
+		protected long hitCount() {
+			Cache<?, ?> c = current();
+			return c != null ? c.stats().hitCount() : 0L;
+		}
+
+		@Override
+		protected @Nullable Long missCount() {
+			Cache<?, ?> c = current();
+			return c != null ? c.stats().missCount() : null;
+		}
+
+		@Override
+		protected @Nullable Long evictionCount() {
+			Cache<?, ?> c = current();
+			return c != null ? c.stats().evictionCount() : null;
+		}
+
+		@Override
+		protected long putCount() {
+			Cache<?, ?> c = current();
+			return c != null ? c.stats().loadCount() : 0L;
+		}
+
+		@Override
+		protected void bindImplementationSpecificMetrics(MeterRegistry registry) {
+			// Intentionally empty - see class javadoc.
+		}
+
+		private @Nullable Cache<?, ?> current() {
+			AtomicReference<Cache<?, ?>> ref = getCache();
+			return ref != null ? ref.get() : null;
+		}
+
 	}
 
 }

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
@@ -122,11 +122,34 @@ public class LocalResponseCacheGatewayFilterFactory
 		return List.of("timeToLive", "size");
 	}
 
+	/**
+	 * Callback invoked by {@link LocalResponseCacheGatewayFilterFactory} (and
+	 * {@code LocalResponseCacheAutoConfiguration} for the global cache) each time a
+	 * Caffeine cache backing {@code LocalResponseCache} is created or replaced. Allows
+	 * external components - typically a Micrometer binder - to attach observers without
+	 * the filter factory depending on Micrometer directly.
+	 *
+	 * <p>
+	 * Implementations must be safe to invoke multiple times with the same {@code
+	 * cacheName} (e.g. on every route refresh) since the gateway may rebuild the cache.
+	 */
 	@FunctionalInterface
 	public interface CacheMetricsListener {
 
+		/**
+		 * Invoked after a Caffeine cache for {@code cacheName} is created (or re-created
+		 * on refresh).
+		 * @param cache the current Caffeine cache instance.
+		 * @param cacheName the cache name used for tagging metrics; for per-route caches
+		 * this is {@code <routeId>-cache}.
+		 */
 		void onCacheCreated(com.github.benmanes.caffeine.cache.Cache<?, ?> cache, String cacheName);
 
+		/**
+		 * No-op default returned when no metrics binder is wired in (e.g. when Micrometer
+		 * is absent or
+		 * {@code spring.cloud.gateway.server.webflux.metrics.enabled=false}).
+		 */
 		CacheMetricsListener NOOP = (cache, cacheName) -> {
 		};
 

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
@@ -80,13 +80,6 @@ public class LocalResponseCacheGatewayFilterFactory
 
 	public LocalResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
 			Duration defaultTimeToLive, DataSize defaultSize, RequestOptions requestOptions,
-			CacheMetricsListener cacheMetricsListener) {
-		this(cacheManagerFactory, defaultTimeToLive, defaultSize, requestOptions, new CaffeineCacheManager(),
-				cacheMetricsListener);
-	}
-
-	public LocalResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
-			Duration defaultTimeToLive, DataSize defaultSize, RequestOptions requestOptions,
 			CaffeineCacheManager caffeineCacheManager, CacheMetricsListener cacheMetricsListener) {
 		super(RouteCacheConfiguration.class);
 		this.cacheManagerFactory = cacheManagerFactory;
@@ -129,18 +122,11 @@ public class LocalResponseCacheGatewayFilterFactory
 		return List.of("timeToLive", "size");
 	}
 
-	/**
-	 * Listener notified when a new Caffeine cache is created, allowing external
-	 * components (e.g., metrics) to observe cache instances.
-	 */
 	@FunctionalInterface
 	public interface CacheMetricsListener {
 
 		void onCacheCreated(com.github.benmanes.caffeine.cache.Cache<?, ?> cache, String cacheName);
 
-		/**
-		 * No-op implementation used when metrics infrastructure is not available.
-		 */
 		CacheMetricsListener NOOP = (cache, cacheName) -> {
 		};
 

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheUtils.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheUtils.java
@@ -48,7 +48,7 @@ public final class LocalResponseCacheUtils {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static Caffeine createCaffeine(LocalResponseCacheProperties cacheProperties) {
-		Caffeine caffeine = Caffeine.newBuilder();
+		Caffeine caffeine = Caffeine.newBuilder().recordStats();
 		LOGGER.info("Initializing Caffeine");
 		Duration ttlSeconds = cacheProperties.getTimeToLive();
 		caffeine.expireAfterWrite(ttlSeconds);

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheUtils.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheUtils.java
@@ -48,6 +48,7 @@ public final class LocalResponseCacheUtils {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static Caffeine createCaffeine(LocalResponseCacheProperties cacheProperties) {
+		// Record stats unconditionally; LongAdder overhead is negligible.
 		Caffeine caffeine = Caffeine.newBuilder().recordStats();
 		LOGGER.info("Initializing Caffeine");
 		Duration ttlSeconds = cacheProperties.getTimeToLive();

--- a/spring-cloud-gateway-server-webflux/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-cloud-gateway-server-webflux/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -10,4 +10,5 @@ org.springframework.cloud.gateway.discovery.GatewayDiscoveryClientAutoConfigurat
 org.springframework.cloud.gateway.config.SimpleUrlHandlerMappingGlobalCorsAutoConfiguration
 org.springframework.cloud.gateway.config.GatewayReactiveLoadBalancerClientAutoConfiguration
 org.springframework.cloud.gateway.config.LocalResponseCacheAutoConfiguration
+org.springframework.cloud.gateway.config.LocalResponseCacheMetricsAutoConfiguration
 org.springframework.cloud.gateway.config.GatewayTracingAutoConfiguration

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
@@ -25,9 +25,13 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory.CacheMetricsListener;
 import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
 import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheUtils;
+import org.springframework.cloud.gateway.filter.factory.cache.ResponseCacheManagerFactory;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CacheKeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -38,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author LivingLikeKrillin
  */
-class LocalResponseCacheMetricsAutoConfigurationTests {
+public class LocalResponseCacheMetricsAutoConfigurationTests {
 
 	@Test
 	void metricsListenerCreatedWhenMeterRegistryPresent() {
@@ -58,6 +62,19 @@ class LocalResponseCacheMetricsAutoConfigurationTests {
 			.withConfiguration(AutoConfigurations.of(LocalResponseCacheAutoConfiguration.class,
 					LocalResponseCacheMetricsAutoConfiguration.class))
 			.withPropertyValues(GatewayProperties.PREFIX + ".filter.local-response-cache.enabled=true")
+			.run(context -> {
+				assertThat(context).doesNotHaveBean(CacheMetricsListener.class);
+			});
+	}
+
+	@Test
+	void metricsListenerNotCreatedWhenGatewayDisabled() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheAutoConfiguration.class,
+					LocalResponseCacheMetricsAutoConfiguration.class))
+			.withUserConfiguration(MeterRegistryConfig.class)
+			.withPropertyValues(GatewayProperties.PREFIX + ".filter.local-response-cache.enabled=true",
+					GatewayProperties.PREFIX + ".enabled=false")
 			.run(context -> {
 				assertThat(context).doesNotHaveBean(CacheMetricsListener.class);
 			});
@@ -128,6 +145,26 @@ class LocalResponseCacheMetricsAutoConfigurationTests {
 				assertThat(context).hasSingleBean(CacheMetricsListener.class);
 				assertThat(registry.find("cache.size").tag("cache", "response-cache").gauge()).isNotNull();
 			});
+	}
+
+	@Test
+	void perRouteCacheMetricsRegisteredViaFilterFactory() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		CacheMetricsListener listener = (cache,
+				cacheName) -> io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics.monitor(registry, cache,
+						cacheName, java.util.Collections.emptyList());
+
+		Duration ttl = Duration.ofMinutes(5);
+		ResponseCacheManagerFactory cacheManagerFactory = new ResponseCacheManagerFactory(new CacheKeyGenerator());
+		LocalResponseCacheGatewayFilterFactory factory = new LocalResponseCacheGatewayFilterFactory(cacheManagerFactory,
+				ttl, null, new LocalResponseCacheProperties.RequestOptions(), new CaffeineCacheManager(), listener);
+
+		LocalResponseCacheGatewayFilterFactory.RouteCacheConfiguration routeConfig = new LocalResponseCacheGatewayFilterFactory.RouteCacheConfiguration();
+		routeConfig.setRouteId("my-route");
+		routeConfig.setTimeToLive(ttl);
+		factory.apply(routeConfig);
+
+		assertThat(registry.find("cache.size").tag("cache", "my-route-cache").gauge()).isNotNull();
 	}
 
 	@Configuration(proxyBeanMethods = false)

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
@@ -114,6 +114,22 @@ class LocalResponseCacheMetricsAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	void globalCacheMetricsRegisteredViaCaffeineCache() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheAutoConfiguration.class,
+					LocalResponseCacheMetricsAutoConfiguration.class))
+			.withBean(MeterRegistry.class, () -> registry)
+			.withPropertyValues(GatewayProperties.PREFIX + ".filter.local-response-cache.enabled=true",
+					GatewayProperties.PREFIX + ".enabled=true",
+					GatewayProperties.PREFIX + ".global-filter.local-response-cache.enabled=true")
+			.run(context -> {
+				assertThat(context).hasSingleBean(CacheMetricsListener.class);
+				assertThat(registry.find("cache.size").tag("cache", "response-cache").gauge()).isNotNull();
+			});
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	static class MeterRegistryConfig {
 

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.config;
+
+import java.time.Duration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory.CacheMetricsListener;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheProperties;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link LocalResponseCacheMetricsAutoConfiguration}.
+ *
+ * @author LivingLikeKrillin
+ */
+class LocalResponseCacheMetricsAutoConfigurationTests {
+
+	@Test
+	void metricsListenerCreatedWhenMeterRegistryPresent() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheAutoConfiguration.class,
+					LocalResponseCacheMetricsAutoConfiguration.class))
+			.withUserConfiguration(MeterRegistryConfig.class)
+			.withPropertyValues(GatewayProperties.PREFIX + ".filter.local-response-cache.enabled=true")
+			.run(context -> {
+				assertThat(context).hasSingleBean(CacheMetricsListener.class);
+			});
+	}
+
+	@Test
+	void metricsListenerNotCreatedWhenMeterRegistryAbsent() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheAutoConfiguration.class,
+					LocalResponseCacheMetricsAutoConfiguration.class))
+			.withPropertyValues(GatewayProperties.PREFIX + ".filter.local-response-cache.enabled=true")
+			.run(context -> {
+				assertThat(context).doesNotHaveBean(CacheMetricsListener.class);
+			});
+	}
+
+	@Test
+	void metricsListenerNotCreatedWhenMetricsDisabled() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheAutoConfiguration.class,
+					LocalResponseCacheMetricsAutoConfiguration.class))
+			.withUserConfiguration(MeterRegistryConfig.class)
+			.withPropertyValues(GatewayProperties.PREFIX + ".filter.local-response-cache.enabled=true",
+					GatewayProperties.PREFIX + ".metrics.enabled=false")
+			.run(context -> {
+				assertThat(context).doesNotHaveBean(CacheMetricsListener.class);
+			});
+	}
+
+	@Test
+	void caffeineRecordStatsEnabled() {
+		LocalResponseCacheProperties properties = new LocalResponseCacheProperties();
+		properties.setTimeToLive(Duration.ofMinutes(5));
+		Caffeine<Object, Object> caffeine = LocalResponseCacheUtils.createCaffeine(properties);
+		com.github.benmanes.caffeine.cache.Cache<Object, Object> cache = caffeine.build();
+
+		cache.put("key", "value");
+		cache.getIfPresent("key");
+		cache.getIfPresent("missing");
+
+		assertThat(cache.stats().hitCount()).isEqualTo(1);
+		assertThat(cache.stats().missCount()).isEqualTo(1);
+	}
+
+	@Test
+	void cacheMetricsListenerBindsToMeterRegistry() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+		LocalResponseCacheProperties properties = new LocalResponseCacheProperties();
+		properties.setTimeToLive(Duration.ofMinutes(5));
+		Caffeine<Object, Object> caffeine = LocalResponseCacheUtils.createCaffeine(properties);
+		com.github.benmanes.caffeine.cache.Cache<Object, Object> cache = caffeine.build();
+
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheMetricsAutoConfiguration.class))
+			.withBean(MeterRegistry.class, () -> registry)
+			.run(context -> {
+				CacheMetricsListener listener = context.getBean(CacheMetricsListener.class);
+				listener.onCacheCreated(cache, "test-cache");
+
+				cache.put("key", "value");
+				cache.getIfPresent("key");
+
+				assertThat(registry.find("cache.gets").tag("result", "hit").functionCounter()).isNotNull();
+				assertThat(registry.find("cache.size").tag("cache", "test-cache").gauge()).isNotNull();
+			});
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class MeterRegistryConfig {
+
+		@Bean
+		MeterRegistry meterRegistry() {
+			return new SimpleMeterRegistry();
+		}
+
+	}
+
+}

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/LocalResponseCacheMetricsAutoConfigurationTests.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.gateway.config;
 
 import java.time.Duration;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
@@ -165,6 +167,88 @@ public class LocalResponseCacheMetricsAutoConfigurationTests {
 		factory.apply(routeConfig);
 
 		assertThat(registry.find("cache.size").tag("cache", "my-route-cache").gauge()).isNotNull();
+	}
+
+	@Test
+	void metricsKeepTrackingCurrentCacheAcrossReplacement() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheMetricsAutoConfiguration.class))
+			.withBean(MeterRegistry.class, () -> registry)
+			.run(context -> {
+				CacheMetricsListener listener = context.getBean(CacheMetricsListener.class);
+
+				Cache<Object, Object> firstCache = Caffeine.newBuilder().recordStats().build();
+				listener.onCacheCreated(firstCache, "my-route-cache");
+				firstCache.put("a", "1");
+				firstCache.put("b", "2");
+
+				Cache<Object, Object> secondCache = Caffeine.newBuilder().recordStats().build();
+				listener.onCacheCreated(secondCache, "my-route-cache");
+				for (int i = 0; i < 5; i++) {
+					secondCache.put("key-" + i, "value-" + i);
+				}
+
+				Gauge sizeGauge = registry.find("cache.size").tag("cache", "my-route-cache").gauge();
+				assertThat(sizeGauge).isNotNull();
+				assertThat(sizeGauge.value()).isEqualTo(5.0);
+
+				long meterCount = registry.getMeters()
+					.stream()
+					.filter(m -> "cache.size".equals(m.getId().getName()))
+					.filter(m -> "my-route-cache".equals(m.getId().getTag("cache")))
+					.count();
+				assertThat(meterCount).isEqualTo(1);
+			});
+	}
+
+	@Test
+	void perRouteMetricsSurviveRouteRefresh() {
+		SimpleMeterRegistry registry = new SimpleMeterRegistry();
+
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(LocalResponseCacheMetricsAutoConfiguration.class))
+			.withBean(MeterRegistry.class, () -> registry)
+			.run(context -> {
+				CacheMetricsListener listener = context.getBean(CacheMetricsListener.class);
+				Duration ttl = Duration.ofMinutes(5);
+				ResponseCacheManagerFactory cacheManagerFactory = new ResponseCacheManagerFactory(
+						new CacheKeyGenerator());
+				CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+				LocalResponseCacheGatewayFilterFactory factory = new LocalResponseCacheGatewayFilterFactory(
+						cacheManagerFactory, ttl, null, new LocalResponseCacheProperties.RequestOptions(), cacheManager,
+						listener);
+
+				LocalResponseCacheGatewayFilterFactory.RouteCacheConfiguration routeConfig = new LocalResponseCacheGatewayFilterFactory.RouteCacheConfiguration();
+				routeConfig.setRouteId("my-route");
+				routeConfig.setTimeToLive(ttl);
+
+				factory.apply(routeConfig);
+				factory.apply(routeConfig);
+
+				org.springframework.cache.Cache currentCache = cacheManager.getCache("my-route-cache");
+				assertThat(currentCache).isNotNull();
+				for (int i = 0; i < 5; i++) {
+					currentCache.put("key-" + i, "value-" + i);
+				}
+				currentCache.get("key-0");
+				currentCache.get("missing");
+
+				Gauge sizeGauge = registry.find("cache.size").tag("cache", "my-route-cache").gauge();
+				assertThat(sizeGauge).isNotNull();
+				assertThat(sizeGauge.value()).isEqualTo(5.0);
+				assertThat(registry.find("cache.gets")
+					.tag("cache", "my-route-cache")
+					.tag("result", "hit")
+					.functionCounter()
+					.count()).isEqualTo(1.0);
+				assertThat(registry.find("cache.gets")
+					.tag("cache", "my-route-cache")
+					.tag("result", "miss")
+					.functionCounter()
+					.count()).isEqualTo(1.0);
+			});
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
## Summary
- Enable Caffeine `recordStats()` so cache statistics are collected at runtime
- Introduce a `CacheMetricsListener` callback in `LocalResponseCacheGatewayFilterFactory` and wire it from `LocalResponseCacheAutoConfiguration` for both the global cache and each per-route cache
- Add `LocalResponseCacheMetricsAutoConfiguration` that, when a `MeterRegistry` is present, exposes the standard Micrometer cache meters (`cache.size`, `cache.gets`, `cache.puts`, `cache.evictions`) tagged with `cache=<routeId>-cache` (per-route) or `cache=response-cache` (global) through Actuator
- Bind those meters through a refresh-safe `SwappableCacheMetricsListener`: each cacheName is bound to the registry once via a custom `CacheMeterBinder` backed by a mutable `AtomicReference`, and subsequent `onCacheCreated` calls swap the underlying Caffeine cache without re-registering meters. Without this indirection, `MeterRegistry`'s duplicate-id dedup keeps the gauge bound to the discarded cache and it eventually reports `NaN` once GC reclaims the old instance, which is exactly what happens after every `RefreshRoutesEvent`
- Tighten the `CacheMetricsListener` contract javadoc to require multi-invocation safety
- Document the metrics in `local-cache-response-filter.adoc` and `global-filters.adoc`

Fixes gh-3722

## Test plan
- [x] Verify `CacheMetricsListener` bean is created when `MeterRegistry` is present
- [x] Verify no bean is created when `MeterRegistry` is absent
- [x] Verify no bean is created when `gateway.metrics.enabled=false`
- [x] Verify Caffeine `recordStats()` collects hit/miss counts
- [x] Verify cache metrics are bound to `MeterRegistry` via listener callback
- [x] Verify gauges keep tracking the current cache when `onCacheCreated` is invoked twice for the same cacheName (regression test for the route-refresh stale-metric path)
- [x] Verify per-route metrics survive a route refresh end-to-end through `LocalResponseCacheGatewayFilterFactory.apply` and that `cache.size`, `cache.gets{result=hit}`, and `cache.gets{result=miss}` reflect the current cache
