### PR TITLE
Update documentation for DiscoveryClient locator section according to last updates since from 2025.0 version

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/the-discoveryclient-route-definition-locator.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/the-discoveryclient-route-definition-locator.adoc
@@ -5,7 +5,7 @@ You can configure the gateway to create routes based on services registered with
 
 By default, the routes created use the protocol `lb://service-name` (where `service-name` is the String that `DiscoveryClient::getServices` will return) and this means that they are load-balanced. For that reason, you also need to include the `org.springframework.cloud:spring-cloud-starter-loadbalancer` dependency, so that it is available on the classpath.
 
-To enable this, set `spring.cloud.gateway.discovery.locator.enabled=true` and make sure a `DiscoveryClient` implementation (such as Netflix Eureka, Consul, Zookeeper or Kubernetes) is on the classpath and enabled.
+To enable this, set `spring.cloud.gateway.server.webflux.discovery.locator.enabled=true` and make sure a `DiscoveryClient` implementation (such as Netflix Eureka, Consul, Zookeeper or Kubernetes) is on the classpath and enabled.
 
 [[configuring-predicates-and-filters-for-discoveryclient-routes]]
 == Configuring Predicates and Filters For `DiscoveryClient` Routes
@@ -18,7 +18,7 @@ the ID of the service from the `DiscoveryClient`.
 The default filter is a rewrite path filter with the regex `/serviceId/?(?<remaining>.*)` and the replacement `/$\{remaining}`.
 This strips the service ID from the path before the request is sent downstream.
 
-If you want to customize the predicates or filters used by the `DiscoveryClient` routes, set `spring.cloud.gateway.discovery.locator.predicates[x]` and `spring.cloud.gateway.discovery.locator.filters[y]`.
+If you want to customize the predicates or filters used by the `DiscoveryClient` routes, set `spring.cloud.gateway.server.webflux.discovery.locator.predicates[x]` and `spring.cloud.gateway.server.webflux.discovery.locator.filters[y]`.
 When doing so, you need to make sure to include the default predicate and filter shown earlier, if you want to retain that functionality.
 The following examples shows what this looks like in properties and yaml format:
 
@@ -26,15 +26,15 @@ The following examples shows what this looks like in properties and yaml format:
 [soure,properties]
 ====
 ----
-spring.cloud.gateway.discovery.locator.predicates[0].name=Path
-spring.cloud.gateway.discovery.locator.predicates[0].args[pattern]="'/'+serviceId+'/**'"
-spring.cloud.gateway.discovery.locator.predicates[1].name=Host
-spring.cloud.gateway.discovery.locator.predicates[1].args[pattern]="'**.foo.com'"
-spring.cloud.gateway.discovery.locator.filters[0].name=CircuitBreaker
-spring.cloud.gateway.discovery.locator.filters[0].args[name]=serviceId
-spring.cloud.gateway.discovery.locator.filters[1].name=RewritePath
-spring.cloud.gateway.discovery.locator.filters[1].args[regexp]="'/' + serviceId + '/?(?<remaining>.*)'"
-spring.cloud.gateway.discovery.locator.filters[1].args[replacement]="'/$\{remaining}'"
+spring.cloud.gateway.server.webflux.discovery.locator.predicates[0].name=Path
+spring.cloud.gateway.server.webflux.discovery.locator.predicates[0].args[pattern]="'/'+serviceId+'/**'"
+spring.cloud.gateway.server.webflux.discovery.locator.predicates[1].name=Host
+spring.cloud.gateway.server.webflux.discovery.locator.predicates[1].args[pattern]="'**.foo.com'"
+spring.cloud.gateway.server.webflux.discovery.locator.filters[0].name=CircuitBreaker
+spring.cloud.gateway.server.webflux.discovery.locator.filters[0].args[name]=serviceId
+spring.cloud.gateway.server.webflux.discovery.locator.filters[1].name=RewritePath
+spring.cloud.gateway.server.webflux.discovery.locator.filters[1].args[regexp]="'/' + serviceId + '/?(?<remaining>.*)'"
+spring.cloud.gateway.server.webflux.discovery.locator.filters[1].args[replacement]="'/$\{remaining}'"
 ----
 ====
 
@@ -45,22 +45,24 @@ spring.cloud.gateway.discovery.locator.filters[1].args[replacement]="'/$\{remain
 spring:
   cloud:
     gateway:
-      discovery:
-        locator:
-          predicates:
-          - name: Host
-            args:
-              pattern: "'**.foo.com'"
-          - name: Path
-            args:
-              pattern: "'/'+serviceId+'/**'"
-          filters:
-          - name: CircuitBreaker
-            args:
-              name: serviceId
-          - name: RewritePath
-            args:
-              regexp: "'/' + serviceId + '/?(?<remaining>.*)'"
-              replacement: "'/${remaining}'"
+      server:
+        webflux:
+          discovery:
+            locator:
+              predicates:
+              - name: Host
+                args:
+                  pattern: "'**.foo.com'"
+              - name: Path
+                args:
+                  pattern: "'/'+serviceId+'/**'"
+              filters:
+              - name: CircuitBreaker
+                args:
+                  name: serviceId
+              - name: RewritePath
+                args:
+                  regexp: "'/' + serviceId + '/?(?<remaining>.*)'"
+                  replacement: "'/${remaining}'"
 ----
 ====


### PR DESCRIPTION
# Problem:
Differences in documentation that confuse readers. Especially in the section linked below:
https://docs.spring.io/spring-cloud-gateway/reference/spring-cloud-gateway-server-webflux/the-discoveryclient-route-definition-locator.html

# Solution description:
Replace all places where the old property prefixes were with new prefixes according to the last updates since the 2025.0 version

# Source:
https://github.com/spring-cloud/spring-cloud-release/wiki/Spring-Cloud-2025.0-Release-Notes#spring-cloud-gateway

# Additionally:
The issue that inspired me to make this update: https://github.com/spring-cloud/spring-cloud-gateway/issues/4038