### PR TITLE
docs: Update CONTRIBUTING.md to reference DCO instead of CLA

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,21 +3,22 @@
 
 Spring Cloud is released under the non-restrictive Apache 2.0 license,
 and follows a very standard Github development process, using Github
-tracker for issues and merging pull requests into master. If you want
+tracker for issues and merging pull requests into main. If you want
 to contribute even something trivial please do not hesitate, but
 follow the guidelines below.
 
-## Sign the Contributor License Agreement
-Before we accept a non-trivial patch or pull request we will need you to sign the
-[Contributor License Agreement](https://cla.pivotal.io/sign/spring).
-Signing the contributor's agreement does not grant anyone commit rights to the main
-repository, but it does mean that we can accept your contributions, and you will get an
-author credit if we do.  Active contributors might be asked to join the core team, and
-given the ability to merge pull requests.
+## Developer Certificate of Origin (DCO)
+All commits must include a `Signed-off-by` trailer at the end of each commit message
+to indicate that the contributor agrees to the
+[Developer Certificate of Origin](https://developercertificate.org/).
+You can add this automatically by using `git commit -s`.
+
+For additional details, please refer to the blog post
+[Hello DCO, Goodbye CLA: Simplifying Contributions to Spring](https://spring.io/blog/2025/01/06/hello-dco-goodbye-cla-simplifying-contributions-to-spring).
 
 ## Code of Conduct
 This project adheres to the Contributor Covenant [Code of conduct](https://github.com/spring-cloud/spring-cloud-build/blob/main/docs/modules/ROOT/partials/code-of-conduct.adoc). By participating, you  are expected to uphold this code. Please report
-unacceptable behavior to spring-code-of-conduct@pivotal.io.
+unacceptable behavior to code-of-conduct@spring.io.
 
 ## Code Conventions and Housekeeping
 None of these is essential for a pull request, but they will all help.  They can also be
@@ -26,7 +27,7 @@ added after the original pull request but before a merge.
 * Use the Spring Framework code format conventions. If you use Eclipse
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
-  [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
+  [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/main/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
   [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546) to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -37,7 +38,7 @@ added after the original pull request but before a merge.
   than cosmetic changes).
 * Add some Javadocs and, if you change the namespace, some XSD doc elements.
 * A few unit tests would help a lot as well -- someone has to do it.
-* If no-one else is using your branch, please rebase it against the current master (or
+* If no-one else is using your branch, please rebase it against the current main (or
   other target branch in the main project).
 * When writing a commit message please follow [these conventions](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit


### PR DESCRIPTION
Update `.github/CONTRIBUTING.md` to replace the outdated CLA requirement with
the current DCO (Developer Certificate of Origin) guidance.

The `README.adoc` (generated from `spring-cloud-build`) already references DCO,
but `.github/CONTRIBUTING.md` still pointed to the retired Pivotal CLA.

While here, I also aligned a few other stale references:
- `master` → `main` (branch references)
- `spring-code-of-conduct@pivotal.io` → `code-of-conduct@spring.io`
  (matching the current `spring-cloud-build` contributing docs)

Fixes gh-3884