### PR TITLE
Add warn logging when WebSocket message receive fails

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
@@ -262,6 +262,12 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 										+ ", corresponding session:" + session.getId() + ", packet: "
 										+ webSocketMessage.getPayloadAsText());
 							}
+						}).doOnError(throwable -> {
+							if (log.isWarnEnabled()) {
+								log.warn("Error receiving WebSocket message from client session: "
+										+ session.getId() + ", proxySession: "
+										+ proxySession.getId(), throwable);
+							}
 						}));
 					// .log("proxySessionSend", Level.FINE);
 					Mono<Void> serverSessionSend = session
@@ -270,6 +276,12 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 								log.trace("session(send from backend): " + session.getId()
 										+ ", corresponding proxySession:" + proxySession.getId() + " packet: "
 										+ webSocketMessage.getPayloadAsText());
+							}
+						}).doOnError(throwable -> {
+							if (log.isWarnEnabled()) {
+								log.warn("Error receiving WebSocket message from backend proxySession: "
+										+ proxySession.getId() + ", session: "
+										+ session.getId(), throwable);
 							}
 						}));
 					// .log("sessionSend", Level.FINE);

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/WebsocketRoutingFilter.java
@@ -173,6 +173,14 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 		}
 	}
 
+	private static void logReceiveError(String fromLabel, String fromId, String toLabel, String toId,
+			Throwable throwable) {
+		if (log.isWarnEnabled()) {
+			log.warn("Error receiving WebSocket message from " + fromLabel + ": " + fromId + ", " + toLabel + ": "
+					+ toId, throwable);
+		}
+	}
+
 	private static class ProxyWebSocketHandler implements WebSocketHandler {
 
 		private final WebSocketClient client;
@@ -262,13 +270,9 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 										+ ", corresponding session:" + session.getId() + ", packet: "
 										+ webSocketMessage.getPayloadAsText());
 							}
-						}).doOnError(throwable -> {
-							if (log.isWarnEnabled()) {
-								log.warn("Error receiving WebSocket message from client session: "
-										+ session.getId() + ", proxySession: "
-										+ proxySession.getId(), throwable);
-							}
-						}));
+						})
+							.doOnError(throwable -> logReceiveError("client session", session.getId(), "proxySession",
+									proxySession.getId(), throwable)));
 					// .log("proxySessionSend", Level.FINE);
 					Mono<Void> serverSessionSend = session
 						.send(proxySession.receive().doOnNext(WebSocketMessage::retain).doOnNext(webSocketMessage -> {
@@ -277,13 +281,9 @@ public class WebsocketRoutingFilter implements GlobalFilter, Ordered {
 										+ ", corresponding proxySession:" + proxySession.getId() + " packet: "
 										+ webSocketMessage.getPayloadAsText());
 							}
-						}).doOnError(throwable -> {
-							if (log.isWarnEnabled()) {
-								log.warn("Error receiving WebSocket message from backend proxySession: "
-										+ proxySession.getId() + ", session: "
-										+ session.getId(), throwable);
-							}
-						}));
+						})
+							.doOnError(throwable -> logReceiveError("backend proxySession", proxySession.getId(),
+									"session", session.getId(), throwable)));
 					// .log("sessionSend", Level.FINE);
 					// Ensure closeStatus from one propagates to the other
 					Mono.when(serverClose, proxyClose).subscribe();


### PR DESCRIPTION
## Problem

When the gateway proxies WebSocket connections and a message exceeds the max frame payload length, the connection is dropped silently with no logging even at TRACE level. This makes it difficult to diagnose WebSocket connectivity issues.

## Changes

- Added `doOnError` handlers to both client-to-backend and backend-to-client WebSocket message flows in `WebsocketRoutingFilter`
- Logs a WARN level message with session IDs and the error cause when a receive error occurs

Fixes gh-1048