### PR TITLE
Add URI template support to ProxyExchange for observability

### DIFF
--- a/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
+++ b/spring-cloud-gateway-mvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
@@ -32,6 +32,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.Vector;
 import java.util.function.Function;
@@ -50,6 +52,7 @@ import org.springframework.cloud.gateway.mvc.config.ProxyProperties;
 import org.springframework.core.Conventions;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.RequestEntity.BodyBuilder;
@@ -146,6 +149,10 @@ public class ProxyExchange<T> {
 	public static Set<String> DEFAULT_SENSITIVE = ProxyProperties.DEFAULT_SENSITIVE;
 
 	private URI uri;
+
+	private String uriTemplate;
+
+	private Map<String, ?> uriVariables;
 
 	private RestTemplate rest;
 
@@ -247,6 +254,8 @@ public class ProxyExchange<T> {
 	 */
 	public ProxyExchange<T> uri(URI uri) {
 		this.uri = uri;
+		this.uriTemplate = null;
+		this.uriVariables = null;
 		return this;
 	}
 
@@ -262,6 +271,21 @@ public class ProxyExchange<T> {
 		catch (URISyntaxException e) {
 			throw new IllegalStateException("Cannot create URI", e);
 		}
+	}
+
+	/**
+	 * Sets the uri for the backend call using a URI template with variables. When a
+	 * template is provided, the downstream {@link RestTemplate} call preserves the
+	 * template pattern for observability (e.g. Micrometer URI tags).
+	 * @param uriTemplate the URI template (e.g. {@code "http://service/foos/{id}"})
+	 * @param uriVariables the variables to expand in the template
+	 * @return this for convenience
+	 */
+	public ProxyExchange<T> uri(String uriTemplate, Map<String, ?> uriVariables) {
+		this.uriTemplate = uriTemplate;
+		this.uriVariables = uriVariables;
+		this.uri = rest.getUriTemplateHandler().expand(uriTemplate, uriVariables);
+		return this;
 	}
 
 	public String path() {
@@ -356,6 +380,11 @@ public class ProxyExchange<T> {
 		Type type = this.responseType;
 		if (type instanceof TypeVariable || type instanceof WildcardType) {
 			type = Object.class;
+		}
+		if (this.uriTemplate != null && this.uriVariables != null) {
+			return rest.exchange(this.uriTemplate, Objects.requireNonNull(requestEntity.getMethod()),
+					new HttpEntity<>(requestEntity.getBody(), requestEntity.getHeaders()),
+					ParameterizedTypeReference.forType(type), this.uriVariables);
 		}
 		return rest.exchange(requestEntity, ParameterizedTypeReference.forType(type));
 	}

--- a/spring-cloud-gateway-mvc/src/test/java/org/springframework/cloud/gateway/mvc/ProductionConfigurationTests.java
+++ b/spring-cloud-gateway-mvc/src/test/java/org/springframework/cloud/gateway/mvc/ProductionConfigurationTests.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,9 @@ public class ProductionConfigurationTests {
 	@Autowired
 	private TestApplication application;
 
+	@Autowired
+	private MeterRegistry meterRegistry;
+
 	@LocalServerPort
 	private int port;
 
@@ -84,6 +88,17 @@ public class ProductionConfigurationTests {
 	@Test
 	public void get() {
 		assertThat(rest.getForObject("/proxy/0", Foo.class).getName()).isEqualTo("bye");
+	}
+
+	@Test
+	public void getWithUriTemplate() {
+		assertThat(rest.getForObject("/proxy/template/0", Foo.class).getName()).isEqualTo("bye");
+	}
+
+	@Test
+	public void getWithUriTemplatePreservesUriTagForObservability() {
+		rest.getForObject("/proxy/template/0", Foo.class);
+		assertThat(meterRegistry.find("http.client.requests").tag("uri", "/foos/{id}").timer()).isNotNull();
 	}
 
 	@Test
@@ -361,6 +376,11 @@ public class ProductionConfigurationTests {
 			@GetMapping("/proxy/{id}")
 			public ResponseEntity<?> proxyFoos(@PathVariable Integer id, ProxyExchange<?> proxy) {
 				return proxy.uri(home.toString() + "/foos/" + id).get();
+			}
+
+			@GetMapping("/proxy/template/{id}")
+			public ResponseEntity<?> proxyWithTemplate(@PathVariable Integer id, ProxyExchange<?> proxy) {
+				return proxy.uri(home.toString() + "/foos/{id}", Map.of("id", String.valueOf(id))).get();
 			}
 
 			@GetMapping("/proxy/path/**")


### PR DESCRIPTION
ProxyExchange.exchange() used rest.exchange(RequestEntity, ...) which loses
the URI template pattern, causing Micrometer http.client.requests uri tag
to always be "none".

Add uri(String, Map) overload that preserves the template so RestTemplate
can pass it to Micrometer.

Fixes #3458