### PR TITLE
Support empty path prefixes in PrefixPathGatewayFilterFactory

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactory.java
@@ -64,8 +64,9 @@ public class PrefixPathGatewayFilterFactory
 	@Override
 	public GatewayFilter apply(Config config) {
 		return new GatewayFilter() {
-			final UriTemplate uriTemplate = new UriTemplate(
-					Objects.requireNonNull(config.prefix, "prefix must not be null"));
+			final String prefix = Objects.requireNonNull(config.prefix, "prefix must not be null");
+
+			final @Nullable UriTemplate uriTemplate = prefix.isEmpty() ? null : new UriTemplate(prefix);
 
 			@Override
 			public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
@@ -78,10 +79,15 @@ public class PrefixPathGatewayFilterFactory
 				ServerHttpRequest req = exchange.getRequest();
 				addOriginalRequestUrl(exchange, req.getURI());
 
-				Map<String, String> uriVariables = getUriTemplateVariables(exchange);
-				URI uri = uriTemplate.expand(uriVariables);
+				String newPath = req.getURI().getRawPath();
+				URI uri = req.getURI();
 
-				String newPath = uri.getRawPath() + req.getURI().getRawPath();
+				if (uriTemplate != null) {
+					Map<String, String> uriVariables = getUriTemplateVariables(exchange);
+					uri = uriTemplate.expand(uriVariables);
+					newPath = uri.getRawPath() + newPath;
+				}
+
 				exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, uri);
 				ServerHttpRequest request = req.mutate().path(newPath).build();
 

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/PrefixPathGatewayFilterFactoryTest.java
@@ -49,6 +49,12 @@ public class PrefixPathGatewayFilterFactoryTest {
 	}
 
 	@Test
+	public void testEmptyPrefixPath() {
+		testPrefixPathFilter("", "/bar", "/bar");
+		testPrefixPathFilter("", "/hello%20world", "/hello%20world");
+	}
+
+	@Test
 	public void testPrefixPathWithVariable() {
 		HashMap<String, String> variables = new HashMap<>();
 		variables.put("id", "foo");


### PR DESCRIPTION
Closes #3201

## Summary
Allow empty path prefixes in PrefixPathGatewayFilterFactory by avoiding UriTemplate creation when the prefix is empty. This prevents exceptions and preserves the original request path.

## Changes
- Added conditional handling for empty prefix values
- Avoided UriTemplate instantiation for empty prefix
- Preserved existing behavior for non-empty prefixes

## Tests
- Added test coverage for empty prefix scenarios
- Verified no exceptions are thrown
- Confirmed original path remains unchanged