### PR TITLE
Support unresolved remote addresses in XForwardedHeadersFilter

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -237,7 +237,8 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 
 		if (isForEnabled()) {
 			String remoteAddr = null;
-			if (request.getRemoteAddress() != null && request.getRemoteAddress().getAddress() != null) {
+			if (request.getRemoteAddress() != null) {
+				// Support unresolved addresses (getAddress() may be null)
 				remoteAddr = request.getRemoteAddress().getHostString();
 			}
 			// match xforwarded for against trusted proxies

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -92,6 +92,27 @@ public class XForwardedHeadersFilterTests {
 	}
 
 	@Test
+	public void unresolvedRemoteAddressAddsXForwardedForHeader() {
+		// Create unresolved InetSocketAddress (this is the actual bug scenario)
+		InetSocketAddress unresolved = InetSocketAddress.createUnresolved("example.com", 80);
+
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost:8080/get")
+			.remoteAddress(unresolved)
+			.header(HttpHeaders.HOST, "myhost")
+			.build();
+
+		XForwardedHeadersFilter filter = new XForwardedHeadersFilter(ALLOW_ALL_REGEX);
+
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
+
+		// Verify header is present (this currently fails before your fix)
+		assertThat(headers.headerNames()).contains(X_FORWARDED_FOR_HEADER);
+
+		// Verify it uses host string (not null)
+		assertThat(headers.getFirst(X_FORWARDED_FOR_HEADER)).isEqualTo("example.com");
+	}
+
+	@Test
 	public void defaultPort() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost/get")
 			.remoteAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))


### PR DESCRIPTION
Closes #2648

## Summary
Support unresolved remote addresses in `XForwardedHeadersFilter` by using the remote host string when `getRemoteAddress()` is present, even if the underlying address is unresolved.

## Changes
- removed the extra `getAddress() != null` guard when determining the remote address
- preserved existing behavior for resolved remote addresses
- added test coverage for unresolved `InetSocketAddress` values

## Tests
- added a test covering `InetSocketAddress.createUnresolved(...)`
- verified `X-Forwarded-For` is written for unresolved remote addresses