### PR TITLE
Add route ID-based CORS lookup for Host-predicated routes

### DIFF
--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/cors/CorsGatewayFilterApplicationListener.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/filter/cors/CorsGatewayFilterApplicationListener.java
@@ -87,10 +87,12 @@ public class CorsGatewayFilterApplicationListener implements ApplicationListener
 		routeLocator.getRoutes().collectList().subscribe(routes -> {
 			// pre-populate with pre-existing global cors configurations to combine with.
 			Map<String, CorsConfiguration> corsConfigurations = new LinkedHashMap<>();
+			Map<String, CorsConfiguration> routeCorsConfigurations = new LinkedHashMap<>();
 
 			routes.forEach(route -> {
 				Optional<CorsConfiguration> corsConfiguration = getCorsConfiguration(route);
 				corsConfiguration.ifPresent(configuration -> {
+					routeCorsConfigurations.put(route.getId(), configuration);
 					String pathPredicate = getPathPredicate(route);
 					corsConfigurations.put(pathPredicate, configuration);
 				});
@@ -101,6 +103,7 @@ public class CorsGatewayFilterApplicationListener implements ApplicationListener
 					corsConfigurations.put(path, config);
 				}
 			});
+			routePredicateHandlerMapping.setRouteCorsConfigurations(routeCorsConfigurations);
 			routePredicateHandlerMapping.setCorsConfigurations(corsConfigurations);
 		});
 	}

--- a/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
+++ b/spring-cloud-gateway-server/src/main/java/org/springframework/cloud/gateway/handler/RoutePredicateHandlerMapping.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.gateway.handler;
 
+import java.util.Collections;
+import java.util.Map;
 import java.util.function.Function;
 
 import reactor.core.publisher.Mono;
@@ -27,6 +29,7 @@ import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.reactive.UrlBasedCorsConfigurationSource;
 import org.springframework.web.reactive.handler.AbstractHandlerMapping;
 import org.springframework.web.server.ServerWebExchange;
 
@@ -50,6 +53,8 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 	private final Integer managementPort;
 
 	private final ManagementPortType managementPortType;
+
+	private volatile Map<String, CorsConfiguration> routeCorsConfigurations = Collections.emptyMap();
 
 	public RoutePredicateHandlerMapping(FilteringWebHandler webHandler, RouteLocator routeLocator,
 			GlobalCorsProperties globalCorsProperties, Environment environment) {
@@ -105,6 +110,30 @@ public class RoutePredicateHandlerMapping extends AbstractHandlerMapping {
 						logger.trace("No RouteDefinition found for [" + getExchangeDesc(exchange) + "]");
 					}
 				})));
+		});
+	}
+
+	public void setRouteCorsConfigurations(Map<String, CorsConfiguration> routeCorsConfigurations) {
+		this.routeCorsConfigurations = routeCorsConfigurations;
+	}
+
+	@Override
+	public void setCorsConfigurations(Map<String, CorsConfiguration> corsConfigurations) {
+		if (this.routeCorsConfigurations.isEmpty()) {
+			super.setCorsConfigurations(corsConfigurations);
+			return;
+		}
+		UrlBasedCorsConfigurationSource pathBasedSource = new UrlBasedCorsConfigurationSource(getPathPatternParser());
+		pathBasedSource.setCorsConfigurations(corsConfigurations);
+		setCorsConfigurationSource(exchange -> {
+			Route route = exchange.getAttribute(GATEWAY_ROUTE_ATTR);
+			if (route != null) {
+				CorsConfiguration routeConfig = this.routeCorsConfigurations.get(route.getId());
+				if (routeConfig != null) {
+					return routeConfig;
+				}
+			}
+			return pathBasedSource.getCorsConfiguration(exchange);
 		});
 	}
 

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/cors/CorsPerRouteTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/cors/CorsPerRouteTests.java
@@ -97,6 +97,50 @@ public class CorsPerRouteTests extends BaseWebClientTests {
 	}
 
 	@Test
+	public void testPreFlightCorsRequestHostPredicateA() {
+		testClient.options()
+			.uri("/anything")
+			.header("Origin", "https://origin-a.com")
+			.header("Host", "hosta.example.com")
+			.header("Access-Control-Request-Method", "GET")
+			.exchange()
+			.expectBody(Map.class)
+			.consumeWith(result -> {
+				assertThat(result.getResponseBody()).isNull();
+				assertThat(result.getStatus()).isEqualTo(HttpStatus.OK);
+
+				HttpHeaders responseHeaders = result.getResponseHeaders();
+				assertThat(responseHeaders.getAccessControlAllowOrigin()).as(missingHeader(ACCESS_CONTROL_ALLOW_ORIGIN))
+					.isEqualTo("https://origin-a.com");
+				assertThat(responseHeaders.getAccessControlAllowMethods())
+					.as(missingHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+					.containsExactly(HttpMethod.GET);
+			});
+	}
+
+	@Test
+	public void testPreFlightCorsRequestHostPredicateB() {
+		testClient.options()
+			.uri("/anything")
+			.header("Origin", "https://origin-b.com")
+			.header("Host", "hostb.example.com")
+			.header("Access-Control-Request-Method", "POST")
+			.exchange()
+			.expectBody(Map.class)
+			.consumeWith(result -> {
+				assertThat(result.getResponseBody()).isNull();
+				assertThat(result.getStatus()).isEqualTo(HttpStatus.OK);
+
+				HttpHeaders responseHeaders = result.getResponseHeaders();
+				assertThat(responseHeaders.getAccessControlAllowOrigin()).as(missingHeader(ACCESS_CONTROL_ALLOW_ORIGIN))
+					.isEqualTo("https://origin-b.com");
+				assertThat(responseHeaders.getAccessControlAllowMethods())
+					.as(missingHeader(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+					.containsExactly(HttpMethod.POST);
+			});
+	}
+
+	@Test
 	public void testPreFlightForbiddenCorsRequest() {
 		testClient.get()
 			.uri("/cors")

--- a/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/cors/CorsGatewayFilterApplicationListenerTests.java
+++ b/spring-cloud-gateway-server/src/test/java/org/springframework/cloud/gateway/filter/cors/CorsGatewayFilterApplicationListenerTests.java
@@ -34,6 +34,7 @@ import reactor.core.publisher.Flux;
 import org.springframework.cloud.gateway.config.GlobalCorsProperties;
 import org.springframework.cloud.gateway.event.RefreshRoutesResultEvent;
 import org.springframework.cloud.gateway.handler.RoutePredicateHandlerMapping;
+import org.springframework.cloud.gateway.handler.predicate.HostRoutePredicateFactory;
 import org.springframework.cloud.gateway.handler.predicate.PathRoutePredicateFactory;
 import org.springframework.cloud.gateway.route.Route;
 import org.springframework.cloud.gateway.route.RouteLocator;
@@ -104,6 +105,9 @@ class CorsGatewayFilterApplicationListenerTests {
 	@Captor
 	private ArgumentCaptor<Map<String, CorsConfiguration>> corsConfigurations;
 
+	@Captor
+	private ArgumentCaptor<Map<String, CorsConfiguration>> routeCorsConfigurations;
+
 	private GlobalCorsProperties globalCorsProperties;
 
 	private CorsGatewayFilterApplicationListener listener;
@@ -150,12 +154,76 @@ class CorsGatewayFilterApplicationListenerTests {
 		return config;
 	}
 
+	@Test
+	void testOnApplicationEvent_hostOnlyRoutes_storesRouteCorsConfigurations() {
+
+		String hostA = "hosta.example.com";
+		String hostB = "hostb.example.com";
+		String originA = "https://originA.com";
+		String originB = "https://originB.com";
+		String routeIdA = "host-route-a";
+		String routeIdB = "host-route-b";
+
+		Route routeA = buildHostRoute(routeIdA, hostA, originA);
+		Route routeB = buildHostRoute(routeIdB, hostB, originB);
+
+		when(routeLocator.getRoutes()).thenReturn(Flux.just(routeA, routeB));
+
+		listener.onApplicationEvent(new RefreshRoutesResultEvent(this));
+
+		Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+
+			verify(handlerMapping).setRouteCorsConfigurations(routeCorsConfigurations.capture());
+
+			Map<String, CorsConfiguration> routeConfigs = routeCorsConfigurations.getValue();
+			assertThat(routeConfigs).containsKeys(routeIdA, routeIdB);
+			assertThat(routeConfigs.get(routeIdA).getAllowedOrigins()).containsExactly(originA);
+			assertThat(routeConfigs.get(routeIdB).getAllowedOrigins()).containsExactly(originB);
+		});
+	}
+
+	@Test
+	void testOnApplicationEvent_pathRoutes_alsoStoresRouteCorsConfigurations() {
+
+		Route route1 = buildRoute(ROUTE_ID_1, ROUTE_PATH_1, ORIGIN_ROUTE_1);
+		Route route2 = buildRoute(ROUTE_ID_2, ROUTE_PATH_2, ORIGIN_ROUTE_2);
+
+		when(routeLocator.getRoutes()).thenReturn(Flux.just(route1, route2));
+
+		listener.onApplicationEvent(new RefreshRoutesResultEvent(this));
+
+		Awaitility.await().atMost(Duration.ofSeconds(2)).untilAsserted(() -> {
+
+			verify(handlerMapping).setRouteCorsConfigurations(routeCorsConfigurations.capture());
+			verify(handlerMapping).setCorsConfigurations(corsConfigurations.capture());
+
+			Map<String, CorsConfiguration> routeConfigs = routeCorsConfigurations.getValue();
+			assertThat(routeConfigs).containsKeys(ROUTE_ID_1, ROUTE_ID_2);
+			assertThat(routeConfigs.get(ROUTE_ID_1).getAllowedOrigins()).containsExactly(ORIGIN_ROUTE_1);
+			assertThat(routeConfigs.get(ROUTE_ID_2).getAllowedOrigins()).containsExactly(ORIGIN_ROUTE_2);
+
+			// path-based configurations should still work
+			Map<String, CorsConfiguration> pathConfigs = corsConfigurations.getValue();
+			assertThat(pathConfigs).containsKeys(ROUTE_PATH_1, ROUTE_PATH_2);
+		});
+	}
+
 	private Route buildRoute(String id, String path, String allowedOrigin) {
 
 		return Route.async()
 			.id(id)
 			.uri(ROUTE_URI)
 			.predicate(new PathRoutePredicateFactory().apply(config -> config.setPatterns(List.of(path))))
+			.metadata(METADATA_KEY, Map.of(ALLOWED_ORIGINS_KEY, List.of(allowedOrigin)))
+			.build();
+	}
+
+	private Route buildHostRoute(String id, String host, String allowedOrigin) {
+
+		return Route.async()
+			.id(id)
+			.uri(ROUTE_URI)
+			.predicate(new HostRoutePredicateFactory().apply(config -> config.setPatterns(List.of(host))))
 			.metadata(METADATA_KEY, Map.of(ALLOWED_ORIGINS_KEY, List.of(allowedOrigin)))
 			.build();
 	}

--- a/spring-cloud-gateway-server/src/test/resources/application-cors-per-route-config.yml
+++ b/spring-cloud-gateway-server/src/test/resources/application-cors-per-route-config.yml
@@ -26,3 +26,21 @@ spring:
                 - GET
                 - PUT
               allowedHeaders: '*'
+        - id: cors_host_a
+          uri: ${test.uri}
+          predicates:
+            - Host=hosta.example.com
+          metadata:
+            cors:
+              allowedOrigins: 'https://origin-a.com'
+              allowedMethods:
+                - GET
+        - id: cors_host_b
+          uri: ${test.uri}
+          predicates:
+            - Host=hostb.example.com
+          metadata:
+            cors:
+              allowedOrigins: 'https://origin-b.com'
+              allowedMethods:
+                - POST


### PR DESCRIPTION
Routes using only Host predicates fall back to `/**` as the path-based
CORS key, so multiple Host-predicated routes overwrite each other's
CORS configuration.

Add a route ID-keyed map alongside the existing path-based map and
wrap `CorsConfigurationSource` to resolve by matched route ID first.

Fixes gh-3278