### PR TITLE
Docs: Document required dependency for JsonToGrpc filter

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/jsontogrpc-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/jsontogrpc-factory.adoc
@@ -22,6 +22,18 @@ src/main/resources/proto/hello.proto
 
 NOTE: `streaming` is not supported.
 
+=== Required Dependencies
+
+To use the `JsonToGrpc` filter, add the following dependencies:
+
+[source,xml]
+----
+<dependency>
+    <groupId>com.fasterxml.jackson.dataformat</groupId>
+    <artifactId>jackson-dataformat-protobuf</artifactId>
+</dependency>
+----
+
 
 *application.yml.*
 


### PR DESCRIPTION
## What does this PR do?

Documents the required `jackson-dataformat-protobuf` dependency for the
JsonToGrpc filter.

## Why is it needed?

Without this dependency, users get a `NoClassDefFoundError` when using the
JsonToGrpc filter.

Fixes #3424