### PR TITLE
Wire JDK HttpClient with virtual-thread executor when spring.threads.virtual.enabled=true

### DIFF
--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.server.mvc;
 
+import java.net.http.HttpClient;
 import java.util.Map;
 import java.util.Objects;
 
@@ -24,6 +25,7 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.EnvironmentPostProcessor;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.http.client.HttpRedirects;
@@ -63,13 +65,18 @@ import org.springframework.cloud.gateway.server.mvc.predicate.PredicateBeanFacto
 import org.springframework.cloud.gateway.server.mvc.predicate.PredicateDiscoverer;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.task.VirtualThreadTaskExecutor;
+import org.springframework.core.type.AnnotatedTypeMetadata;
 import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
@@ -111,6 +118,37 @@ public class GatewayServerMvcAutoConfiguration {
 			// for backwards compatibility if user overrode
 			requestFactoryProvider.ifAvailable(restClientBuilder::requestFactory);
 		};
+	}
+
+	/**
+	 * When Spring Boot virtual threads are enabled
+	 * (<code>spring.threads.virtual.enabled=true</code>) and the JDK {@link HttpClient}
+	 * is the chosen outbound HTTP factory, the JDK HttpClient does not by default
+	 * propagate the virtual-threads configuration to its internal request executor. It
+	 * falls back to {@code Executors.newCachedThreadPool()}, which spawns platform
+	 * threads (named {@code HttpClient-N-Worker-M}) and caps proxy throughput well below
+	 * what the virtual-thread Tomcat front end can sustain. See <a href=
+	 * "https://github.com/spring-cloud/spring-cloud-gateway/issues/4150">#4150</a>.
+	 *
+	 * <p>
+	 * This bean explicitly wires the JDK HttpClient with a virtual-thread-per-task
+	 * executor so outbound proxy calls run on virtual threads end-to-end. It is only
+	 * registered when the user has not provided their own
+	 * {@link ClientHttpRequestFactory} and the JDK HttpClient would actually be used
+	 * (either explicitly via {@code spring.http.clients.imperative.factory=jdk} or by
+	 * auto-detection when no higher-priority client like Apache, Jetty, or Reactor Netty
+	 * is on the classpath).
+	 */
+	@Bean
+	@ConditionalOnMissingBean(ClientHttpRequestFactory.class)
+	@ConditionalOnClass(name = "java.net.http.HttpClient")
+	@ConditionalOnProperty(prefix = "spring.threads.virtual", name = "enabled", havingValue = "true")
+	@Conditional(GatewayJdkHttpClientFactoryCondition.class)
+	public ClientHttpRequestFactory gatewayVirtualThreadJdkClientHttpRequestFactory() {
+		HttpClient httpClient = HttpClient.newBuilder()
+			.executor(new VirtualThreadTaskExecutor("gateway-jdk-http-"))
+			.build();
+		return new JdkClientHttpRequestFactory(httpClient);
 	}
 
 	@Bean
@@ -293,6 +331,26 @@ public class GatewayServerMvcAutoConfiguration {
 					System.setProperty("jdk.httpclient.allowRestrictedHeaders", restrictedHeaders + ",host");
 				}
 			}
+		}
+
+	}
+
+	/**
+	 * Matches when the JDK {@link HttpClient} is the chosen outbound factory: either
+	 * {@code spring.http.clients.imperative.factory=jdk} is set explicitly, or no
+	 * higher-priority client (Apache, Jetty, Reactor Netty) is on the classpath so
+	 * {@link GatewayHttpClientEnvironmentPostProcessor} would auto-detect JDK.
+	 */
+	static class GatewayJdkHttpClientFactoryCondition implements Condition {
+
+		@Override
+		public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+			Environment env = context.getEnvironment();
+			String factory = env.getProperty(GatewayHttpClientEnvironmentPostProcessor.SPRING_HTTP_FACTORY_PROPERTY);
+			if (StringUtils.hasText(factory)) {
+				return Factory.JDK.name().equalsIgnoreCase(factory);
+			}
+			return !GatewayHttpClientEnvironmentPostProcessor.HIGHER_PRIORITY;
 		}
 
 	}

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfigurationTests.java
@@ -16,9 +16,13 @@
 
 package org.springframework.cloud.gateway.server.mvc;
 
+import java.lang.reflect.Field;
+import java.net.http.HttpClient;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -48,6 +52,9 @@ import org.springframework.cloud.gateway.server.mvc.handler.HandlerFunctionAutoC
 import org.springframework.cloud.gateway.server.mvc.predicate.PredicateAutoConfiguration;
 import org.springframework.cloud.loadbalancer.annotation.LoadBalancerClient;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.core.task.VirtualThreadTaskExecutor;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -170,6 +177,75 @@ public class GatewayServerMvcAutoConfigurationTests {
 	}
 
 	@Test
+	void virtualThreadJdkClientHttpRequestFactoryNotRegisteredByDefault() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FilterAutoConfiguration.class, PredicateAutoConfiguration.class,
+					HandlerFunctionAutoConfiguration.class, GatewayServerMvcAutoConfiguration.class,
+					HttpClientAutoConfiguration.class, RestTemplateAutoConfiguration.class,
+					RestClientAutoConfiguration.class))
+			.run(context -> assertThat(context).doesNotHaveBean("gatewayVirtualThreadJdkClientHttpRequestFactory"));
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadJdkClientHttpRequestFactoryRegisteredWhenVirtualThreadsEnabled() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FilterAutoConfiguration.class, PredicateAutoConfiguration.class,
+					HandlerFunctionAutoConfiguration.class, GatewayServerMvcAutoConfiguration.class,
+					HttpClientAutoConfiguration.class, RestTemplateAutoConfiguration.class,
+					RestClientAutoConfiguration.class))
+			.withPropertyValues("spring.threads.virtual.enabled=true")
+			.run(context -> {
+				assertThat(context).hasBean("gatewayVirtualThreadJdkClientHttpRequestFactory");
+				ClientHttpRequestFactory factory = context.getBean("gatewayVirtualThreadJdkClientHttpRequestFactory",
+						ClientHttpRequestFactory.class);
+				assertThat(factory).isInstanceOf(JdkClientHttpRequestFactory.class);
+				HttpClient httpClient = extractHttpClient((JdkClientHttpRequestFactory) factory);
+				assertThat(httpClient.executor()).isPresent();
+				assertThat(httpClient.executor().get()).isInstanceOf(VirtualThreadTaskExecutor.class);
+			});
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadJdkClientHttpRequestFactoryNotRegisteredWhenFactoryIsNotJdk() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FilterAutoConfiguration.class, PredicateAutoConfiguration.class,
+					HandlerFunctionAutoConfiguration.class, GatewayServerMvcAutoConfiguration.class,
+					HttpClientAutoConfiguration.class, RestTemplateAutoConfiguration.class,
+					RestClientAutoConfiguration.class))
+			.withPropertyValues("spring.threads.virtual.enabled=true", "spring.http.clients.imperative.factory=simple")
+			.run(context -> assertThat(context).doesNotHaveBean("gatewayVirtualThreadJdkClientHttpRequestFactory"));
+	}
+
+	@Test
+	@EnabledForJreRange(min = JRE.JAVA_21)
+	void virtualThreadJdkClientHttpRequestFactoryBacksOffWhenUserProvidesOne() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FilterAutoConfiguration.class, PredicateAutoConfiguration.class,
+					HandlerFunctionAutoConfiguration.class, GatewayServerMvcAutoConfiguration.class,
+					HttpClientAutoConfiguration.class, RestTemplateAutoConfiguration.class,
+					RestClientAutoConfiguration.class))
+			.withPropertyValues("spring.threads.virtual.enabled=true")
+			.withUserConfiguration(UserClientHttpRequestFactoryConfig.class)
+			.run(context -> {
+				assertThat(context).doesNotHaveBean("gatewayVirtualThreadJdkClientHttpRequestFactory");
+				assertThat(context).hasBean("userClientHttpRequestFactory");
+			});
+	}
+
+	private static HttpClient extractHttpClient(JdkClientHttpRequestFactory factory) {
+		try {
+			Field field = JdkClientHttpRequestFactory.class.getDeclaredField("httpClient");
+			field.setAccessible(true);
+			return (HttpClient) field.get(factory);
+		}
+		catch (ReflectiveOperationException ex) {
+			throw new IllegalStateException("Could not read httpClient from JdkClientHttpRequestFactory", ex);
+		}
+	}
+
+	@Test
 	void loadBalancerFunctionHandlerAdded() {
 		new ApplicationContextRunner()
 			.withConfiguration(AutoConfigurations.of(FilterAutoConfiguration.class, PredicateAutoConfiguration.class,
@@ -193,6 +269,18 @@ public class GatewayServerMvcAutoConfigurationTests {
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
 	static class TestConfig {
+
+	}
+
+	@org.springframework.context.annotation.Configuration(proxyBeanMethods = false)
+	static class UserClientHttpRequestFactoryConfig {
+
+		@org.springframework.context.annotation.Bean
+		ClientHttpRequestFactory userClientHttpRequestFactory() {
+			return (uri, httpMethod) -> {
+				throw new UnsupportedOperationException("test factory");
+			};
+		}
 
 	}
 


### PR DESCRIPTION
Fixes #4150.

## Problem

When `spring.threads.virtual.enabled=true` is set, Spring Boot switches the inbound Tomcat handlers to virtual threads, but Spring Cloud Gateway MVC's outbound JDK `HttpClient` still falls back to `Executors.newCachedThreadPool()` — spawning ~145 platform threads named `HttpClient-N-Worker-M` and capping proxy throughput at roughly 25% of what the virtual-thread front end can sustain.

The reporter's benchmark on the issue:

| Metric | Before | After |
|--------|-------:|------:|
| Throughput @ c=200 | 2.3K req/s | 9.8K req/s |
| P99 latency       | 439 ms     | 152 ms    |
| Platform threads  | 145        | 0         |

## Fix

Registers a `ClientHttpRequestFactory` bean in `GatewayServerMvcAutoConfiguration` that builds a `JdkClientHttpRequestFactory` whose underlying `java.net.http.HttpClient` is wired with a `VirtualThreadTaskExecutor`, so outbound proxy calls run on virtual threads end-to-end.

The bean is conditional on:

- `spring.threads.virtual.enabled=true`
- `java.net.http.HttpClient` on the classpath
- JDK being the chosen outbound factory — explicit via `spring.http.clients.imperative.factory=jdk`, or auto-detected when no Apache / Jetty / Reactor Netty is on the classpath
- the user not having defined their own `ClientHttpRequestFactory` (`@ConditionalOnMissingBean`)

## Tests

Four new unit tests in `GatewayServerMvcAutoConfigurationTests` covering each conditional path:

- bean is not registered by default
- bean is registered and wired with a `VirtualThreadTaskExecutor` when virtual threads are enabled
- bean is not registered when `spring.http.clients.imperative.factory=simple`
- bean backs off when the user provides their own `ClientHttpRequestFactory`

The Java-21-specific tests are gated with `@EnabledForJreRange(min = JRE.JAVA_21)`. All 9 tests pass locally on JDK 21.