### PR TITLE
Forward incoming headers in WebFlux ProxyExchange body requests

### DIFF
--- a/spring-cloud-gateway-proxyexchange-webflux/src/main/java/org/springframework/cloud/gateway/webflux/ProxyExchange.java
+++ b/spring-cloud-gateway-proxyexchange-webflux/src/main/java/org/springframework/cloud/gateway/webflux/ProxyExchange.java
@@ -372,7 +372,8 @@ public class ProxyExchange<T> {
 		Objects.requireNonNull(requestEntity.getMethod(), "Method must not be null");
 		RequestBodySpec builder = rest.method(requestEntity.getMethod())
 			.uri(requestEntity.getUrl())
-			.headers(headers -> addHeaders(headers, requestEntity.getHeaders()));
+			.headers(headers -> addHeaders(headers, requestEntity.getHeaders()))
+			.headers(headers -> addHeaders(headers, exchange.getRequest().getHeaders()));
 		WebClient.ResponseSpec result;
 		if (requestEntity.getBody() instanceof Publisher) {
 			@SuppressWarnings("unchecked")
@@ -384,12 +385,10 @@ public class ProxyExchange<T> {
 		}
 		else {
 			if (hasBody) {
-				result = builder.headers(headers -> addHeaders(headers, exchange.getRequest().getHeaders()))
-					.body(exchange.getRequest().getBody(), DataBuffer.class)
-					.retrieve();
+				result = builder.body(exchange.getRequest().getBody(), DataBuffer.class).retrieve();
 			}
 			else {
-				result = builder.headers(headers -> addHeaders(headers, exchange.getRequest().getHeaders())).retrieve();
+				result = builder.retrieve();
 			}
 		}
 		return result.onStatus(HttpStatusCode::isError, t -> Mono.empty())

--- a/spring-cloud-gateway-proxyexchange-webflux/src/test/java/org/springframework/cloud/gateway/webflux/ProductionConfigurationTests.java
+++ b/spring-cloud-gateway-proxyexchange-webflux/src/test/java/org/springframework/cloud/gateway/webflux/ProductionConfigurationTests.java
@@ -124,6 +124,16 @@ public class ProductionConfigurationTests {
 	}
 
 	@Test
+	public void postWithBodyForwardsIncomingHeaders() throws Exception {
+		ResponseEntity<Bar> response = rest
+			.exchange(RequestEntity.post(rest.getRestTemplate().getUriTemplateHandler().expand("/proxy/0"))
+				.header("X-Custom", "incoming-header-value")
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(Collections.singletonMap("name", "foo")), Bar.class);
+		assertThat(response.getBody().getName()).contains("incoming-header-value");
+	}
+
+	@Test
 	public void postJsonWithWhitespace() {
 		var json = """
 				{


### PR DESCRIPTION
## Summary

The WebFlux variant of `ProxyExchange.exchange()` drops incoming request headers on POST/PUT/PATCH/DELETE-with-body, because the two body-carrying branches skip the `addHeaders(...)` call that the body-less branches make. Custom headers like `Authorization` or `X-Custom` set on the original request never reach the upstream service.

## Changes

- Hoist `addHeaders(exchange.getRequest().getHeaders())` to the builder construction site so every branch picks it up
- Remove the duplicate `addHeaders` calls from the body-less branches (they were no-ops anyway since `addHeaders` is idempotent)
- Add `postWithBodyForwardsIncomingHeaders` regression test using the existing `/proxy/{id}` -> `/bars` wiring

## Context

The webmvc variant of `ProxyExchange` is unaffected: its private `headers(BodyBuilder)` helper already adds incoming headers on every method, so I kept the fix scoped to the webflux module.

`./mvnw -pl spring-cloud-gateway-proxyexchange-webflux test` passes locally (28/28).

Fixes gh-2559
