### PR TITLE
Skip route refresh after the context starts shutting down

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
@@ -35,6 +35,8 @@ import org.springframework.cloud.gateway.event.RefreshRoutesResultEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.event.ContextClosedEvent;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 
@@ -55,6 +57,8 @@ public class CachingRouteLocator
 	private final Map<String, List> cache = new ConcurrentHashMap<>();
 
 	private @Nullable ApplicationEventPublisher applicationEventPublisher;
+
+	private volatile boolean contextClosing = false;
 
 	public CachingRouteLocator(RouteLocator delegate) {
 		this.delegate = delegate;
@@ -85,6 +89,13 @@ public class CachingRouteLocator
 
 	@Override
 	public void onApplicationEvent(RefreshRoutesEvent event) {
+		// gh-2471: skip refresh once the ApplicationContext has started shutting
+		// down. RefreshRoutesEvent can still be published during shutdown (e.g.
+		// ConsulServiceRegistry.deregister()), and any bean lookup performed by
+		// the delegate at that point would fail with BeanCreationNotAllowedException.
+		if (contextClosing) {
+			return;
+		}
 		try {
 			if (this.cache.containsKey(CACHE_KEY) && event.isScoped()) {
 				final Mono<List<Route>> scopedRoutes = fetch(event.getMetadata()).collect(Collectors.toList())
@@ -138,6 +149,10 @@ public class CachingRouteLocator
 	@Override
 	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
 		this.applicationEventPublisher = applicationEventPublisher;
+		if (applicationEventPublisher instanceof ConfigurableApplicationContext context) {
+			ApplicationListener<ContextClosedEvent> shutdownListener = event -> this.contextClosing = true;
+			context.addApplicationListener(shutdownListener);
+		}
 	}
 
 }

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/route/CachingRouteLocatorShutdownTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/route/CachingRouteLocatorShutdownTests.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.route;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
+import org.springframework.context.support.GenericApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Reproduction tests for gh-2471: shutdown can cause BeanCreationNotAllowedException
+ * because RefreshRoutesEvent listeners (such as CachingRouteLocator) keep delegating to
+ * RouteLocator beans even after the ApplicationContext has started destroying singletons
+ * (e.g. ConsulServiceRegistry.deregister() publishing a RefreshRoutesEvent during
+ * destroy). The expected behaviour is that CachingRouteLocator short-circuits the refresh
+ * once shutdown has begun, so it does not try to obtain (or recreate) any beans that the
+ * BeanFactory will refuse to provide.
+ */
+public class CachingRouteLocatorShutdownTests {
+
+	@Test
+	public void doesNotRefreshAfterContextHasStartedClosing() {
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.refresh();
+
+		AtomicInteger fetchCount = new AtomicInteger();
+		Route route = Route.async().id("r1").uri("http://localhost").order(0).predicate(exchange -> true).build();
+
+		RouteLocator delegate = () -> {
+			fetchCount.incrementAndGet();
+			return Flux.just(route);
+		};
+
+		CachingRouteLocator locator = new CachingRouteLocator(delegate);
+		locator.setApplicationEventPublisher(context);
+		context.addApplicationListener(locator);
+
+		// Prime the cache so the first fetch counts as the baseline (1).
+		locator.getRoutes().collectList().block();
+		int baselineFetches = fetchCount.get();
+		assertThat(baselineFetches).isEqualTo(1);
+
+		// Simulate the gh-2471 trigger: a bean (Consul service registry, in the
+		// real report) publishes a RefreshRoutesEvent from its destroy callback
+		// while the BeanFactory is already destroying singletons. At that point
+		// the BeanFactory refuses to create or look up new beans and throws
+		// BeanCreationNotAllowedException.
+		context.getDefaultListableBeanFactory().registerDisposableBean("refreshOnShutdown", new DisposableBean() {
+			@Override
+			public void destroy() {
+				context.publishEvent(new RefreshRoutesEvent(this));
+			}
+		});
+
+		context.close();
+
+		// With shutdown gating in place, the destroy-phase RefreshRoutesEvent
+		// must be ignored. Today this assertion fails because the listener
+		// keeps invoking the delegate even after destroy has begun.
+		assertThat(fetchCount.get())
+			.as("CachingRouteLocator must not delegate to RouteLocator beans during context destruction (gh-2471)")
+			.isEqualTo(baselineFetches);
+	}
+
+}


### PR DESCRIPTION
## Summary

Stops `CachingRouteLocator` from delegating to the wrapped `RouteLocator` once the `ApplicationContext` has begun closing. The listener was firing on `RefreshRoutesEvent` instances published during the destroy phase (typically by `ConsulServiceRegistry.deregister()`), which led the delegate path to ask the `BeanFactory` for beans that were already being destroyed and produced the `BeanCreationNotAllowedException` reported in gh-2471.

## Why `isActive()` is not enough

The first instinct is `AbstractApplicationContext.isActive()`, but `active` only flips to `false` at the very end of `doClose()` — after `destroyBeans()` has already run. The first signal available is `ContextClosedEvent`, published in step 1 of `doClose()`, before any destroy callback fires.

```
publishEvent(ContextClosedEvent)   // step 1
getLifecycleProcessor().onClose()  // step 2
destroyBeans()                     // step 3  ← failure happens here
...
this.active.set(false)             // step 6
```

## The fix

When the event publisher is a `ConfigurableApplicationContext`, register a small `ContextClosedEvent` listener that flips a `volatile boolean contextClosing` flag, and short-circuit `onApplicationEvent(RefreshRoutesEvent)` when the flag is set.

```java
public void onApplicationEvent(RefreshRoutesEvent event) {
    if (contextClosing) { return; }
    // existing logic
}

public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
    this.applicationEventPublisher = publisher;
    if (publisher instanceof ConfigurableApplicationContext context) {
        context.addApplicationListener(
            (ApplicationListener<ContextClosedEvent>) event -> this.contextClosing = true);
    }
}
```

+12 / -2 in `CachingRouteLocator.java`. No interfaces added. The existing `CachingRouteLocatorTests` keep passing because they wire a lambda publisher, so the new `instanceof` branch is skipped and the guard stays inactive — the original behaviour is preserved for non-context publishers.

## Reproduction

`CachingRouteLocatorShutdownTests` makes the race deterministic by registering a `DisposableBean` whose `destroy()` publishes a `RefreshRoutesEvent` — the same timing the Consul registry exercises:

```java
context.getDefaultListableBeanFactory().registerDisposableBean(
    "refreshOnShutdown",
    () -> context.publishEvent(new RefreshRoutesEvent(this)));
context.close();
```

Without the guard the test fails (`expected: 1 but was: 2`); with the guard it passes. The broader Route/Routing test set in `spring-cloud-gateway-server-webflux` (219 tests) stays green.

Happy to open a 4.3.x backport once this lands.

Fixes gh-2471
