### PR TITLE
Add test coverage for incomplete CORS preflight requests

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/cors/CorsGlobalTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/cors/CorsGlobalTests.java
@@ -66,6 +66,18 @@ public class CorsGlobalTests extends BaseWebClientTests {
 	}
 
 	@Test
+	public void testPreFlightCorsRequestWithoutAccessControlRequestMethod() {
+		ClientResponse clientResponse = webClient.options()
+			.uri("/abc/123/function")
+			.header("Origin", "domain.com")
+			.exchangeToMono(Mono::just)
+			.block();
+
+		assertThat(clientResponse).isNotNull();
+		assertThat(clientResponse.statusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+	}
+
+	@Test
 	public void testCorsRequest() {
 		ResponseEntity<String> response = webClient.get()
 			.uri("/abc/123/function")


### PR DESCRIPTION
Adds test coverage for OPTIONS requests missing the
Access-Control-Request-Method header.

This verifies current global CORS handling for incomplete preflight requests
and helps prevent regressions in request validation behavior.

tested with ./mvnw test -pl spring-cloud-gateway-server-webflux -Dtest=CorsGlobalTests