### PR TITLE
Guard gRPC beans on grpc-netty instead of grpc-api

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/ConfigurableHintsRegistrationProcessor.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/ConfigurableHintsRegistrationProcessor.java
@@ -70,7 +70,7 @@ class ConfigurableHintsRegistrationProcessor implements BeanFactoryInitializatio
 			Set.of("org.springframework.security.oauth2.client.OAuth2AuthorizedClient",
 					"org.springframework.security.web.server.SecurityWebFilterChain",
 					"org.springframework.boot.security.autoconfigure.SecurityProperties"),
-			JsonToGrpcGatewayFilterFactory.class, Set.of("io.grpc.Channel"), RedisRateLimiter.class,
+			JsonToGrpcGatewayFilterFactory.class, Set.of("io.grpc.netty.NettyChannelBuilder"), RedisRateLimiter.class,
 			Set.of("org.springframework.data.redis.core.RedisTemplate",
 					"org.springframework.web.reactive.DispatcherHandler"),
 			SpringCloudCircuitBreakerResilience4JFilterFactory.class, circuitBreakerConditionalClasses,

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/GatewayAutoConfiguration.java
@@ -370,7 +370,7 @@ public class GatewayAutoConfiguration {
 	@Bean
 	@ConditionalOnEnabledFilter
 	@ConditionalOnProperty(name = "server.http2.enabled", matchIfMissing = true)
-	@ConditionalOnClass(name = "io.grpc.Channel")
+	@ConditionalOnClass(name = "io.grpc.netty.NettyChannelBuilder")
 	public JsonToGrpcGatewayFilterFactory jsonToGRPCFilterFactory(GrpcSslConfigurer gRPCSSLContext,
 			ResourceLoader resourceLoader) {
 		return new JsonToGrpcGatewayFilterFactory(gRPCSSLContext, resourceLoader);
@@ -379,7 +379,7 @@ public class GatewayAutoConfiguration {
 	@Bean
 	@ConditionalOnEnabledFilter(JsonToGrpcGatewayFilterFactory.class)
 	@ConditionalOnMissingBean(GrpcSslConfigurer.class)
-	@ConditionalOnClass(name = "io.grpc.Channel")
+	@ConditionalOnClass(name = "io.grpc.netty.NettyChannelBuilder")
 	public GrpcSslConfigurer grpcSslConfigurer(HttpClientProperties properties, SslBundles bundles)
 			throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
 		TrustManagerFactory trustManagerFactory = TrustManagerFactory

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
@@ -57,6 +57,7 @@ import org.springframework.cloud.gateway.actuate.GatewayControllerEndpoint;
 import org.springframework.cloud.gateway.actuate.GatewayLegacyControllerEndpoint;
 import org.springframework.cloud.gateway.config.GatewayAutoConfigurationTests.CustomHttpClientFactory.CustomSslConfigurer;
 import org.springframework.cloud.gateway.config.HttpClientProperties.Pool.LeasingStrategy;
+import org.springframework.cloud.gateway.filter.factory.JsonToGrpcGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.factory.TokenRelayGatewayFilterFactory;
 import org.springframework.cloud.gateway.filter.headers.ForwardedHeadersFilter;
 import org.springframework.cloud.gateway.filter.headers.GRPCRequestHeadersFilter;
@@ -312,6 +313,26 @@ public class GatewayAutoConfigurationTests {
 			.run(context -> {
 				assertThat(context).doesNotHaveBean(GRPCRequestHeadersFilter.class)
 					.doesNotHaveBean(GRPCResponseHeadersFilter.class);
+			});
+	}
+
+	@Test // gh-4169
+	public void grpcBeansNotConfiguredWhenGrpcNettyAbsent() {
+		// io.grpc.Channel comes from grpc-api, but the gRPC beans require grpc-netty
+		// (io.grpc.netty.NettyChannelBuilder). When grpc-api is present without
+		// grpc-netty the beans must back off rather than fail the context with
+		// NoClassDefFoundError: io/grpc/netty/NettyChannelBuilder.
+		new ReactiveWebApplicationContextRunner()
+			.withClassLoader(
+					new org.springframework.boot.test.context.FilteredClassLoader("io.grpc.netty.NettyChannelBuilder"))
+			.withConfiguration(AutoConfigurations.of(WebFluxAutoConfiguration.class, MetricsAutoConfiguration.class,
+					SimpleMetricsExportAutoConfiguration.class, GatewayAutoConfiguration.class,
+					HttpClientCustomizedConfig.class, ServerPropertiesConfig.class))
+			.withPropertyValues("server.http2.enabled=true")
+			.run(context -> {
+				assertThat(context).hasNotFailed();
+				assertThat(context).doesNotHaveBean(JsonToGrpcGatewayFilterFactory.class);
+				assertThat(context).doesNotHaveBean(GrpcSslConfigurer.class);
 			});
 	}
 


### PR DESCRIPTION
Fixes gh-4169

## Problem

`JsonToGrpcGatewayFilterFactory` and `GrpcSslConfigurer` in `GatewayAutoConfiguration` are guarded with `@ConditionalOnClass(name = "io.grpc.Channel")`. However `io.grpc.Channel` ships in **grpc-api**, while both beans actually require **grpc-netty** classes:

- `GrpcSslConfigurer` extends `AbstractSslConfigurer<NettyChannelBuilder, ManagedChannel>` and uses `io.grpc.netty.GrpcSslContexts`.
- `JsonToGrpcGatewayFilterFactory` uses `io.grpc.netty.NettyChannelBuilder`.

`grpc-netty`, `grpc-protobuf` and `grpc-stub` are declared `<optional>` in the server module. When an application has `grpc-api` on the classpath (e.g. pulled in transitively by an unrelated dependency) but not `grpc-netty`, these beans are still created and fail with:

```
java.lang.NoClassDefFoundError: io/grpc/netty/NettyChannelBuilder
```

The only workaround today is to add the full `grpc-netty` dependency even when the gateway's gRPC support is never used (see also gh-2769).

## Change

Switch the `@ConditionalOnClass` guards on both beans (and the matching AOT reflection-hint registration in `ConfigurableHintsRegistrationProcessor`) from `io.grpc.Channel` to `io.grpc.netty.NettyChannelBuilder` — a class that is actually used by both beans and the exact class reported missing. The beans now activate only when grpc-netty is present.

Scope is limited to the webflux server module; the webmvc variant has no equivalent gRPC auto-configuration.

## Test evidence

Added `GatewayAutoConfigurationTests#grpcBeansNotConfiguredWhenGrpcNettyAbsent`, which hides `io.grpc.netty.NettyChannelBuilder` via `FilteredClassLoader` (simulating grpc-api present, grpc-netty absent) and asserts the context starts and neither gRPC bean is created.

- With the fix: passes (beans back off cleanly).
- Reverting the guards to `io.grpc.Channel` makes the test fail, with `jsonToGRPCFilterFactory` wrongly present — confirming it is a genuine regression test.

```
Tests run: 3, Failures: 0, Errors: 0, Skipped: 0
  -- in org.springframework.cloud.gateway.config.GatewayAutoConfigurationTests
```
(`grpcBeansNotConfiguredWhenGrpcNettyAbsent`, `gRPCFiltersConfiguredWhenHTTP2Enabled`, `gRPCFiltersNotConfiguredWhenHTTP2Disabled`)

`mvn validate` (spring-javaformat + checkstyle) passes on the module. Commit is DCO signed-off.