### PR TITLE
Expose disposeInactivePoolsInBackground for HttpClient connection pool

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/HttpClientFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/HttpClientFactory.java
@@ -192,6 +192,11 @@ public class HttpClientFactory extends AbstractFactoryBean<HttpClient> {
 			builder.evictInBackground(pool.getEvictionInterval());
 			builder.metrics(pool.isMetrics());
 
+			if (pool.getInactivePoolDisposeInterval() != null && pool.getPoolInactivity() != null) {
+				builder.disposeInactivePoolsInBackground(pool.getInactivePoolDisposeInterval(),
+						pool.getPoolInactivity());
+			}
+
 			// Define the pool leasing strategy
 			if (pool.getLeasingStrategy() == FIFO) {
 				builder.fifo();

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/HttpClientProperties.java
@@ -209,6 +209,20 @@ public class HttpClientProperties {
 		private boolean metrics = false;
 
 		/**
+		 * Interval at which connection pools are regularly checked in the background, and
+		 * the pools that have been inactive for longer than {@code poolInactivity} are
+		 * disposed. If NULL, inactive pools are not disposed in the background.
+		 */
+		private Duration inactivePoolDisposeInterval = null;
+
+		/**
+		 * Duration of inactivity after which a connection pool is considered inactive and
+		 * eligible to be disposed by the background check. Only applies when
+		 * {@code inactivePoolDisposeInterval} is set.
+		 */
+		private Duration poolInactivity = null;
+
+		/**
 		 * Configures the leasing strategy for the pool (fifo or lifo), defaults to FIFO
 		 * which is Netty's default.
 		 */
@@ -278,6 +292,22 @@ public class HttpClientProperties {
 			this.metrics = metrics;
 		}
 
+		public Duration getInactivePoolDisposeInterval() {
+			return inactivePoolDisposeInterval;
+		}
+
+		public void setInactivePoolDisposeInterval(Duration inactivePoolDisposeInterval) {
+			this.inactivePoolDisposeInterval = inactivePoolDisposeInterval;
+		}
+
+		public Duration getPoolInactivity() {
+			return poolInactivity;
+		}
+
+		public void setPoolInactivity(Duration poolInactivity) {
+			this.poolInactivity = poolInactivity;
+		}
+
 		public LeasingStrategy getLeasingStrategy() {
 			return leasingStrategy;
 		}
@@ -291,7 +321,8 @@ public class HttpClientProperties {
 			return "Pool{" + "type=" + type + ", name='" + name + '\'' + ", maxConnections=" + maxConnections
 					+ ", acquireTimeout=" + acquireTimeout + ", maxIdleTime=" + maxIdleTime + ", maxLifeTime="
 					+ maxLifeTime + ", evictionInterval=" + evictionInterval + ", metrics=" + metrics
-					+ ", leasingStrategy=" + leasingStrategy + '}';
+					+ ", inactivePoolDisposeInterval=" + inactivePoolDisposeInterval + ", poolInactivity="
+					+ poolInactivity + ", leasingStrategy=" + leasingStrategy + '}';
 		}
 
 		public enum PoolType {

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/config/GatewayAutoConfigurationTests.java
@@ -129,6 +129,8 @@ public class GatewayAutoConfigurationTests {
 					"spring.cloud.gateway.server.webflux.httpclient.pool.eviction-interval=10s",
 					"spring.cloud.gateway.server.webflux.httpclient.pool.type=fixed",
 					"spring.cloud.gateway.server.webflux.httpclient.pool.metrics=true",
+					"spring.cloud.gateway.server.webflux.httpclient.pool.inactive-pool-dispose-interval=30s",
+					"spring.cloud.gateway.server.webflux.httpclient.pool.pool-inactivity=5m",
 					"spring.cloud.gateway.server.webflux.httpclient.pool.leasing-strategy=lifo",
 					"spring.cloud.gateway.server.webflux.httpclient.compression=true",
 					"spring.cloud.gateway.server.webflux.httpclient.wiretap=true",
@@ -145,6 +147,8 @@ public class GatewayAutoConfigurationTests {
 				assertThat(properties.isCompression()).isEqualTo(true);
 				assertThat(properties.getPool().getEvictionInterval()).hasSeconds(10);
 				assertThat(properties.getPool().isMetrics()).isEqualTo(true);
+				assertThat(properties.getPool().getInactivePoolDisposeInterval()).hasSeconds(30);
+				assertThat(properties.getPool().getPoolInactivity()).hasMinutes(5);
 				assertThat(properties.getPool().getLeasingStrategy()).isEqualTo(LeasingStrategy.LIFO);
 				assertThat(properties.getSsl().getSslBundle()).isEqualTo("mybundle");
 


### PR DESCRIPTION
Fixes #4165

## Problem
`HttpClientProperties.Pool` exposes several Reactor Netty connection-pool knobs (`max-idle-time`, `max-life-time`, `eviction-interval`, …) but not `ConnectionProvider.Builder#disposeInactivePoolsInBackground(disposeInterval, poolInactivity)`.

The existing `eviction-interval` (`evictInBackground`) only evicts idle *connections* within a pool; it does not remove the *pool* entries themselves from Reactor Netty's internal `channelPools` map. When downstream instances churn — e.g. Kubernetes pods rolling, so the remote `IP:port` (and therefore the `PoolKey`) keeps changing — entries accumulate and are never reclaimed, which manifests as a slow memory leak (see #4165 for the analysis and a linked Reactor Netty report).

## Change
Expose the missing knob, mirroring how the other pool properties are wired:

- Add `inactive-pool-dispose-interval` and `pool-inactivity` (both `Duration`, null/disabled by default) to `HttpClientProperties.Pool`.
- In `HttpClientFactory#buildConnectionProvider`, call `builder.disposeInactivePoolsInBackground(...)` only when **both** are set, so default behavior is unchanged.

```properties
spring.cloud.gateway.server.webflux.httpclient.pool.inactive-pool-dispose-interval=5m
spring.cloud.gateway.server.webflux.httpclient.pool.pool-inactivity=5m
```

## Test evidence
Extended the existing `GatewayAutoConfigurationTests#nettyHttpClientConfigured` binding test to set and assert both new properties.

```
./mvnw -pl spring-cloud-gateway-server-webflux -Dtest='GatewayAutoConfigurationTests#nettyHttpClientConfigured' test
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```
checkstyle + spring-javaformat `validate` pass. Commit is DCO signed-off.

## Verification done
1. No in-flight PR (searched open/closed PRs for `disposeInactive` / `4165` — none). 2. No self-claim comments on the issue. 3. Code-focused — touches only `.java`. 4. Confirmed the property/builder call is absent on current `main`. 6. Triage gate N/A (spring-cloud/*, not spring-projects/*).