### PR TITLE
Skip rate-limit header mutation on committed response

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestRateLimiterGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/RequestRateLimiterGatewayFilterFactory.java
@@ -131,8 +131,14 @@ public class RequestRateLimiterGatewayFilterFactory
 			}
 			return limiter.isAllowed(routeId, key).flatMap(response -> {
 
-				for (Map.Entry<String, String> header : response.getHeaders().entrySet()) {
-					exchange.getResponse().getHeaders().add(header.getKey(), header.getValue());
+				// The response may already be committed when the filter chain is
+				// re-subscribed with the same exchange (for example by the retry
+				// filter). Adding headers to a committed response would throw
+				// UnsupportedOperationException from ReadOnlyHttpHeaders.
+				if (!exchange.getResponse().isCommitted()) {
+					for (Map.Entry<String, String> header : response.getHeaders().entrySet()) {
+						exchange.getResponse().getHeaders().add(header.getKey(), header.getValue());
+					}
 				}
 
 				if (response.isAllowed()) {

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestRateLimiterGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/RequestRateLimiterGatewayFilterFactoryTests.java
@@ -105,6 +105,36 @@ public class RequestRateLimiterGatewayFilterFactoryTests extends BaseWebClientTe
 		assertFilterFactory(exchange -> Mono.empty(), null, true, HttpStatus.FORBIDDEN, true, true);
 	}
 
+	@Test
+	public void deniedDoesNotMutateHeadersWhenResponseAlreadyCommitted() {
+		// gh-4175: when the filter chain is re-subscribed with the same exchange (for
+		// example by the retry filter), the response may already be committed. Adding the
+		// rate-limit headers to a committed response throws UnsupportedOperationException
+		// (ReadOnlyHttpHeaders), so the filter must skip the header mutation.
+		String key = "notallowedkey";
+		Map<String, String> headers = Collections.singletonMap("X-Tokens-Remaining", "0");
+		when(rateLimiter.isAllowed("myroute", key)).thenReturn(Mono.just(new Response(false, headers)));
+
+		MockServerHttpRequest request = MockServerHttpRequest.get("/").build();
+		MockServerWebExchange exchange = MockServerWebExchange.from(request);
+		exchange.getAttributes()
+			.put(ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR,
+					Route.async().id("myroute").predicate(ex -> true).uri("http://localhost").build());
+
+		// Simulate a previous subscription having already committed the response.
+		exchange.getResponse().setComplete().block();
+		assertThat(exchange.getResponse().isCommitted()).isTrue();
+
+		RequestRateLimiterGatewayFilterFactory factory = this.context
+			.getBean(RequestRateLimiterGatewayFilterFactory.class);
+		GatewayFilter filter = factory.apply(config -> {
+			config.setRouteId("myroute");
+			config.setKeyResolver(resolver2);
+		});
+
+		StepVerifier.create(filter.filter(exchange, this.filterChain)).expectComplete().verify();
+	}
+
 	private void assertFilterFactory(KeyResolver keyResolver, String key, boolean allowed, HttpStatus expectedStatus) {
 		assertFilterFactory(keyResolver, key, allowed, expectedStatus, null, false);
 	}


### PR DESCRIPTION
Fixes gh-4175

### Problem
`RequestRateLimiterGatewayFilterFactory` copies the rate-limiter response headers onto the exchange response via `exchange.getResponse().getHeaders().add(...)` unconditionally:

```java
return limiter.isAllowed(routeId, key).flatMap(response -> {
    for (Map.Entry<String, String> header : response.getHeaders().entrySet()) {
        exchange.getResponse().getHeaders().add(header.getKey(), header.getValue());
    }
    ...
```

When the filter chain is re-subscribed with the **same** `ServerWebExchange` — most notably when `RetryGatewayFilterFactory` is placed before the rate limiter and retries on `series=CLIENT_ERROR` — the response from the first (denied) pass is already committed. `getHeaders()` then returns a `ReadOnlyHttpHeaders` instance, and `add(...)` fails with `UnsupportedOperationException`.

### Change
Guard the header mutation with `ServerHttpResponse.isCommitted()` so headers are only added while the response can still be modified. This is a minimal, compatibility-preserving fix: the default complete-signal behavior on a denied request is unchanged, and the existing `throwOnLimit` option keeps working. (Approach suggested by @dongyikuan919 in the issue thread.)

### Test evidence
Added `deniedDoesNotMutateHeadersWhenResponseAlreadyCommitted` to `RequestRateLimiterGatewayFilterFactoryTests`, which commits the response before invoking the filter and asserts it completes instead of erroring.

- Without the fix the new test fails with `onError(java.lang.UnsupportedOperationException)`.
- With the fix the full test class passes: `Tests run: 7, Failures: 0, Errors: 0, Skipped: 0`.

Built and tested with JDK 21 against `spring-cloud-gateway-server-webflux`; `spring-javaformat:apply` reports no formatting changes.

Verification done: (1) no in-flight PR for #4175 (only the previously merged #4072 that added `throwOnLimit`); (2) issue has no self-claim; (3) fix is in `.java` files; (4) confirmed the unguarded `getHeaders().add()` still present on current `main`; (5) commit signed off for DCO.