### PR TITLE
docs: document that SimpleClientHttpRequestFactory is not suitable for WebMVC gateway

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -70,6 +70,7 @@
 
 * xref:spring-cloud-gateway-server-webmvc.adoc[]
 ** xref:spring-cloud-gateway-server-webmvc/starter.adoc[]
+** xref:spring-cloud-gateway-server-webmvc/http-client.adoc[]
 ** xref:spring-cloud-gateway-server-webmvc/glossary.adoc[]
 ** xref:spring-cloud-gateway-server-webmvc/how-it-works.adoc[]
 ** xref:spring-cloud-gateway-server-webmvc/java-routes-api.adoc[]

--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/http-client.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/http-client.adoc
@@ -1,0 +1,62 @@
+[[http-client]]
+= HTTP Client
+
+Spring Cloud Gateway Server MVC uses Spring Boot's `RestClient` infrastructure to forward requests to backend services.
+The underlying `ClientHttpRequestFactory` is resolved from the application context, driven by `spring.http.clients.imperative.factory`.
+
+IMPORTANT: `SimpleClientHttpRequestFactory` (backed by `java.net.HttpURLConnection`) is **not suitable** for the WebMVC gateway.
+`HttpURLConnection` throws a `java.io.IOException` (such as `FileNotFoundException` for 404 responses) instead of providing the response body for 4xx/5xx status codes.
+The gateway cannot forward error responses correctly in this case, and the client will receive an `HTTP 500` instead of the actual upstream error status.
+
+== Selecting an HTTP Client
+
+Use one of the following supported implementations:
+
+=== JDK HttpClient (recommended, no extra dependency)
+
+Set the factory to `jdk` to use Java's built-in `HttpClient` (available since Java 11):
+
+.application.yml
+[source,yaml]
+----
+spring:
+  http:
+    clients:
+      imperative:
+        factory: jdk
+----
+
+=== OkHttp
+
+Add `com.squareup.okhttp3:okhttp` to your classpath. The factory is selected automatically when `okhttp3.OkHttpClient` is on the classpath, or you can set it explicitly:
+
+.application.yml
+[source,yaml]
+----
+spring:
+  http:
+    clients:
+      imperative:
+        factory: okhttp
+----
+
+=== Apache HttpComponents
+
+Add `org.apache.httpcomponents.client5:httpclient5` to your classpath, or set the factory explicitly:
+
+.application.yml
+[source,yaml]
+----
+spring:
+  http:
+    clients:
+      imperative:
+        factory: apache
+----
+
+NOTE: If you have OkHttp or Apache HttpComponents on the classpath, Spring Boot's auto-detection will prefer them over `SimpleClientHttpRequestFactory`, so the IMPORTANT notice above only applies when running without any of those libraries.
+
+== Related Documentation
+
+* xref:spring-cloud-gateway-server-webmvc/tls-and-ssl.adoc[TLS and SSL] – configure SSL bundles for backend calls
+* https://docs.spring.io/spring-boot/reference/io/rest-client.html#io.rest-client.restclient[Spring Boot RestClient documentation]


### PR DESCRIPTION
## Problem

When using Spring Cloud Gateway Server MVC with the default `SimpleClientHttpRequestFactory` (backed by `java.net.HttpURLConnection`), upstream 4xx/5xx responses are not forwarded correctly — the gateway returns HTTP 500 instead of the actual error status. This happens because `URLConnection` throws a `java.io.IOException` for non-2xx responses instead of making the response body available.

This was identified in #3451 and documented as a known limitation by the team:

> "We can use this issue to document that `SimpleClientHttpRequestFactory` (and `URLConnection` which it uses) is not suitable for the WebMVC gateway server."

## Changes

Add a new `http-client.adoc` page under `spring-cloud-gateway-server-webmvc/`:

- **IMPORTANT** warning explaining why `SimpleClientHttpRequestFactory`/`URLConnection` is not suitable
- How to configure a suitable factory via `spring.http.clients.imperative.factory` (values: `jdk`, `okhttp`, `apache`)
- NOTE that OkHttp / Apache HttpComponents are auto-detected when available, so the warning only applies to minimal setups
- Cross-references to TLS/SSL docs and Spring Boot RestClient docs

Also adds the new page to `nav.adoc`.

Closes #3451

🤖 Generated with [Claude Code](https://claude.com/claude-code)