### PR TITLE
GH-1949: Document that overriding discovery locator filters replaces defaults

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/the-discoveryclient-route-definition-locator.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/the-discoveryclient-route-definition-locator.adoc
@@ -19,7 +19,14 @@ The default filter is a rewrite path filter with the regex `/serviceId/?(?<remai
 This strips the service ID from the path before the request is sent downstream.
 
 If you want to customize the predicates or filters used by the `DiscoveryClient` routes, set `spring.cloud.gateway.discovery.locator.predicates[x]` and `spring.cloud.gateway.discovery.locator.filters[y]`.
-When doing so, you need to make sure to include the default predicate and filter shown earlier, if you want to retain that functionality.
+
+[IMPORTANT]
+====
+Setting `spring.cloud.gateway.discovery.locator.filters` *replaces* the entire default filter list.
+If you only add your own filters without re-declaring `RewritePath`, the service ID will *not* be stripped from the path and requests will fail with a `404` on the downstream service.
+Always include the default `RewritePath` filter when defining custom filters, as shown in the examples below.
+====
+
 The following examples shows what this looks like in properties and yaml format:
 
 .application.properties


### PR DESCRIPTION
## Summary

Closes #1949

The existing documentation mentioned that users must re-include the default `RewritePath` filter when customizing `spring.cloud.gateway.discovery.locator.filters`, but the warning was easy to miss.

This PR adds an explicit `[IMPORTANT]` callout block that:
- Explains that `filters` configuration *replaces* the entire default filter list (not appends to it)
- Describes the concrete failure mode: requests result in `404` on the downstream service because the service ID is not stripped from the path
- Points the reader to the examples that show the correct pattern (include `RewritePath`)

## Test plan

- [ ] AsciiDoc renders with the IMPORTANT callout visible
- [ ] Example YAML/properties still shows `RewritePath` included alongside the custom `CircuitBreaker` filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)