### PR TITLE
docs: clarify Retry series+statuses interaction and AddRequestHeader comma limitation

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/addrequestheader-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/addrequestheader-factory.adoc
@@ -21,6 +21,17 @@ spring:
 
 This listing adds `X-Request-red:blue` header to the downstream request's headers for all matching requests.
 
+NOTE: The shortcut notation (`AddRequestHeader=Name, Value`) parses the value on the first comma, so header values that contain a comma must use the expanded (`name`/`value` args) form:
++
+[source,yaml]
+----
+filters:
+  - name: AddRequestHeader
+    args:
+      name: X-My-Header
+      value: "Value, with comma"
+----
+
 `AddRequestHeader` is aware of the URI variables used to match a path or host.
 URI variables may be used in the value and are expanded at runtime.
 The following example configures an `AddRequestHeader` `GatewayFilter` that uses a variable:

--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/retry-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/retry-factory.adoc
@@ -6,7 +6,7 @@ The `Retry` `GatewayFilter` factory supports the following parameters:
 * `retries`: The number of retries that should be attempted.
 * `statuses`: The HTTP status codes that should be retried, represented by using `org.springframework.http.HttpStatus`.
 * `methods`: The HTTP methods that should be retried, represented by using `org.springframework.http.HttpMethod`.
-* `series`: The series of status codes to be retried, represented by using `org.springframework.http.HttpStatus.Series`.
+* `series`: The series of status codes to be retried, represented by using `org.springframework.http.HttpStatus.Series`. When both `series` and `statuses` are set, a response is retried only if it matches the series AND is listed in `statuses`. To retry based on specific status codes without any series restriction, set `series` to an empty list (or `null` in YAML).
 * `exceptions`: A list of thrown exceptions that should be retried.
 * `backoff`: The configured exponential backoff for the retries.
 Retries are performed after a backoff interval of `firstBackoff * (factor ^ n)`, where `n` is the iteration.

--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/addrequestheader.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/addrequestheader.adoc
@@ -44,6 +44,17 @@ class RouteConfiguration {
 
 This listing adds `X-Request-red:blue` header to the downstream request's headers for all matching requests.
 
+NOTE: The shortcut notation (`AddRequestHeader=Name, Value`) parses the value on the first comma, so header values that contain a comma must use the expanded (`name`/`value` args) form:
++
+[source,yaml]
+----
+filters:
+  - name: AddRequestHeader
+    args:
+      name: X-My-Header
+      value: "Value, with comma"
+----
+
 `AddRequestHeader` is aware of the URI variables used to match a path or host.
 URI variables may be used in the value and are expanded at runtime.
 The following example configures an `AddRequestHeader` filter that uses a variable:


### PR DESCRIPTION
## Summary

Closes #1536
Closes #1896

- **Retry filter (`series` + `statuses` interaction)**: When both `series` and `statuses` are set on the Retry `GatewayFilter`, a retry is only triggered when the response matches the `series` AND is listed in `statuses`. This was confusing to users who expected `statuses` alone to be sufficient. Added a clarifying sentence and guidance to set `series` to an empty list when retrying by specific status codes only.

- **`AddRequestHeader` comma limitation**: The shortcut notation `AddRequestHeader=Name, Value` splits on the first comma, so any header value containing a literal comma is silently truncated. Added a `NOTE` callout with the expanded `name`/`value` workaround in both the WebFlux and WebMVC docs.

## Test plan

- [ ] Verify NOTE renders correctly in Antora docs build
- [ ] Confirm expanded-form YAML example is syntactically valid
- [ ] Confirm `series: []` / `series: null` YAML example is accurate for the Retry filter