### PR TITLE
docs: document required dependencies for JsonToGrpc filter

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/jsontogrpc-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/jsontogrpc-factory.adoc
@@ -3,6 +3,53 @@
 
 The JSONToGRPC GatewayFilter Factory converts a JSON payload to a gRPC request.
 
+[[jsontogrpc-dependencies]]
+== Required Dependencies
+
+The `JsonToGrpc` filter depends on several optional libraries that are *not* included by default.
+You must add them explicitly to your project:
+
+.Maven
+[source,xml]
+----
+<dependency>
+    <groupId>tools.jackson.dataformat</groupId>
+    <artifactId>jackson-dataformat-protobuf</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.grpc</groupId>
+    <artifactId>grpc-netty</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.grpc</groupId>
+    <artifactId>grpc-protobuf</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.grpc</groupId>
+    <artifactId>grpc-stub</artifactId>
+</dependency>
+<dependency>
+    <groupId>com.google.protobuf</groupId>
+    <artifactId>protobuf-java-util</artifactId>
+</dependency>
+----
+
+.Gradle
+[source,groovy]
+----
+implementation 'tools.jackson.dataformat:jackson-dataformat-protobuf'
+implementation 'io.grpc:grpc-netty'
+implementation 'io.grpc:grpc-protobuf'
+implementation 'io.grpc:grpc-stub'
+implementation 'com.google.protobuf:protobuf-java-util'
+----
+
+[WARNING]
+====
+If any of these dependencies are missing you will see a `NoClassDefFoundError` at runtime (for example, `com/fasterxml/jackson/dataformat/protobuf/ProtobufFactory`) when a request hits the route.
+The versions are managed by the Spring Cloud Gateway BOM, so no version attributes are needed when using the BOM.
+====
+
 The filter takes the following arguments:
 
 * `service`: Short name of the service that handles the request.


### PR DESCRIPTION
## Summary

Closes #3424

The `JsonToGrpc` GatewayFilter requires several optional libraries (`jackson-dataformat-protobuf`, `grpc-netty`, `grpc-protobuf`, `grpc-stub`, `protobuf-java-util`) that are *not* pulled in transitively by `spring-cloud-starter-gateway`. Without them users see a `NoClassDefFoundError` at runtime — confusing because the route is accepted at startup.

Added a `[[jsontogrpc-dependencies]]` section before the parameters list with:
- Maven and Gradle snippets for all five dependencies (versions managed by the BOM)
- A `WARNING` callout linking the symptom (`NoClassDefFoundError`) to the cause

## Test plan

- [ ] Docs build with Antora renders the new section without errors
- [ ] Maven/Gradle snippets are syntactically correct