### PR TITLE
docs: document naming convention and YAML usage for custom route predicates

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/developer-guide.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/developer-guide.adoc
@@ -37,6 +37,54 @@ public class MyRoutePredicateFactory extends AbstractRoutePredicateFactory<MyRou
 
 }
 ----
+[[naming-custom-predicates-and-references-in-configuration]]
+=== Naming Custom Predicates And References In Configuration
+
+Custom route predicate factory class names should end in `RoutePredicateFactory`.
+
+For example, to reference a predicate named `My` in configuration files, the factory must be in a class named `MyRoutePredicateFactory`:
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+          - id: my_route
+            uri: https://example.org
+            predicates:
+            - My=argument
+----
+
+Or using fully expanded arguments:
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      server:
+        webflux:
+          routes:
+          - id: my_route
+            uri: https://example.org
+            predicates:
+            - name: My
+              args:
+                myArg: argument
+----
+
+The predicate factory must override `shortcutFieldOrder()` to define the order of shortcut arguments and `Config` fields must match the keys used in the `args` map.
+
+WARNING: It is possible to create a predicate named without the `RoutePredicateFactory` suffix.
+Such a predicate could be referenced by its full class name (minus the package) in configuration files.
+This is **not** a supported naming convention and this syntax may be removed in future releases.
+Please update the predicate name to be compliant.
+
 [[writing-custom-gatewayfilter-factories]]
 == Writing Custom GatewayFilter Factories
 


### PR DESCRIPTION
## Summary

Closes #3463

The Developer Guide explained how to write a custom `RoutePredicateFactory` and how to reference custom `GatewayFilter`s in YAML configuration, but there was no equivalent guidance for custom predicates. Users were left guessing whether the same naming convention applied.

Added a `[[naming-custom-predicates-and-references-in-configuration]]` subsection immediately after the custom predicate class example that mirrors the existing filter naming section:

- Documents the `RoutePredicateFactory` suffix naming convention (strips `RoutePredicateFactory` → predicate name used in config)
- Shows both shortcut (`- My=argument`) and fully-expanded (`name: My`, `args: ...`) YAML forms
- Notes that `shortcutFieldOrder()` must be overridden for the shortcut form to work
- Adds a `WARNING` about non-standard names (no suffix), consistent with the existing filter warning

## Test plan

- [ ] Docs build with Antora renders without errors
- [ ] YAML examples are syntactically valid
- [ ] Section placement logically follows the predicate factory class example