### PR TITLE
Correct filter name from PreserveHostHeader to preserveHost

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/preservehostheader.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/preservehostheader.adoc
@@ -20,7 +20,7 @@ spring:
               predicates:
               - Path=/**
               filters:
-              - PreserveHostHeader
+              - preserveHost
 ----
 
 .GatewaySampleApplication.java


### PR DESCRIPTION
In the WebMVC version of Spring Cloud Gateway, the global defaultFilters property (available in WebFlux) is missing. I hope the official team can add this feature. Currently, if I add filters to each route, the filter name for the route is preserveHost instead of PreserveHostHeader.