### PR TITLE
Fix RFC 7239 Forwarded header relay for entries without for

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -164,9 +164,10 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 		List<Forwarded> forwardeds = parse(forwardedHeaders);
 
 		for (Forwarded f : forwardeds) {
-			// only add if "for" value matches trustedProxies
 			String forValue = f.get("for");
-			if (forValue != null && trustedProxies.isTrusted(forValue)) {
+			// Preserve valid Forwarded entries without a `for` parameter.
+			// Per RFC 7239, all Forwarded parameters are optional.
+			if (forValue == null || trustedProxies.isTrusted(forValue)) {
 				updated.add(FORWARDED_HEADER, f.toHeaderValue());
 			}
 		}

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
@@ -121,6 +121,25 @@ public class ForwardedHeadersFilterTests {
 	}
 
 	@Test
+	public void forwardedHeaderWithoutForIsPreserved() throws UnknownHostException {
+		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost/get")
+			.remoteAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
+			.header(FORWARDED_HEADER, "proto=http;host=example.com, for=23.45.67.89")
+			.build();
+
+		ForwardedHeadersFilter filter = new ForwardedHeadersFilter(".*");
+
+		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
+
+		assertThat(headers.get(FORWARDED_HEADER)).hasSize(3);
+
+		List<Forwarded> forwardeds = ForwardedHeadersFilter.parse(headers.get(FORWARDED_HEADER));
+
+		assertThat(forwardeds)
+			.anyMatch(forwarded -> "example.com".equals(forwarded.get("host")) && forwarded.get("for") == null);
+	}
+
+	@Test
 	public void noHostHeader() throws UnknownHostException {
 		MockServerHttpRequest request = MockServerHttpRequest.get("http://localhost/get")
 			.remoteAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/ForwardedRequestHeadersFilter.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/ForwardedRequestHeadersFilter.java
@@ -176,8 +176,8 @@ public class ForwardedRequestHeadersFilter implements HttpHeadersFilter.RequestH
 			List<Forwarded> forwardeds = parse(forwardedHeader);
 
 			for (Forwarded f : forwardeds) {
-				// only add if "for" value matches trustedProxies
-				if (trustedProxies.isTrusted(f.get("for"))) {
+				// preserve existing forwarded entries that do not contain a "for" value
+				if (f.get("for") == null || trustedProxies.isTrusted(f.get("for"))) {
 					updated.add(FORWARDED_HEADER, f.toHeaderValue());
 				}
 			}

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/ForwardedRequestHeadersFilterTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/ForwardedRequestHeadersFilterTests.java
@@ -181,6 +181,27 @@ public class ForwardedRequestHeadersFilterTests {
 	}
 
 	@Test
+	public void forwardedHeaderWithoutForIsPreserved() {
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/get")
+			.remoteAddress("10.0.0.1:80")
+			.header(FORWARDED_HEADER, "proto=http;host=example.com, for=23.45.67.89")
+			.buildRequest(null);
+		servletRequest.setRemoteHost("10.0.0.1");
+		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
+
+		ForwardedRequestHeadersFilter filter = new ForwardedRequestHeadersFilter(".*");
+
+		HttpHeaders headers = filter.apply(request.headers().asHttpHeaders(), request);
+
+		assertThat(headers.get(FORWARDED_HEADER)).hasSize(3);
+
+		List<Forwarded> forwardeds = ForwardedRequestHeadersFilter.parse(headers.get(FORWARDED_HEADER));
+
+		assertThat(forwardeds)
+			.anyMatch(forwarded -> "example.com".equals(forwarded.get("host")) && forwarded.get("for") == null);
+	}
+
+	@Test
 	public void noHostHeader() throws UnknownHostException {
 		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/get")
 			.remoteAddress("10.0.0.1:80")


### PR DESCRIPTION
Per RFC 7239, all forwarded-pair entries are optional. Both
  `ForwardedHeadersFilter` (webflux) and `ForwardedRequestHeadersFilter` (webmvc)
  currently drop entries where `for` is absent, even when sent by trusted proxies
  (remote address is already validated earlier in the same method).

  This causes legitimate upstream `host`/`proto` information to be silently lost
  in multi-hop proxy chains. The webmvc filter also throws NPE on null `for`.

  Changes:
  - webflux: preserve when `for == null OR trustedProxies.isTrusted(forValue)`
  - webmvc: same fix + adds null-safety to prevent NPE in `TrustedProxies.isTrusted`
  - Tests covering header-without-for-field preservation

Fixes gh-4214