### PR TITLE
Add MVC retry backoff support

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/retry.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webmvc/filters/retry.adoc
@@ -19,10 +19,9 @@ The `Retry` filter supports the following parameters:
 * `series`: The series of status codes to be retried, represented by using `org.springframework.http.HttpStatus.Series`.
 * `exceptions`: A list of thrown exceptions that should be retried.
 * `cacheBody`: A flag to signal if the request body should be cached. If set to `true`, the `adaptCacheBody` filter must be used to send the cached body downstream.
-//* `backoff`: The configured exponential backoff for the retries.
-//Retries are performed after a backoff interval of `firstBackoff * (factor ^ n)`, where `n` is the iteration.
-//If `maxBackoff` is configured, the maximum backoff applied is limited to `maxBackoff`.
-//If `basedOnPreviousValue` is true, the backoff is calculated by using `prevBackoff * factor`.
+* `backoff`: The configured exponential backoff for the retries.
+Retries are performed after a backoff interval of `firstBackoff * (factor ^ n)`, where `n` is the iteration.
+If `maxBackoff` is configured, the maximum backoff applied is limited to `maxBackoff`.
 
 The following defaults are configured for `Retry` filter, if enabled:
 
@@ -31,7 +30,7 @@ The following defaults are configured for `Retry` filter, if enabled:
 * `methods`: GET method
 * `exceptions`: `IOException`, `TimeoutException` and `RetryException`
 * `cacheBody`: `false`
-//* `backoff`: disabled
+* `backoff`: disabled
 
 WARNING: Setting `cacheBody` to `true` causes the gateway to read the whole body into memory. This should be used with caution.
 
@@ -57,12 +56,18 @@ spring:
                   series: SERVER_ERROR
                   methods: GET,POST
                   cacheBody: true
+                  backoff:
+                    firstBackoff: 100ms
+                    maxBackoff: 500ms
+                    factor: 2
               - name: AdaptCachedBody
 ----
 
 .GatewaySampleApplication.java
 [source,java]
 ----
+import java.time.Duration;
+
 import static org.springframework.cloud.gateway.server.mvc.filter.BeforeFilterFunctions.uri;
 import static org.springframework.cloud.gateway.server.mvc.filter.FilterFunctions.adaptCachedBody;
 import static org.springframework.cloud.gateway.server.mvc.filter.RetryFilterFunctions.retry;
@@ -81,7 +86,8 @@ class RouteConfiguration {
             .filter(retry(config -> config.setRetries(3)
                     .setSeries(Set.of(HttpStatus.Series.SERVER_ERROR))
                     .setMethods(Set.of(HttpMethod.GET, HttpMethod.POST))
-                    .setCacheBody(true)))
+                    .setCacheBody(true)
+                    .setBackoff(Duration.ofMillis(100), Duration.ofMillis(500), 2)))
             .filter(adaptCachedBody())
             .build();
     }
@@ -143,4 +149,3 @@ spring:
 ----
 spring.cloud.gateway.server.webmvc.use-framework-retry-filter=true
 ----
-

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/FrameworkRetryFilterFunctions.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/FrameworkRetryFilterFunctions.java
@@ -17,15 +17,19 @@
 package org.springframework.cloud.gateway.server.mvc.filter;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.function.Consumer;
 
 import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
+import org.springframework.cloud.gateway.server.mvc.filter.RetryFilterFunctions.BackoffConfig;
 import org.springframework.core.retry.RetryPolicy;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.ExponentialBackOff;
 import org.springframework.web.servlet.function.HandlerFilterFunction;
 import org.springframework.web.servlet.function.ServerRequest;
 import org.springframework.web.servlet.function.ServerResponse;
@@ -55,6 +59,7 @@ public abstract class FrameworkRetryFilterFunctions {
 
 	public static HandlerFilterFunction<ServerResponse, ServerResponse> frameworkRetry(
 			RetryFilterFunctions.RetryConfig config) {
+		validate(config);
 		return (request, next) -> {
 			CompositeRetryPolicy compositeRetryPolicy = new CompositeRetryPolicy(config);
 
@@ -94,6 +99,22 @@ public abstract class FrameworkRetryFilterFunctions {
 		return config.getMethods().contains(method);
 	}
 
+	private static void validate(RetryFilterFunctions.RetryConfig config) {
+		if (config.getBackoff() != null) {
+			config.getBackoff().validate();
+		}
+	}
+
+	private static BackOff createBackOff(BackoffConfig backoff) {
+		ExponentialBackOff exponentialBackOff = new ExponentialBackOff(backoff.getFirstBackoff().toMillis(),
+				backoff.getFactor());
+		Duration maxBackoff = backoff.getMaxBackoff();
+		if (maxBackoff != null) {
+			exponentialBackOff.setMaxInterval(maxBackoff.toMillis());
+		}
+		return exponentialBackOff;
+	}
+
 	/**
 	 * Composite retry policy that combines exception-based and HTTP status-based retry
 	 * logic. Each instance is used for a single request execution, so we can use a
@@ -105,8 +126,17 @@ public abstract class FrameworkRetryFilterFunctions {
 
 		private int attemptCount = 0;
 
+		private final BackOff backOff;
+
 		CompositeRetryPolicy(RetryFilterFunctions.RetryConfig config) {
 			this.config = config;
+			this.backOff = config.getBackoff() != null ? createBackOff(config.getBackoff())
+					: RetryPolicy.withDefaults().getBackOff();
+		}
+
+		@Override
+		public BackOff getBackOff() {
+			return this.backOff;
 		}
 
 		@Override

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/GatewayRetryFilterFunctions.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/GatewayRetryFilterFunctions.java
@@ -17,12 +17,14 @@
 package org.springframework.cloud.gateway.server.mvc.filter;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
 import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
+import org.springframework.cloud.gateway.server.mvc.filter.RetryFilterFunctions.BackoffConfig;
 import org.springframework.cloud.gateway.server.mvc.filter.RetryFilterFunctions.RetryConfig;
 import org.springframework.cloud.gateway.server.mvc.filter.RetryFilterFunctions.RetryException;
 import org.springframework.http.HttpMethod;
@@ -31,6 +33,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.CompositeRetryPolicy;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
@@ -64,6 +67,7 @@ public abstract class GatewayRetryFilterFunctions {
 	}
 
 	public static HandlerFilterFunction<ServerResponse, ServerResponse> retry(RetryConfig config) {
+		validate(config);
 		RetryTemplateBuilder retryTemplateBuilder = RetryTemplate.builder();
 		CompositeRetryPolicy compositeRetryPolicy = new CompositeRetryPolicy();
 		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<>();
@@ -71,6 +75,7 @@ public abstract class GatewayRetryFilterFunctions {
 		SimpleRetryPolicy simpleRetryPolicy = new SimpleRetryPolicy(config.getRetries(), retryableExceptions);
 		compositeRetryPolicy
 			.setPolicies(Arrays.asList(simpleRetryPolicy, new HttpRetryPolicy(config)).toArray(new RetryPolicy[0]));
+		retryTemplateBuilder = configureBackoff(retryTemplateBuilder, config);
 		RetryTemplate retryTemplate = retryTemplateBuilder.customPolicy(compositeRetryPolicy).build();
 		return (request, next) -> retryTemplate.execute(context -> {
 			if (config.isCacheBody()) {
@@ -102,6 +107,23 @@ public abstract class GatewayRetryFilterFunctions {
 
 	private static boolean isRetryableMethod(HttpMethod method, RetryConfig config) {
 		return config.getMethods().contains(method);
+	}
+
+	private static void validate(RetryConfig config) {
+		if (config.getBackoff() != null) {
+			config.getBackoff().validate();
+		}
+	}
+
+	private static RetryTemplateBuilder configureBackoff(RetryTemplateBuilder retryTemplateBuilder,
+			RetryConfig config) {
+		BackoffConfig backoff = config.getBackoff();
+		if (backoff == null) {
+			return retryTemplateBuilder;
+		}
+		Duration maxBackoff = backoff.getMaxBackoff() != null ? backoff.getMaxBackoff()
+				: Duration.ofMillis(ExponentialBackOffPolicy.DEFAULT_MAX_INTERVAL);
+		return retryTemplateBuilder.exponentialBackoff(backoff.getFirstBackoff(), backoff.getFactor(), maxBackoff);
 	}
 
 	public static class HttpRetryPolicy extends NeverRetryPolicy {

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/RetryFilterFunctions.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/RetryFilterFunctions.java
@@ -17,9 +17,11 @@
 package org.springframework.cloud.gateway.server.mvc.filter;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
@@ -33,6 +35,7 @@ import org.springframework.core.NestedRuntimeException;
 import org.springframework.core.log.LogMessage;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.web.servlet.function.HandlerFilterFunction;
 import org.springframework.web.servlet.function.ServerRequest;
@@ -111,6 +114,8 @@ public abstract class RetryFilterFunctions {
 
 		private boolean cacheBody = false;
 
+		private BackoffConfig backoff;
+
 		public int getRetries() {
 			return retries;
 		}
@@ -168,6 +173,76 @@ public abstract class RetryFilterFunctions {
 
 		public RetryConfig setCacheBody(boolean cacheBody) {
 			this.cacheBody = cacheBody;
+			return this;
+		}
+
+		public BackoffConfig getBackoff() {
+			return backoff;
+		}
+
+		public RetryConfig setBackoff(BackoffConfig backoff) {
+			this.backoff = backoff;
+			return this;
+		}
+
+		public RetryConfig setBackoff(Duration firstBackoff, Duration maxBackoff, int factor) {
+			this.backoff = new BackoffConfig(firstBackoff, maxBackoff, factor);
+			return this;
+		}
+
+	}
+
+	public static class BackoffConfig {
+
+		private Duration firstBackoff = Duration.ofMillis(5);
+
+		private Duration maxBackoff;
+
+		private int factor = 2;
+
+		public BackoffConfig() {
+		}
+
+		public BackoffConfig(Duration firstBackoff, Duration maxBackoff, int factor) {
+			this.firstBackoff = firstBackoff;
+			this.maxBackoff = maxBackoff;
+			this.factor = factor;
+		}
+
+		public void validate() {
+			Objects.requireNonNull(this.firstBackoff, "firstBackoff must be present");
+			Assert.isTrue(this.firstBackoff.toMillis() >= 1, "firstBackoff must be >= 1ms");
+			Assert.isTrue(this.factor > 1, "factor must be greater than 1");
+			if (this.maxBackoff != null) {
+				Assert.isTrue(this.maxBackoff.compareTo(this.firstBackoff) > 0,
+						"maxBackoff must be greater than firstBackoff");
+			}
+		}
+
+		public Duration getFirstBackoff() {
+			return firstBackoff;
+		}
+
+		public BackoffConfig setFirstBackoff(Duration firstBackoff) {
+			this.firstBackoff = firstBackoff;
+			return this;
+		}
+
+		public Duration getMaxBackoff() {
+			return maxBackoff;
+		}
+
+		public BackoffConfig setMaxBackoff(Duration maxBackoff) {
+			this.maxBackoff = maxBackoff;
+			return this;
+		}
+
+		public int getFactor() {
+			return factor;
+		}
+
+		public BackoffConfig setFactor(int factor) {
+			this.factor = factor;
 			return this;
 		}
 

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/RetryFilterFunctionBackoffTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/RetryFilterFunctionBackoffTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.server.mvc.filter;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.servlet.function.HandlerFilterFunction;
+import org.springframework.web.servlet.function.ServerRequest;
+import org.springframework.web.servlet.function.ServerResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+class RetryFilterFunctionBackoffTests {
+
+	private static final Duration BACKOFF = Duration.ofMillis(50);
+
+	private static final Duration MAX_BACKOFF = Duration.ofMillis(100);
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void gatewayRetryUsesConfiguredBackoff() throws Exception {
+		assertBackoff(
+				GatewayRetryFilterFunctions.retry(config -> config.setRetries(2).setBackoff(BACKOFF, MAX_BACKOFF, 2)));
+	}
+
+	@Test
+	void frameworkRetryUsesConfiguredBackoff() throws Exception {
+		assertBackoff(FrameworkRetryFilterFunctions
+			.frameworkRetry(config -> config.setRetries(2).setBackoff(BACKOFF, MAX_BACKOFF, 2)));
+	}
+
+	@Test
+	void retryConfigBindsBackoff() {
+		MapConfigurationPropertySource source = new MapConfigurationPropertySource(
+				Map.of("backoff.firstBackoff", "100ms", "backoff.maxBackoff", "500ms", "backoff.factor", "2"));
+
+		RetryFilterFunctions.RetryConfig config = new Binder(Collections.singletonList(source), null,
+				ApplicationConversionService.getSharedInstance())
+			.bindOrCreate("", Bindable.of(RetryFilterFunctions.RetryConfig.class));
+
+		assertThat(config.getBackoff()).isNotNull();
+		assertThat(config.getBackoff().getFirstBackoff()).isEqualTo(Duration.ofMillis(100));
+		assertThat(config.getBackoff().getMaxBackoff()).isEqualTo(Duration.ofMillis(500));
+		assertThat(config.getBackoff().getFactor()).isEqualTo(2);
+	}
+
+	@Test
+	void rejectsMissingFirstBackoff() {
+		RetryFilterFunctions.BackoffConfig backoff = new RetryFilterFunctions.BackoffConfig().setFirstBackoff(null);
+
+		assertThatNullPointerException().isThrownBy(backoff::validate).withMessage("firstBackoff must be present");
+	}
+
+	@Test
+	void rejectsFirstBackoffLessThanOneMillisecond() {
+		RetryFilterFunctions.BackoffConfig backoff = new RetryFilterFunctions.BackoffConfig()
+			.setFirstBackoff(Duration.ZERO);
+
+		assertThatIllegalArgumentException().isThrownBy(backoff::validate).withMessage("firstBackoff must be >= 1ms");
+	}
+
+	@Test
+	void rejectsFactorLessThanTwo() {
+		RetryFilterFunctions.BackoffConfig backoff = new RetryFilterFunctions.BackoffConfig().setFactor(1);
+
+		assertThatIllegalArgumentException().isThrownBy(backoff::validate).withMessage("factor must be greater than 1");
+	}
+
+	@Test
+	void rejectsMaxBackoffNotGreaterThanFirstBackoff() {
+		RetryFilterFunctions.BackoffConfig backoff = new RetryFilterFunctions.BackoffConfig()
+			.setFirstBackoff(Duration.ofMillis(50))
+			.setMaxBackoff(Duration.ofMillis(50));
+
+		assertThatIllegalArgumentException().isThrownBy(backoff::validate)
+			.withMessage("maxBackoff must be greater than firstBackoff");
+	}
+
+	private void assertBackoff(HandlerFilterFunction<ServerResponse, ServerResponse> filter) throws Exception {
+		AtomicInteger attempts = new AtomicInteger();
+		long start = System.nanoTime();
+
+		ServerResponse response = filter.filter(request(), request -> {
+			if (attempts.incrementAndGet() == 1) {
+				return ServerResponse.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+			}
+			return ServerResponse.ok().build();
+		});
+
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(attempts.get()).isEqualTo(2);
+		assertThat(Duration.ofNanos(System.nanoTime() - start)).isGreaterThanOrEqualTo(Duration.ofMillis(40));
+	}
+
+	private ServerRequest request() {
+		MockHttpServletRequest servletRequest = new MockHttpServletRequest("GET", "/retry");
+		return ServerRequest.create(servletRequest, Collections.emptyList());
+	}
+
+}

--- a/spring-cloud-gateway-server-webmvc/src/test/resources/application-propertiesbeandefinitionregistrartests.yml
+++ b/spring-cloud-gateway-server-webmvc/src/test/resources/application-propertiesbeandefinitionregistrartests.yml
@@ -58,6 +58,10 @@ spring.cloud.gateway.server.webmvc:
             retries: 3
             series: SERVER_ERROR
             methods: GET,POST
+            backoff:
+              firstBackoff: 5ms
+              maxBackoff: 50ms
+              factor: 2
         - name: CircuitBreaker
           args:
             id: mycb


### PR DESCRIPTION
## Summary
- Add `backoff` support to MVC `RetryConfig` with `firstBackoff`, `maxBackoff`, and `factor`
- Apply configured backoff in both MVC retry implementations: `GatewayRetryFilterFunctions` and `FrameworkRetryFilterFunctions`
- Document YAML and Java DSL usage and add regression coverage for both retry paths, nested config binding, and invalid backoff validation

Fixes #4141

## Testing
- `./mvnw -pl spring-cloud-gateway-server-webmvc -Dtest=RetryFilterFunctionBackoffTests,RetryFilterFunctionSelectionLogicTests,RetryFilterFunctionNoSpringRetrySelectionTests test`
- `./mvnw -pl spring-cloud-gateway-server-webmvc -DskipTests verify`
