### PR TITLE
Allow query parameters without value in proxied URL.

### DIFF
--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtils.java
@@ -342,9 +342,14 @@ public abstract class MvcUtils {
 	public static MultiValueMap<String, String> encodeQueryParams(MultiValueMap<String, String> params) {
 		MultiValueMap<String, String> encodedQueryParams = new LinkedMultiValueMap<>(params.size());
 		for (Map.Entry<String, List<String>> entry : params.entrySet()) {
-			for (String value : entry.getValue()) {
-				encodedQueryParams.add(UriUtils.encode(entry.getKey(), StandardCharsets.UTF_8),
-						UriUtils.encode(value, StandardCharsets.UTF_8));
+			String key = UriUtils.encode(entry.getKey(), StandardCharsets.UTF_8);
+			if (CollectionUtils.isEmpty(entry.getValue())) {
+				encodedQueryParams.put(key, entry.getValue());
+			}
+			else {
+				for (String value : entry.getValue()) {
+					encodedQueryParams.add(key, UriUtils.encode(value, StandardCharsets.UTF_8));
+				}
 			}
 		}
 		return CollectionUtils.unmodifiableMultiValueMap(encodedQueryParams);

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/ServerMvcIntegrationTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/ServerMvcIntegrationTests.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -1024,6 +1025,44 @@ public class ServerMvcIntegrationTests {
 	}
 
 	@Test
+	public void queryParamWithoutValueWorks() {
+		restClient.get()
+			.uri("/queryParamWithoutValue?myparam")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody(Map.class)
+			.consumeWith(result -> {
+				Map responseBody = result.getResponseBody();
+				assertThat(responseBody).containsKey("args");
+				Map args = getMap(responseBody, "args");
+				assertThat(args).containsKey("myparam");
+				assertThat(args.get("myparam")).isEqualTo("");
+				String url = (String) responseBody.get("url");
+				assertThat(url).endsWith("/get?myparam");
+			});
+	}
+
+	@Test
+	public void queryParamWithEmptyValueWorks() {
+		restClient.get()
+			.uri("/get?myparam=")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody(Map.class)
+			.consumeWith(result -> {
+				Map responseBody = result.getResponseBody();
+				assertThat(responseBody).containsKey("args");
+				Map args = getMap(responseBody, "args");
+				assertThat(args).containsKey("myparam");
+				assertThat(args.get("myparam")).isEqualTo("");
+				String url = (String) responseBody.get("url");
+				assertThat(url).endsWith("/get?myparam=");
+			});
+	}
+
+	@Test
 	public void clientResponseBodyAttributeWorks() {
 		restClient.get()
 			.uri("/anything/readresponsebody")
@@ -1688,6 +1727,30 @@ public class ServerMvcIntegrationTests {
 					})
 					.build();
 			// @formatter:on
+		}
+
+		@Bean
+		public RouterFunction<ServerResponse> gatewayRouterFunctionsEmptyQueryParamFilter() {
+			Function<ServerRequest, ServerRequest> transformQueryParamWithoutValue = request -> ServerRequest
+				.from(request)
+				.params(params -> {
+					// transform any query parameter with empty string value to not have
+					// any value at all
+					for (var param : params.entrySet()) {
+						if (param.getValue().size() == 1 && param.getValue().get(0).isEmpty()) {
+							params.put(param.getKey(), Collections.emptyList());
+						}
+					}
+				})
+				.build();
+			// @formatter:off
+			return route("testQueryParamWithoutValue")
+					.GET("/queryParamWithoutValue", http())
+					.before(transformQueryParamWithoutValue)
+					.filter(new HttpbinUriResolver())
+					.filter(setPath("/get"))
+					.build();
+            // @formatter:on
 		}
 
 		@Bean

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtilsTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/common/MvcUtilsTests.java
@@ -17,11 +17,13 @@
 package org.springframework.cloud.gateway.server.mvc.common;
 
 import java.util.Collections;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.servlet.function.ServerRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,6 +62,13 @@ class MvcUtilsTests {
 		ServerRequest request = ServerRequest.create(servletRequest, Collections.emptyList());
 
 		assertThat(MvcUtils.stripContextPath(request, "/path")).isEqualTo("/path");
+	}
+
+	@Test
+	void encodeQueryParamsKeepsParamWithoutValue() {
+		var queryParams = MultiValueMap.<String, String>fromMultiValue(Map.of("test", Collections.emptyList()));
+		var encoded = MvcUtils.encodeQueryParams(queryParams);
+		assertThat(encoded).isEqualTo(queryParams);
 	}
 
 }


### PR DESCRIPTION
Align the behavior of query parameters in MvcUtils with [HierarchicalUriComponents from spring-web](https://github.com/spring-projects/spring-framework/blob/fc0ad3d367620c8ac54b89123a0de72be5948387/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java#L213) to
allow query parameters without value to be passed along in the proxied request by [ProxyExchangeHandlerFunction](https://github.com/spring-cloud/spring-cloud-gateway/blob/01261758bf7a0cb671f8a2b949c6f83bf96b0529/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/ProxyExchangeHandlerFunction.java#L92).

A query parameter`?param` in the incoming request is still parsed as `"param" -> [""]` by webmvc, but this change allows custom filter implementations (like the one in the included test `gatewayRouterFunctionsEmptyQueryParamFilter`) to transform incoming query parameters to be preserved without trailing equal sign such that `?param` in the original request is not proxied as `?param=`.

Fixes gh-3197.