### PR TITLE
Return 503 for unavailable downstream service

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -16,7 +16,9 @@
 
 package org.springframework.cloud.gateway.filter;
 
+import java.net.ConnectException;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -199,7 +201,18 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 						th -> new ResponseStatusException(HttpStatus.GATEWAY_TIMEOUT, th.getMessage(), th));
 		}
 
+		responseFlux = responseFlux.onErrorMap(NettyRoutingFilter::isUnavailable,
+				th -> new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, th.getMessage(), th));
+
 		return responseFlux.then(chain.filter(exchange));
+	}
+
+	private static boolean isUnavailable(Throwable throwable) {
+		if (throwable instanceof ConnectException || throwable instanceof UnknownHostException) {
+			return true;
+		}
+		Throwable cause = throwable.getCause();
+		return cause != null && cause != throwable && isUnavailable(cause);
 	}
 
 	protected ByteBuf getByteBuf(DataBuffer dataBuffer) {

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterIntegrationTests.java
@@ -125,8 +125,16 @@ public class NettyRoutingFilterIntegrationTests extends BaseWebClientTests {
 			.uri("/connect/delay/2")
 			.exchange()
 			.expectStatus()
-			.isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+			.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
 			.expectBody()
+			.jsonPath("$.status")
+			.isEqualTo(String.valueOf(HttpStatus.SERVICE_UNAVAILABLE.value()))
+			.jsonPath("$.error")
+			.isEqualTo(HttpStatus.SERVICE_UNAVAILABLE.getReasonPhrase())
+			.jsonPath("$.path")
+			.isEqualTo("/connect/delay/2")
+			.jsonPath("$.message")
+			.exists()
 			.jsonPath("$.message")
 			.value(containsString("Connection refused"));
 


### PR DESCRIPTION
Fixes spring-cloud/spring-cloud-gateway#4208.

This updates the WebFlux `NettyRoutingFilter` so downstream connection failures are reported as `503 Service Unavailable` instead of `500 Internal Server Error`.

Previously, when Gateway could not connect to the downstream service, for example because the target port was closed, Reactor Netty raised a connection exception and the request resulted in a generic 500 response.

The change maps connection-related failures such as `ConnectException` and `UnknownHostException` to `ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE)`.

Validation:

- `./mvnw -pl spring-cloud-gateway-server-webflux -Dtest=NettyRoutingFilterIntegrationTests#shouldApplyConnectTimeoutPerRoute test`
- `./mvnw -pl spring-cloud-gateway-server-webflux -Dtest=NettyRoutingFilterIntegrationTests test`
- `git diff --check`