### PR TITLE
Fix trusted forwarded header preservation

### DIFF
--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfiguration.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfiguration.java
@@ -138,7 +138,7 @@ public class GatewayServerMvcAutoConfiguration {
 	}
 
 	@Bean
-	@Conditional(TrustedProxies.NotForwardedTrustedProxiesCondition.class)
+	@Conditional(TrustedProxies.NotTrustedProxiesCondition.class)
 	public RemoveForwardedRequestHeadersFilter removeForwardedRequestHeadersFilter() {
 		return new RemoveForwardedRequestHeadersFilter();
 	}
@@ -227,7 +227,7 @@ public class GatewayServerMvcAutoConfiguration {
 	}
 
 	@Bean
-	@Conditional(TrustedProxies.NotXForwardedTrustedProxiesCondition.class)
+	@Conditional(TrustedProxies.NotTrustedProxiesCondition.class)
 	public RemoveXForwardedRequestHeadersFilter removeXForwardedRequestHeadersFilter() {
 		return new RemoveXForwardedRequestHeadersFilter();
 	}

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/TrustedProxies.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/filter/TrustedProxies.java
@@ -141,6 +141,19 @@ public interface TrustedProxies {
 
 	}
 
+	class NotTrustedProxiesCondition extends NoneNestedConditions {
+
+		public NotTrustedProxiesCondition() {
+			super(ConfigurationPhase.REGISTER_BEAN);
+		}
+
+		@ConditionalOnPropertyExists
+		static class OnTrustedProxiesNotEmpty {
+
+		}
+
+	}
+
 	class OnPropertyExistsCondition extends SpringBootCondition {
 
 		@Override

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfigurationTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/GatewayServerMvcAutoConfigurationTests.java
@@ -225,6 +225,24 @@ public class GatewayServerMvcAutoConfigurationTests {
 			});
 	}
 
+	@Test
+	public void removeForwardedHeaderFiltersNotEnabledWhenTrustedProxiesConfigured() {
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FilterAutoConfiguration.class, PredicateAutoConfiguration.class,
+					HandlerFunctionAutoConfiguration.class, GatewayServerMvcAutoConfiguration.class,
+					HttpClientAutoConfiguration.class, RestTemplateAutoConfiguration.class,
+					RestClientAutoConfiguration.class, SslAutoConfiguration.class))
+			.withPropertyValues("spring.cloud.gateway.server.webmvc.forwarded-request-headers-filter.enabled=false",
+					"spring.cloud.gateway.server.webmvc.x-forwarded-request-headers-filter.enabled=false",
+					"spring.cloud.gateway.server.webmvc.trusted-proxies=.*")
+			.run(context -> {
+				assertThat(context).doesNotHaveBean(ForwardedRequestHeadersFilter.class)
+					.doesNotHaveBean(XForwardedRequestHeadersFilter.class)
+					.doesNotHaveBean(RemoveForwardedRequestHeadersFilter.class)
+					.doesNotHaveBean(RemoveXForwardedRequestHeadersFilter.class);
+			});
+	}
+
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
 	static class TestConfig {


### PR DESCRIPTION
Fixes #4227.

This changes the MVC forwarded-header removal fallback so that it only registers when `spring.cloud.gateway.server.webmvc.trusted-proxies` is not configured.

When an application configures trusted proxies but disables the generated Forwarded/X-Forwarded header filters, the gateway should not strip already trusted upstream forwarded headers. The generated header filters still remain disabled; this only prevents the removal fallback from treating that setup as untrusted.

Tests:
- `./mvnw -pl spring-cloud-gateway-server-webmvc -Dtest=GatewayServerMvcAutoConfigurationTests test`
- `./mvnw -pl spring-cloud-gateway-server-webmvc test`