### PR TITLE
Fixes overlapping X-Forwarded-Prefix for chained path filters [webflux]

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -261,22 +261,23 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 			LinkedHashSet<URI> originalUris = exchange.getAttribute(GATEWAY_ORIGINAL_REQUEST_URL_ATTR);
 			URI requestUri = exchange.getAttribute(GATEWAY_REQUEST_URL_ATTR);
 
-			if (originalUris != null && requestUri != null) {
+			if (originalUris != null && !originalUris.isEmpty() && requestUri != null) {
 
-				originalUris.forEach(originalUri -> {
+				// only the first uri counts: it is the url as received from the client.
+				// later entries are intermediate snapshots added by each path-mutating
+				// filter and would produce overlapping prefixes (gh-4236)
+				URI originalUri = originalUris.iterator().next();
 
-					if (originalUri != null && originalUri.getPath() != null) {
-						String prefix = originalUri.getPath();
+				if (originalUri != null && originalUri.getPath() != null) {
 
-						// strip trailing slashes before checking if request path is end
-						// of original path
-						String originalUriPath = stripTrailingSlash(originalUri);
-						String requestUriPath = stripTrailingSlash(requestUri);
+					// strip trailing slashes before checking if request path is end
+					// of original path
+					String originalUriPath = stripTrailingSlash(originalUri);
+					String requestUriPath = stripTrailingSlash(requestUri);
 
-						updateRequest(updated, originalUri, originalUriPath, requestUriPath);
+					updateRequest(updated, originalUri, originalUriPath, requestUriPath);
 
-					}
-				});
+				}
 			}
 		}
 

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -190,6 +190,58 @@ public class XForwardedHeadersFilterTests {
 	}
 
 	@Test
+	public void prefixToInferOnceWhenChainedPathFiltersProcessRequest() throws Exception {
+		MockServerHttpRequest request = MockServerHttpRequest.get("https://originalhost:8080/tenant/api/blue")
+			.remoteAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
+			.build();
+
+		XForwardedHeadersFilter filter = new XForwardedHeadersFilter(ALLOW_ALL_REGEX);
+		filter.setPrefixAppend(true);
+		filter.setPrefixEnabled(true);
+
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
+		// two chained path filters, e.g. StripPrefix=1 twice, add one entry each
+		originalUris
+			.add(UriComponentsBuilder.fromUriString("https://originalhost:8080/tenant/api/blue").build().toUri());
+		originalUris.add(UriComponentsBuilder.fromUriString("https://originalhost:8080/api/blue").build().toUri());
+		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
+		URI requestUri = UriComponentsBuilder.fromUriString("https://routedservice:8090/blue").build().toUri();
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
+
+		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);
+
+		assertThat(headers.headerNames()).contains(X_FORWARDED_PREFIX_HEADER);
+
+		assertThat(headers.getFirst(X_FORWARDED_PREFIX_HEADER)).isEqualTo("/tenant/api");
+	}
+
+	@Test
+	public void prefixAppendedToExistingHeaderOnceWhenChainedPathFiltersProcessRequest() throws Exception {
+		MockServerHttpRequest request = MockServerHttpRequest.get("https://originalhost:8080/tenant/api/blue")
+			.remoteAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))
+			.header(X_FORWARDED_PREFIX_HEADER, "/upstream")
+			.build();
+
+		XForwardedHeadersFilter filter = new XForwardedHeadersFilter(ALLOW_ALL_REGEX);
+		filter.setPrefixAppend(true);
+		filter.setPrefixEnabled(true);
+
+		ServerWebExchange exchange = MockServerWebExchange.from(request);
+		LinkedHashSet<URI> originalUris = new LinkedHashSet<>();
+		originalUris
+			.add(UriComponentsBuilder.fromUriString("https://originalhost:8080/tenant/api/blue").build().toUri());
+		originalUris.add(UriComponentsBuilder.fromUriString("https://originalhost:8080/api/blue").build().toUri());
+		exchange.getAttributes().put(GATEWAY_ORIGINAL_REQUEST_URL_ATTR, originalUris);
+		URI requestUri = UriComponentsBuilder.fromUriString("https://routedservice:8090/blue").build().toUri();
+		exchange.getAttributes().put(GATEWAY_REQUEST_URL_ATTR, requestUri);
+
+		HttpHeaders headers = filter.filter(request.getHeaders(), exchange);
+
+		assertThat(headers.getFirst(X_FORWARDED_PREFIX_HEADER)).isEqualTo("/upstream,/tenant/api");
+	}
+
+	@Test
 	public void prefixToInferWhenEqualsResource() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest.get("https://originalhost:8080/resource/resource/")
 			.remoteAddress(new InetSocketAddress(InetAddress.getByName("10.0.0.1"), 80))


### PR DESCRIPTION
Fixes gh-4236

When a WebFlux route applies more than one path-mutating filter (e.g. `StripPrefix=1` twice), every filter adds a snapshot of the request URL to `GATEWAY_ORIGINAL_REQUEST_URL_ATTR`, and `XForwardedHeadersFilter` emitted one `X-Forwarded-Prefix` value per suffix-matching snapshot. For a request to `/tenant/api/blue` stripped to `/blue`, the downstream request carried:

```http
X-Forwarded-Prefix: /tenant/api,/api
```

Downstream forwarded-header processing concatenates comma-separated prefix values, so the downstream application reconstructs a wrong context path (`/tenant/api/api` instead of `/tenant/api`).

With this change the prefix is derived once, from the URL as received from the client (the first entry of the attribute, which is insertion-ordered) against the final routed path. A single gateway therefore contributes a single prefix value. Values appended by upstream proxies are still preserved, covered by a new test asserting `/upstream,/tenant/api`.

This is the WebFlux counterpart of gh-4237, fixed separately in #4238 so each module can be reviewed and backported independently.
