### PR TITLE
Fix: LocalResponseCacheGatewayFilterFactory recreates Caffeine cache on every route refresh

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactory.java
@@ -18,7 +18,9 @@ package org.springframework.cloud.gateway.filter.factory.cache;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import org.jspecify.annotations.Nullable;
@@ -63,6 +65,8 @@ public class LocalResponseCacheGatewayFilterFactory
 
 	private final CaffeineCacheManager caffeineCacheManager;
 
+	private final Map<String, CacheSettings> registeredCacheSettings = new ConcurrentHashMap<>();
+
 	public LocalResponseCacheGatewayFilterFactory(ResponseCacheManagerFactory cacheManagerFactory,
 			Duration defaultTimeToLive, DataSize defaultSize, RequestOptions requestOptions) {
 		this(cacheManagerFactory, defaultTimeToLive, defaultSize, requestOptions, new CaffeineCacheManager());
@@ -84,14 +88,31 @@ public class LocalResponseCacheGatewayFilterFactory
 	public GatewayFilter apply(RouteCacheConfiguration config) {
 		LocalResponseCacheProperties cacheProperties = mapRouteCacheConfig(config);
 
-		Caffeine caffeine = LocalResponseCacheUtils.createCaffeine(cacheProperties);
-		String cacheName = config.getRouteId() + "-cache";
-		caffeineCacheManager.registerCustomCache(cacheName, caffeine.build());
-		Cache routeCache = caffeineCacheManager.getCache(cacheName);
-		Objects.requireNonNull(routeCache, "Cache " + cacheName + " not found");
+		Cache routeCache = registerOrReuseCache(config, cacheProperties);
 		return new ResponseCacheGatewayFilter(
 				cacheManagerFactory.create(routeCache, cacheProperties.getTimeToLive(), requestOptions));
 
+	}
+
+	/**
+	 * Returns the cache backing the route. A route refresh applies the filter again, so
+	 * the cache already registered is reused when the route cache configuration has not
+	 * changed, keeping the entries cached so far. A new cache is built when the
+	 * configuration changed, and also when the route has no id, because in that case the
+	 * cache name cannot tell one route from another.
+	 */
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	private Cache registerOrReuseCache(RouteCacheConfiguration config, LocalResponseCacheProperties cacheProperties) {
+		String cacheName = config.getRouteId() + "-cache";
+		CacheSettings settings = new CacheSettings(cacheProperties.getTimeToLive(), cacheProperties.getSize());
+		if (config.getRouteId() == null || !settings.equals(registeredCacheSettings.get(cacheName))) {
+			Caffeine caffeine = LocalResponseCacheUtils.createCaffeine(cacheProperties);
+			caffeineCacheManager.registerCustomCache(cacheName, caffeine.build());
+			registeredCacheSettings.put(cacheName, settings);
+		}
+		Cache routeCache = caffeineCacheManager.getCache(cacheName);
+		Objects.requireNonNull(routeCache, "Cache " + cacheName + " not found");
+		return routeCache;
 	}
 
 	private LocalResponseCacheProperties mapRouteCacheConfig(RouteCacheConfiguration config) {
@@ -146,6 +167,9 @@ public class LocalResponseCacheGatewayFilterFactory
 			return this.routeId;
 		}
 
+	}
+
+	private record CacheSettings(@Nullable Duration timeToLive, @Nullable DataSize size) {
 	}
 
 }

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryTests.java
@@ -16,11 +16,15 @@
 
 package org.springframework.cloud.gateway.filter.factory.cache;
 
+import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -28,14 +32,24 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
+import reactor.core.publisher.Flux;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringBootConfiguration;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
+import org.springframework.cloud.gateway.event.RefreshRoutesResultEvent;
+import org.springframework.cloud.gateway.filter.FilterDefinition;
+import org.springframework.cloud.gateway.handler.predicate.PredicateDefinition;
+import org.springframework.cloud.gateway.route.RouteDefinition;
+import org.springframework.cloud.gateway.route.RouteDefinitionLocator;
 import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.cloud.gateway.test.BaseWebClientTests;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.CacheControl;
@@ -74,6 +88,9 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 	@SpringBootTest(properties = { "spring.cloud.gateway.server.webflux.filter.local-response-cache.enabled=true" },
 			webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 	public class UsingFilterParams extends BaseWebClientTests {
+
+		@Autowired
+		private ConfigurableApplicationContext applicationContext;
 
 		@RetryingTest(3)
 		void shouldNotCacheResponseWhenGetRequestHasBody() {
@@ -193,6 +210,51 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 					.expectBody()
 					.jsonPath("$.headers." + CUSTOM_HEADER)
 					.isEqualTo(customHeaderFromReq1));
+		}
+
+		@RetryingTest(3)
+		void shouldServeCachedResponseAfterRouteRefreshWhenCacheConfigurationIsUnchanged() {
+			String uri = "/" + UUID.randomUUID() + "/refreshable-cache/headers";
+
+			testClient.get()
+				.uri(uri)
+				.header("Host", "www.localresponsecache.org")
+				.header(CUSTOM_HEADER, "1")
+				.exchange()
+				.expectBody()
+				.jsonPath("$.headers." + CUSTOM_HEADER)
+				.isEqualTo("1");
+
+			// A route refresh re-applies the filter factory. The cache configuration is
+			// unchanged, so the entries cached before the refresh must survive it.
+			refreshRoutes();
+			refreshRoutes();
+
+			testClient.get()
+				.uri(uri)
+				.header("Host", "www.localresponsecache.org")
+				.header(CUSTOM_HEADER, "2")
+				.exchange()
+				.expectBody()
+				.jsonPath("$.headers." + CUSTOM_HEADER)
+				.isEqualTo("1");
+		}
+
+		private void refreshRoutes() {
+			CountDownLatch refreshed = new CountDownLatch(1);
+			ApplicationListener<RefreshRoutesResultEvent> listener = event -> refreshed.countDown();
+			applicationContext.addApplicationListener(listener);
+			try {
+				applicationContext.publishEvent(new RefreshRoutesEvent(this));
+				assertThat(refreshed.await(DURATION.toSeconds(), TimeUnit.SECONDS)).isTrue();
+			}
+			catch (InterruptedException ex) {
+				Thread.currentThread().interrupt();
+				throw new IllegalStateException("Interrupted while waiting for the route refresh", ex);
+			}
+			finally {
+				applicationContext.removeApplicationListener(listener);
+			}
 		}
 
 		@RetryingTest(3)
@@ -448,6 +510,28 @@ public class LocalResponseCacheGatewayFilterFactoryTests extends BaseWebClientTe
 									.localResponseCache(null, DataSize.ofBytes(1L)))
 								.uri(uri))
 					.build();
+			}
+
+			/**
+			 * The Java DSL does not set the route id on the filter configuration, so
+			 * routes built with {@link RouteLocatorBuilder} always get a new cache. A
+			 * route definition carries its id all the way to the filter configuration,
+			 * which is what a discovery-driven deployment looks like, so the refresh
+			 * behaviour has to be asserted on a route defined this way.
+			 */
+			@Bean
+			public RouteDefinitionLocator refreshableCacheRouteDefinitionLocator() {
+				RouteDefinition routeDefinition = new RouteDefinition();
+				routeDefinition.setId("refreshable_local_response_cache_test");
+				routeDefinition.setUri(URI.create(uri));
+				routeDefinition.setPredicates(List.of(new PredicateDefinition("Path=/{namespace}/refreshable-cache/**"),
+						new PredicateDefinition("Host={sub}.localresponsecache.org")));
+				FilterDefinition localResponseCache = new FilterDefinition();
+				localResponseCache.setName("LocalResponseCache");
+				localResponseCache.addArg("timeToLive", "2m");
+				routeDefinition.setFilters(List.of(new FilterDefinition("StripPrefix=2"),
+						new FilterDefinition("PrefixPath=/httpbin"), localResponseCache));
+				return () -> Flux.just(routeDefinition);
 			}
 
 		}

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryUnitTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.gateway.filter.factory.cache;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.cloud.gateway.filter.factory.cache.LocalResponseCacheGatewayFilterFactory.RouteCacheConfiguration;
+import org.springframework.cloud.gateway.filter.factory.cache.keygenerator.CacheKeyGenerator;
+import org.springframework.util.unit.DataSize;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link LocalResponseCacheGatewayFilterFactory}.
+ */
+public class LocalResponseCacheGatewayFilterFactoryUnitTests {
+
+	@Test
+	void applyReusesRegisteredCacheOnRouteRefresh() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+		LocalResponseCacheGatewayFilterFactory factory = createFactory(cacheManager);
+
+		RouteCacheConfiguration config = new RouteCacheConfiguration();
+		config.setRouteId("refreshed-route");
+
+		factory.apply(config);
+		Cache cache = cacheManager.getCache("refreshed-route-cache");
+		assertThat(cache).isNotNull();
+		cache.put("cached-key", "cached-value");
+
+		factory.apply(config);
+
+		Cache cacheAfterRefresh = cacheManager.getCache("refreshed-route-cache");
+		assertThat(cacheAfterRefresh).isSameAs(cache);
+		assertThat(cacheAfterRefresh.get("cached-key", String.class)).isEqualTo("cached-value");
+	}
+
+	@Test
+	void applyRegistersOneCachePerRoute() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+		LocalResponseCacheGatewayFilterFactory factory = createFactory(cacheManager);
+
+		RouteCacheConfiguration firstConfig = new RouteCacheConfiguration();
+		firstConfig.setRouteId("first-route");
+		RouteCacheConfiguration secondConfig = new RouteCacheConfiguration();
+		secondConfig.setRouteId("second-route");
+
+		factory.apply(firstConfig);
+		factory.apply(secondConfig);
+
+		Cache firstCache = cacheManager.getCache("first-route-cache");
+		Cache secondCache = cacheManager.getCache("second-route-cache");
+		assertThat(firstCache).isNotNull();
+		assertThat(secondCache).isNotNull();
+		assertThat(firstCache).isNotSameAs(secondCache);
+	}
+
+	private LocalResponseCacheGatewayFilterFactory createFactory(CaffeineCacheManager cacheManager) {
+		return new LocalResponseCacheGatewayFilterFactory(new ResponseCacheManagerFactory(new CacheKeyGenerator()),
+				Duration.ofMinutes(5), DataSize.ofMegabytes(5), new LocalResponseCacheProperties().getRequest(),
+				cacheManager);
+	}
+
+}

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/cache/LocalResponseCacheGatewayFilterFactoryUnitTests.java
@@ -73,6 +73,41 @@ public class LocalResponseCacheGatewayFilterFactoryUnitTests {
 		assertThat(firstCache).isNotSameAs(secondCache);
 	}
 
+	@Test
+	void applyBuildsNewCacheWhenRouteCacheConfigurationChanges() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+		LocalResponseCacheGatewayFilterFactory factory = createFactory(cacheManager);
+
+		RouteCacheConfiguration config = new RouteCacheConfiguration();
+		config.setRouteId("reconfigured-route");
+		config.setTimeToLive(Duration.ofMinutes(2));
+
+		factory.apply(config);
+		Cache cache = cacheManager.getCache("reconfigured-route-cache");
+
+		factory.apply(config.setTimeToLive(Duration.ofMillis(100)));
+
+		assertThat(cacheManager.getCache("reconfigured-route-cache")).isNotSameAs(cache);
+	}
+
+	@Test
+	void applyBuildsNewCacheWhenRouteHasNoId() {
+		CaffeineCacheManager cacheManager = new CaffeineCacheManager();
+		LocalResponseCacheGatewayFilterFactory factory = createFactory(cacheManager);
+
+		RouteCacheConfiguration longLivedConfig = new RouteCacheConfiguration();
+		longLivedConfig.setTimeToLive(Duration.ofMinutes(2));
+		RouteCacheConfiguration shortLivedConfig = new RouteCacheConfiguration();
+		shortLivedConfig.setTimeToLive(Duration.ofMillis(100));
+
+		factory.apply(longLivedConfig);
+		Cache longLivedCache = cacheManager.getCache("null-cache");
+
+		factory.apply(shortLivedConfig);
+
+		assertThat(cacheManager.getCache("null-cache")).isNotSameAs(longLivedCache);
+	}
+
 	private LocalResponseCacheGatewayFilterFactory createFactory(CaffeineCacheManager cacheManager) {
 		return new LocalResponseCacheGatewayFilterFactory(new ResponseCacheManagerFactory(new CacheKeyGenerator()),
 				Duration.ofMinutes(5), DataSize.ofMegabytes(5), new LocalResponseCacheProperties().getRequest(),


### PR DESCRIPTION
Fixes #4243.

`LocalResponseCacheGatewayFilterFactory` built a new `Caffeine` cache and registered it in the `CaffeineCacheManager` under the same name every time the filter was applied. A route refresh applies the filter again, so the entries cached so far were dropped on every refresh.

This change reuses the cache already registered for the route, so cached entries survive a refresh. A new cache is still built in two cases:

- the route cache configuration changed, so the previous cache would keep the old time to live or size;
- the route has no id, because the cache name is then `null-cache` for every such route and cannot tell one route from another. Routes built with `RouteLocatorBuilder` are in this group, since `GatewayFilterSpec.localResponseCache` does not set a route id. Keeping the previous behaviour there avoids routes with different settings sharing one cache.

Verified against `spring-cloud-gateway-server-webflux`: the added unit tests fail without the change and pass with it, and the existing `LocalResponseCacheGatewayFilterFactoryTests` stay green, including `shouldNotCacheResponseWhenTimeToLiveIsReached` which relies on each route keeping its own time to live.
