### PR TITLE
Fix: PathRoutePredicateFactory matchTrailingSlash with Spring Framework 7.0

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
@@ -110,17 +110,26 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 							s -> parsePath(exchange.getRequest().getURI().getRawPath()));
 
 				PathPattern match = null;
+				PathContainer pathForMatch = path;
 				for (int i = 0; i < pathPatterns.size(); i++) {
 					PathPattern pathPattern = pathPatterns.get(i);
 					if (pathPattern.matches(path)) {
 						match = pathPattern;
 						break;
 					}
+					else if (config.isMatchTrailingSlash() && path.value().endsWith("/")) {
+						PathContainer pathWithoutTrailingSlash = parsePath(path.value().substring(0, path.value().length() - 1));
+						if (pathPattern.matches(pathWithoutTrailingSlash)) {
+							match = pathPattern;
+							pathForMatch = pathWithoutTrailingSlash;
+							break;
+						}
+					}
 				}
 
 				if (match != null) {
 					traceMatch("Pattern", match.getPatternString(), path, true);
-					PathMatchInfo pathMatchInfo = match.matchAndExtract(path);
+					PathMatchInfo pathMatchInfo = match.matchAndExtract(pathForMatch);
 					if (pathMatchInfo != null) {
 						putUriTemplateVariables(exchange, pathMatchInfo.getUriVariables());
 					}

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
@@ -118,7 +118,8 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 						break;
 					}
 					else if (config.isMatchTrailingSlash() && path.value().endsWith("/")) {
-						PathContainer pathWithoutTrailingSlash = parsePath(path.value().substring(0, path.value().length() - 1));
+						PathContainer pathWithoutTrailingSlash = parsePath(
+								path.value().substring(0, path.value().length() - 1));
 						if (pathPattern.matches(pathWithoutTrailingSlash)) {
 							match = pathPattern;
 							pathForMatch = pathWithoutTrailingSlash;

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactory.java
@@ -86,8 +86,6 @@ public class PathRoutePredicateFactory extends AbstractRoutePredicateFactory<Pat
 	public Predicate<ServerWebExchange> apply(Config config) {
 		final ArrayList<PathPattern> pathPatterns = new ArrayList<>();
 		synchronized (this.pathPatternParser) {
-			// FIXME: 5.0.0 setMatchOptionalTrailingSeparator missing
-			// pathPatternParser.setMatchOptionalTrailingSeparator(config.isMatchTrailingSlash());
 			config.getPatterns().forEach(pattern -> {
 				String basePath = webFluxProperties.getBasePath();
 				boolean basePathIsNotBlank = StringUtils.hasText(basePath);

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/handler/predicate/PathRoutePredicateFactoryTests.java
@@ -37,6 +37,8 @@ import org.springframework.cloud.gateway.test.BaseWebClientTests;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.security.web.server.WebFilterChainProxy;
 import org.springframework.security.web.server.firewall.StrictServerWebExchangeFirewall;
 import org.springframework.test.annotation.DirtiesContext;
@@ -44,6 +46,7 @@ import org.springframework.web.server.ServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.getUriTemplateVariables;
 
 @SpringBootTest(webEnvironment = RANDOM_PORT, properties = "debug=true")
 @DirtiesContext
@@ -126,6 +129,48 @@ public class PathRoutePredicateFactoryTests extends BaseWebClientTests {
 			.valueEquals(HANDLER_MAPPER_HEADER, RoutePredicateHandlerMapping.class.getSimpleName())
 			.expectHeader()
 			.valueEquals(ROUTE_ID_HEADER, "path_regex");
+	}
+
+	@Test
+	public void trailingSlashMatchesWhenMatchTrailingSlashEnabled() {
+		Config config = new Config().setPatterns(Arrays.asList("/abc/{id}/function")).setMatchTrailingSlash(true);
+		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new WebFluxProperties()).apply(config);
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/abc/123/function/").build());
+
+		assertThat(predicate.test(exchange)).isTrue();
+		assertThat(getUriTemplateVariables(exchange)).containsEntry("id", "123");
+	}
+
+	@Test
+	public void trailingSlashDoesNotMatchWhenMatchTrailingSlashDisabled() {
+		Config config = new Config().setPatterns(Arrays.asList("/abc/{id}/function")).setMatchTrailingSlash(false);
+		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new WebFluxProperties()).apply(config);
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/abc/123/function/").build());
+
+		assertThat(predicate.test(exchange)).isFalse();
+	}
+
+	@Test
+	public void pathWithoutTrailingSlashDoesNotMatchPatternWithTrailingSlash() {
+		Config config = new Config().setPatterns(Arrays.asList("/abc/123/function/")).setMatchTrailingSlash(true);
+		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new WebFluxProperties()).apply(config);
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/abc/123/function").build());
+
+		assertThat(predicate.test(exchange)).isFalse();
+	}
+
+	@Test
+	public void patternWithTrailingSlashMatchesPathWithTrailingSlash() {
+		Config config = new Config().setPatterns(Arrays.asList("/abc/{id}/function/")).setMatchTrailingSlash(true);
+		Predicate<ServerWebExchange> predicate = new PathRoutePredicateFactory(new WebFluxProperties()).apply(config);
+		MockServerWebExchange exchange = MockServerWebExchange
+			.from(MockServerHttpRequest.get("/abc/123/function/").build());
+
+		assertThat(predicate.test(exchange)).isTrue();
+		assertThat(getUriTemplateVariables(exchange)).containsEntry("id", "123");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #4212.

In Spring Framework 7.0, `PathPatternParser.setMatchOptionalTrailingSeparator()` was removed, meaning the `matchTrailingSlash` setting in `PathRoutePredicateFactory` silently had no effect. This change implements trailing slash tolerance natively in `PathRoutePredicateFactory` by falling back to matching the path without the trailing slash when `matchTrailingSlash` is enabled, preserving the original one-directional semantics.