### PR TITLE
Fix: DiscoveryClient Route Definition Locator predicate parse exception after 5.0.2 upgrade

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/discovery/DiscoveryClientRouteDefinitionLocator.java
@@ -75,7 +75,7 @@ public class DiscoveryClientRouteDefinitionLocator implements RouteDefinitionLoc
 		else {
 			routeIdPrefix = discoveryClientName + "_";
 		}
-		evalCtxt = SimpleEvaluationContext.forReadOnlyDataBinding().build();
+		evalCtxt = SimpleEvaluationContext.forReadOnlyDataBinding().withInstanceMethods().build();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #4216.

This restores `withInstanceMethods()` to the `SimpleEvaluationContext` created in `DiscoveryClientRouteDefinitionLocator` so that SpEL expressions containing standard instance methods on String (such as `replaceFirst`) work correctly.