### PR TITLE
Using @Valid on a container (java.util.List) is deprecated

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/GatewayProperties.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/config/GatewayProperties.java
@@ -50,8 +50,7 @@ public class GatewayProperties {
 	 * List of Routes.
 	 */
 	@NotNull
-	@Valid
-	private List<RouteDefinition> routes = new ArrayList<>();
+	private List<@Valid RouteDefinition> routes = new ArrayList<>();
 
 	/**
 	 * List of filter definitions that are applied to every route.

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/route/RouteDefinition.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/route/RouteDefinition.java
@@ -43,11 +43,9 @@ public class RouteDefinition {
 	private @Nullable String id;
 
 	@NotEmpty
-	@Valid
-	private List<PredicateDefinition> predicates = new ArrayList<>();
+	private List<@Valid PredicateDefinition> predicates = new ArrayList<>();
 
-	@Valid
-	private List<FilterDefinition> filters = new ArrayList<>();
+	private List<@Valid FilterDefinition> filters = new ArrayList<>();
 
 	private @Nullable URI uri;
 

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
@@ -47,8 +47,7 @@ public class GatewayMvcProperties {
 	 * Map of Routes.
 	 */
 	@NotNull
-	@Valid
-	private LinkedHashMap<String, RouteProperties> routesMap = new LinkedHashMap<>();
+	private LinkedHashMap<String, @Valid RouteProperties> routesMap = new LinkedHashMap<>();
 
 	/**
 	 * Mime-types that are streaming.

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/GatewayMvcProperties.java
@@ -41,8 +41,7 @@ public class GatewayMvcProperties {
 	 * List of Routes.
 	 */
 	@NotNull
-	@Valid
-	private List<RouteProperties> routes = new ArrayList<>();
+	private List<@Valid RouteProperties> routes = new ArrayList<>();
 
 	/**
 	 * Map of Routes.

--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouteProperties.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/config/RouteProperties.java
@@ -48,14 +48,12 @@ public class RouteProperties {
 	 * List of predicates for matching the Route.
 	 */
 	@NotEmpty
-	@Valid
-	private List<PredicateProperties> predicates = new ArrayList<>();
+	private List<@Valid PredicateProperties> predicates = new ArrayList<>();
 
 	/**
 	 * List of filters to be applied to the Route.
 	 */
-	@Valid
-	private List<FilterProperties> filters = new ArrayList<>();
+	private List<@Valid FilterProperties> filters = new ArrayList<>();
 
 	/**
 	 * The destination URI.


### PR DESCRIPTION
## Summary
Fixes deprecation warnings from Hibernate Validator about applying `@Valid` directly to container types.

## Detail
[Spring Boot 4.1.0](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.1-Release-Notes) upgraded to Hibernate Validator 9.1 which included a change [deprecating the use of `@Valid` at the container level](https://docs.hibernate.org/validator/9.1/whats-new/en-US/html_single/#_deprecating_the_use_of_valid_at_the_container_level).

Meaning that this:
```java
class MyBean {
    @Valid
    List<MyContainerElement> list;
}
```

Should be replaced by this:
```java
class MyBean {
    List<@Valid MyContainerElement> list;
}
```

Else these warnings are raised:

```
o.h.v.i.m.a.CascadingMetaDataBuilder     : HV000271: Using `@Valid` on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s). Affected element: routes
o.h.v.i.m.a.CascadingMetaDataBuilder     : HV000271: Using `@Valid` on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s). Affected element: predicates
o.h.v.i.m.a.CascadingMetaDataBuilder     : HV000271: Using `@Valid` on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s). Affected element: filters
```