### PR TITLE
Fix ordering in test

### DIFF
--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/filter/BeforeFilterFunctionsTests.java
@@ -129,7 +129,7 @@ class BeforeFilterFunctionsTests {
 		assertThat(result.param("foo[]")).isPresent().hasValue("replacement[]");
 		assertThat(result.param("quux")).isPresent().hasValue("corge+");
 		assertThat(result.uri().toString())
-			.hasToString("http://localhost/path?quux=corge%2B&baz=qux&foo%5B%5D=replacement%5B%5D");
+			.hasToString("http://localhost/path?baz=qux&quux=corge%2B&foo%5B%5D=replacement%5B%5D");
 	}
 
 	@Test


### PR DESCRIPTION
Caused by a change in Spring Framework https://github.com/spring-projects/spring-framework/commit/b00f6916550d803bb85c1266c8135c3af6f414f5

Previously Collectors.toSet() returned a HashSet, so the iteration order depended on 'String.hashCode()' for the keys in this test that happened to be 'quux, foo[], baz'. 'rewriteRequestParameter' removes and re-adds the rewritten parameter, moving foo[] to the end and yielding 'quux, baz, foo[]', which is what the assertion had hardcoded.                                                                                                         

With 'LinkedHashSet', the order now follows 'getParameterMap()', which 'MockHttpServletRequest' backs with a 'LinkedHashMap' i.e. insertion order 'foo[], baz, quux', becoming 'baz, quux, foo[]' after the rewrite.