### PR TITLE
Add missing test scope to spring-boot-resttestclient

### DIFF
--- a/spring-cloud-gateway-proxyexchange-webmvc/pom.xml
+++ b/spring-cloud-gateway-proxyexchange-webmvc/pom.xml
@@ -27,6 +27,7 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-resttestclient</artifactId>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Fixes #4256 

`spring-cloud-gateway-proxyexchange-webmvc` declared `spring-boot-resttestclient` without a scope,
so it defaulted to `compile` and leaked onto the classpath of consuming applications.

`RestTestClient` is only used from `src/test/java`, and every other module in the repo
(`server-webmvc`, `server-webflux`, `proxyexchange-webflux`) already scopes it to `test`.
This aligns the module with them.