### PR TITLE
Fix connection pool leak when response is not modified

### DIFF
--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/AbstractGatewayServerResponse.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/AbstractGatewayServerResponse.java
@@ -26,9 +26,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.context.request.ServletWebRequest;
@@ -91,6 +93,11 @@ abstract class AbstractGatewayServerResponse extends GatewayErrorHandlingServerR
 			HttpMethod httpMethod = HttpMethod.valueOf(request.getMethod());
 			if (SAFE_METHODS.contains(httpMethod)
 					&& servletWebRequest.checkNotModified(headers().getETag(), lastModified)) {
+				// Not-modified short-circuit skips writeToInternal, which is where
+				// RestClientProxyExchange / ClientHttpRequestFactoryProxyExchange
+				// close the upstream ClientHttpResponse and return the connection
+				// to the pool (GH-4259).
+				closeClientResponse(request);
 				return null;
 			}
 			else {
@@ -99,6 +106,19 @@ abstract class AbstractGatewayServerResponse extends GatewayErrorHandlingServerR
 		}
 		catch (Throwable throwable) {
 			return handleError(throwable, request, response, context);
+		}
+	}
+
+	/**
+	 * Closes a proxied {@link ClientHttpResponse} stored on the request when the response
+	 * body will not be written (for example HTTP 304 Not Modified).
+	 * @param request the current servlet request
+	 */
+	private static void closeClientResponse(HttpServletRequest request) {
+		Object clientResponse = request.getAttribute(MvcUtils.CLIENT_RESPONSE_ATTR);
+		if (clientResponse instanceof ClientHttpResponse clientHttpResponse) {
+			clientHttpResponse.close();
+			request.removeAttribute(MvcUtils.CLIENT_RESPONSE_ATTR);
 		}
 	}
 

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchangeTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/handler/RestClientProxyExchangeTests.java
@@ -88,6 +88,44 @@ class RestClientProxyExchangeTests {
 		assertThat(responseBody.closed).isTrue();
 	}
 
+	@Test
+	void exchangeWhenNotModifiedThenClosesClientResponse() throws Exception {
+		RestClient restClient = mock(RestClient.class);
+		RestClient.RequestBodyUriSpec requestSpec = mock(RestClient.RequestBodyUriSpec.class);
+		CloseAwareInputStream responseBody = new CloseAwareInputStream();
+		TestClientHttpResponse clientResponse = new TestClientHttpResponse(responseBody);
+		clientResponse.getHeaders().setContentType(MediaType.TEXT_PLAIN);
+		clientResponse.getHeaders().setETag("\"abc\"");
+
+		when(restClient.method(HttpMethod.GET)).thenReturn(requestSpec);
+		when(requestSpec.uri(any(URI.class))).thenReturn(requestSpec);
+		when(requestSpec.headers(any())).thenReturn(requestSpec);
+		when(requestSpec.exchange(any(), eq(false))).thenAnswer((invocation) -> {
+			RestClient.RequestHeadersSpec.ExchangeFunction<ServerResponse> exchangeFunction = invocation.getArgument(0);
+			return exchangeFunction.exchange(mock(HttpRequest.class), clientResponse);
+		});
+
+		RestClientProxyExchange proxyExchange = new RestClientProxyExchange(restClient, new GatewayMvcProperties());
+		MockHttpServletRequest servletRequest = MockMvcRequestBuilders.get("http://localhost/resource")
+			.header(HttpHeaders.IF_NONE_MATCH, "\"abc\"")
+			.buildRequest(null);
+		ServerRequest serverRequest = ServerRequest.create(servletRequest, Collections.emptyList());
+		ProxyExchange.Request request = proxyExchange.request(serverRequest)
+			.uri(URI.create("http://localhost:8781/resource"))
+			.build();
+
+		ServerResponse serverResponse = proxyExchange.exchange(request);
+		// Proxy responses carry the upstream ETag; apply it so checkNotModified can
+		// short-circuit.
+		serverResponse.headers().setETag("\"abc\"");
+
+		MockHttpServletResponse servletResponse = new MockHttpServletResponse();
+		serverResponse.writeTo(servletRequest, servletResponse, Collections::emptyList);
+
+		assertThat(servletResponse.getStatus()).isEqualTo(HttpStatus.NOT_MODIFIED.value());
+		assertThat(clientResponse.closed).isTrue();
+	}
+
 	private static final class ClientDisconnectedResponse extends MockHttpServletResponse {
 
 		private final ServletOutputStream outputStream = new ServletOutputStream() {
@@ -155,6 +193,8 @@ class RestClientProxyExchangeTests {
 
 		private TestClientHttpResponse(CloseAwareInputStream body) {
 			this.body = body;
+			// Default content type used by existing streaming tests; other tests may
+			// override.
 			this.headers.setContentType(MediaType.TEXT_EVENT_STREAM);
 		}
 


### PR DESCRIPTION
Fixes #4259

## Description
When a proxied GET/HEAD response is short-circuited as HTTP 304 Not Modified in `AbstractGatewayServerResponse#writeTo`, `writeToInternal` is never invoked. That path is where `RestClientProxyExchange` / `ClientHttpRequestFactoryProxyExchange` close the upstream `ClientHttpResponse` and return the connection to the pool.

As a result, with Apache HttpComponents Client 5, leased connections are not released after conditional requests that evaluate to not modified.

## Change
On the not-modified short-circuit, close the `ClientHttpResponse` stored in `MvcUtils.CLIENT_RESPONSE_ATTR` (same attribute the reporter’s workaround interceptor closed), then clear the attribute.

No change to the 304 short-circuit behavior itself—only resource cleanup when the body write is skipped.

## Tests
- `RestClientProxyExchangeTests#exchangeWhenNotModifiedThenClosesClientResponse` (If-None-Match + matching ETag → 304 and `ClientHttpResponse.close()`)
- Existing streaming disconnect test still passes
- `./mvnw -pl spring-cloud-gateway-server-webmvc -am test -Dtest=RestClientProxyExchangeTests` (Temurin 21): **2/2**
- checkstyle + spring-javaformat validate clean on the module

## Notes
- Scope is the clear pool leak only; making the not-modified short-circuit optional (mentioned in the issue) is left as a separate enhancement.
- Related but distinct: #3696 (retry path with Apache client).