### PR TITLE
Fix stale route cache on overlapping refreshes

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/route/CachingRouteLocator.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
@@ -54,6 +55,10 @@ public class CachingRouteLocator
 
 	private final Map<String, List> cache = new ConcurrentHashMap<>();
 
+	private final AtomicLong refreshSequenceGenerator = new AtomicLong();
+
+	private long lastAppliedRefreshSequence;
+
 	private @Nullable ApplicationEventPublisher applicationEventPublisher;
 
 	public CachingRouteLocator(RouteLocator delegate) {
@@ -85,19 +90,22 @@ public class CachingRouteLocator
 
 	@Override
 	public void onApplicationEvent(RefreshRoutesEvent event) {
+		long refreshSequence = this.refreshSequenceGenerator.incrementAndGet();
 		try {
 			if (this.cache.containsKey(CACHE_KEY) && event.isScoped()) {
 				final Mono<List<Route>> scopedRoutes = fetch(event.getMetadata()).collect(Collectors.toList())
 					.onErrorResume(s -> Mono.just(List.of()));
 
 				scopedRoutes.subscribe(scopedRoutesList -> {
-					updateCache(Flux.concat(Flux.fromIterable(scopedRoutesList), getNonScopedRoutes(event))
-						.sort(AnnotationAwareOrderComparator.INSTANCE));
+					updateCache(refreshSequence,
+							Flux.concat(Flux.fromIterable(scopedRoutesList), getNonScopedRoutes(event))
+								.sort(AnnotationAwareOrderComparator.INSTANCE));
 				}, this::handleRefreshError);
 			}
 			else {
 				final Mono<List<Route>> allRoutes = fetch().collect(Collectors.toList());
-				allRoutes.subscribe(list -> updateCache(Flux.fromIterable(list)), this::handleRefreshError);
+				allRoutes.subscribe(list -> updateCache(refreshSequence, Flux.fromIterable(list)),
+						this::handleRefreshError);
 			}
 		}
 		catch (Throwable e) {
@@ -105,14 +113,21 @@ public class CachingRouteLocator
 		}
 	}
 
-	private synchronized void updateCache(Flux<Route> routes) {
+	private void updateCache(long refreshSequence, Flux<Route> routes) {
 		routes.materialize()
 			.collect(Collectors.toList())
-			.subscribe(this::publishRefreshEvent, this::handleRefreshError);
+			.subscribe(signals -> publishRefreshEvent(refreshSequence, signals), this::handleRefreshError);
 	}
 
-	private void publishRefreshEvent(List<Signal<Route>> signals) {
-		cache.put(CACHE_KEY, signals);
+	private void publishRefreshEvent(long refreshSequence, List<Signal<Route>> signals) {
+
+		synchronized (this) {
+			if (refreshSequence > this.lastAppliedRefreshSequence) {
+				cache.put(CACHE_KEY, signals);
+				this.lastAppliedRefreshSequence = refreshSequence;
+			}
+		}
+
 		Objects.requireNonNull(applicationEventPublisher, "ApplicationEventPublisher is required");
 		applicationEventPublisher.publishEvent(new RefreshRoutesResultEvent(this));
 	}

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/route/CachingRouteLocatorTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/route/CachingRouteLocatorTests.java
@@ -20,9 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
 
 import org.springframework.cloud.gateway.event.RefreshRoutesEvent;
 import org.springframework.cloud.gateway.event.RefreshRoutesResultEvent;
@@ -136,6 +138,64 @@ public class CachingRouteLocatorTests {
 			.order(id)
 			.predicate(exchange -> true)
 			.build();
+	}
+
+	@Test
+	void latestRefreshShouldWinWhenRefreshesCompleteOutOfOrder() throws Exception {
+
+		Route oldRoute = Route.async()
+			.id("old-route")
+			.uri("http://localhost/old")
+			.order(0)
+			.predicate(exchange -> true)
+			.build();
+
+		Route newRoute = Route.async()
+			.id("new-route")
+			.uri("http://localhost/new")
+			.order(0)
+			.predicate(exchange -> true)
+			.build();
+
+		AtomicInteger calls = new AtomicInteger();
+
+		Sinks.One<Route> firstRefresh = Sinks.one();
+		Sinks.One<Route> secondRefresh = Sinks.one();
+
+		RouteLocator delegate = () -> {
+			if (calls.getAndIncrement() == 0) {
+				return firstRefresh.asMono().flux();
+			}
+			return secondRefresh.asMono().flux();
+		};
+
+		CachingRouteLocator locator = new CachingRouteLocator(delegate);
+
+		CountDownLatch latch = new CountDownLatch(2);
+
+		locator.setApplicationEventPublisher(event -> {
+			if (event instanceof RefreshRoutesResultEvent) {
+				latch.countDown();
+			}
+		});
+
+		// Start the older refresh first.
+		locator.onApplicationEvent(new RefreshRoutesEvent(this));
+
+		// Start the newer refresh second.
+		locator.onApplicationEvent(new RefreshRoutesEvent(this));
+
+		// Force the newer refresh to complete first.
+		assertThat(secondRefresh.tryEmitValue(newRoute)).isEqualTo(Sinks.EmitResult.OK);
+
+		// Force the older refresh to complete afterward.
+		assertThat(firstRefresh.tryEmitValue(oldRoute)).isEqualTo(Sinks.EmitResult.OK);
+
+		assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
+
+		List<Route> routes = locator.getRoutes().collectList().block();
+
+		assertThat(routes).containsExactly(newRoute);
 	}
 
 }


### PR DESCRIPTION
Fixes gh-3956

`CachingRouteLocator.updateCache()` was synchronized, but the synchronized
scope only protected creation of the asynchronous subscription. The actual
cache update could occur after the synchronized method had returned.

When multiple route refreshes overlap, an older and slower refresh can
therefore complete after a newer refresh and overwrite the cache with stale
route data.

This change assigns a monotonically increasing sequence number to each
refresh and only applies a cache result when it is newer than the last
successfully applied refresh.

A regression test verifies that when two refreshes complete out of order,
the result from the newest refresh remains cached.

Testing:
- New regression test passes
- CachingRouteLocatorTests passes
- spring-cloud-gateway-server-webflux module tests pass
- git diff --check passes