### PR TITLE
Fix forwarded headers for untrusted proxies

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -140,12 +140,10 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
 
-		boolean trustedRemoteAddress = request.getRemoteAddress() == null
-				|| trustedProxies.isTrusted(request.getRemoteAddress().getHostString());
-
 		HttpHeaders original = input;
 
-		if (!trustedRemoteAddress) {
+		if (request.getRemoteAddress() != null
+				&& !trustedProxies.isTrusted(request.getRemoteAddress().getHostString())) {
 			log.trace(LogMessage.format("Remote address not trusted. pattern %s remote address %s", trustedProxies,
 					request.getRemoteAddress()));
 			original = removeForwardedHeaders(input, exchange);

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilter.java
@@ -140,14 +140,17 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
 
-		if (request.getRemoteAddress() != null
-				&& !trustedProxies.isTrusted(request.getRemoteAddress().getHostString())) {
-			log.trace(LogMessage.format("Remote address not trusted. pattern %s remote address %s", trustedProxies,
-					request.getRemoteAddress()));
-			return removeForwardedHeaders(input, exchange);
-		}
+		boolean trustedRemoteAddress = request.getRemoteAddress() == null
+				|| trustedProxies.isTrusted(request.getRemoteAddress().getHostString());
 
 		HttpHeaders original = input;
+
+		if (!trustedRemoteAddress) {
+			log.trace(LogMessage.format("Remote address not trusted. pattern %s remote address %s", trustedProxies,
+					request.getRemoteAddress()));
+			original = removeForwardedHeaders(input, exchange);
+		}
+
 		HttpHeaders updated = new HttpHeaders();
 
 		// copy all headers except Forwarded
@@ -195,14 +198,11 @@ public class ForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 					forValue = "[" + forValue + "]";
 				}
 			}
-			if (trustedProxies.isTrusted(forValue)) {
-				// only add for value if trusted
-				int port = remoteAddress.getPort();
-				if (port >= 0) {
-					forValue = forValue + ":" + port;
-				}
-				forwarded.put("for", forValue);
+			int port = remoteAddress.getPort();
+			if (port >= 0) {
+				forValue = forValue + ":" + port;
 			}
+			forwarded.put("for", forValue);
 		}
 
 		if (forwardedByEnabled) {

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilter.java
@@ -222,14 +222,17 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 	public HttpHeaders filter(HttpHeaders input, ServerWebExchange exchange) {
 		ServerHttpRequest request = exchange.getRequest();
 
-		if (request.getRemoteAddress() != null
-				&& !trustedProxies.isTrusted(request.getRemoteAddress().getHostString())) {
-			log.trace(LogMessage.format("Remote address not trusted. pattern %s remote address %s", trustedProxies,
-					request.getRemoteAddress()));
-			return removeXForwardedHeaders(input, exchange);
-		}
+		boolean trustedRemoteAddress = request.getRemoteAddress() == null
+				|| trustedProxies.isTrusted(request.getRemoteAddress().getHostString());
 
 		HttpHeaders original = input;
+
+		if (!trustedRemoteAddress) {
+			log.trace(LogMessage.format("Remote address not trusted. pattern %s remote address %s", trustedProxies,
+					request.getRemoteAddress()));
+			original = removeXForwardedHeaders(input, exchange);
+		}
+
 		HttpHeaders updated = new HttpHeaders();
 
 		for (Map.Entry<String, List<String>> entry : original.headerSet()) {
@@ -242,7 +245,12 @@ public class XForwardedHeadersFilter implements HttpHeadersFilter, Ordered {
 				remoteAddr = request.getRemoteAddress().getHostString();
 			}
 			// match xforwarded for against trusted proxies
-			write(updated, X_FORWARDED_FOR_HEADER, remoteAddr, isForAppend(), trustedProxies::isTrusted);
+			if (trustedRemoteAddress) {
+				write(updated, X_FORWARDED_FOR_HEADER, remoteAddr, isForAppend(), trustedProxies::isTrusted);
+			}
+			else {
+				write(updated, X_FORWARDED_FOR_HEADER, remoteAddr, isForAppend(), value -> true);
+			}
 		}
 
 		String proto = request.getURI().getScheme();

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/ForwardedHeadersFilterTests.java
@@ -297,7 +297,16 @@ public class ForwardedHeadersFilterTests {
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
-		assertThat(headers.headerNames()).doesNotContain(FORWARDED_HEADER);
+		assertThat(headers.headerNames()).contains(FORWARDED_HEADER);
+
+		List<Forwarded> forwardeds = ForwardedHeadersFilter.parse(headers.get(FORWARDED_HEADER));
+
+		assertThat(forwardeds).hasSize(1);
+		Forwarded forwarded = forwardeds.get(0);
+
+		assertThat(forwarded.getValues()).containsEntry("host", "myhost")
+			.containsEntry("proto", "http")
+			.containsEntry("for", "\"10.0.0.1:80\"");
 	}
 
 	@Test
@@ -312,7 +321,20 @@ public class ForwardedHeadersFilterTests {
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
-		assertThat(headers.headerNames()).doesNotContain(FORWARDED_HEADER);
+		assertThat(headers.headerNames()).contains(FORWARDED_HEADER);
+
+		List<Forwarded> forwardeds = ForwardedHeadersFilter.parse(headers.get(FORWARDED_HEADER));
+
+		assertThat(forwardeds).hasSize(1);
+		Forwarded forwarded = forwardeds.get(0);
+
+		assertThat(forwarded.getValues()).containsEntry("host", "myhost")
+			.containsEntry("proto", "http")
+			.containsEntry("for", "\"10.0.0.1:80\"");
+
+		assertThat(headers.get(FORWARDED_HEADER)).noneMatch(value -> value.contains("127.0.0.1"));
+
+		assertThat(headers.get(FORWARDED_HEADER)).noneMatch(value -> value.contains("10.0.0.11"));
 	}
 
 	// verify that existing forwarded header is not forwarded if not trusted

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/headers/XForwardedHeadersFilterTests.java
@@ -375,8 +375,13 @@ public class XForwardedHeadersFilterTests {
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
-		assertThat(headers.headerNames()).doesNotContain(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
+		assertThat(headers.headerNames()).contains(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
 				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER);
+
+		assertThat(headers.getFirst(X_FORWARDED_FOR_HEADER)).isEqualTo("10.0.0.1");
+		assertThat(headers.getFirst(X_FORWARDED_HOST_HEADER)).isEqualTo("localhost:8080");
+		assertThat(headers.getFirst(X_FORWARDED_PORT_HEADER)).isEqualTo("8080");
+		assertThat(headers.getFirst(X_FORWARDED_PROTO_HEADER)).isEqualTo("http");
 	}
 
 	@Test
@@ -391,8 +396,14 @@ public class XForwardedHeadersFilterTests {
 
 		HttpHeaders headers = filter.filter(request.getHeaders(), MockServerWebExchange.from(request));
 
-		assertThat(headers.headerNames()).doesNotContain(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
+		assertThat(headers.headerNames()).contains(X_FORWARDED_FOR_HEADER, X_FORWARDED_HOST_HEADER,
 				X_FORWARDED_PORT_HEADER, X_FORWARDED_PROTO_HEADER);
+
+		assertThat(headers.getFirst(X_FORWARDED_FOR_HEADER)).isEqualTo("10.0.0.1");
+		assertThat(headers.getFirst(X_FORWARDED_FOR_HEADER)).doesNotContain("127.0.0.1");
+		assertThat(headers.getFirst(X_FORWARDED_HOST_HEADER)).isEqualTo("localhost:8080");
+		assertThat(headers.getFirst(X_FORWARDED_PORT_HEADER)).isEqualTo("8080");
+		assertThat(headers.getFirst(X_FORWARDED_PROTO_HEADER)).isEqualTo("http");
 	}
 
 	// : verify that existing x-forwarded-* headers are not forwarded


### PR DESCRIPTION
Fixes #4267

This PR fixes the behavior of `ForwardedHeadersFilter` and `XForwardedHeadersFilter` when a request comes from an untrusted proxy.

Previously, when the remote address was not trusted, the existing `Forwarded` or `X-Forwarded-*` headers were removed and the filter returned immediately. Because of this, the gateway was not generating new forwarded headers using the actual request information.

With this change, the headers received from an untrusted proxy are still removed, but the filter continues processing the request and generates new forwarded headers using the actual remote address and request details.

I have also updated the existing tests for both filters to verify this behavior and to make sure forwarded headers received from an untrusted proxy are not reused.

Tests updated:
- `ForwardedHeadersFilterTests`
- `XForwardedHeadersFilterTests`