### PR TITLE
Guard header copy against committed response in NettyRoutingFilter

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -179,12 +179,27 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 					// the content-length header.
 					// Remove the transfer-encoding header in the response if the
 					// content-length header is present.
-					response.getHeaders().remove(HttpHeaders.TRANSFER_ENCODING);
+					filteredResponseHeaders.remove(HttpHeaders.TRANSFER_ENCODING);
 				}
 
 				exchange.getAttributes().put(CLIENT_RESPONSE_HEADER_NAMES, filteredResponseHeaders.headerNames());
 
-				response.getHeaders().addAll(filteredResponseHeaders);
+				if (response.isCommitted()) {
+					// The response was already committed elsewhere in the filter chain
+					// before
+					// routing completed. response.getHeaders() becomes a
+					// ReadOnlyHttpHeaders once
+					// committed (see AbstractServerHttpResponse), so it can no longer be
+					// mutated --
+					// and headers can't reach the client past this point regardless.
+					if (log.isDebugEnabled()) {
+						log.debug("Response already committed, unable to write filtered response headers for "
+								+ exchange.getLogPrefix());
+					}
+				}
+				else {
+					response.getHeaders().addAll(filteredResponseHeaders);
+				}
 
 				return Mono.just(res);
 			}));

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyRoutingFilter.java
@@ -173,31 +173,31 @@ public class NettyRoutingFilter implements GlobalFilter, Ordered {
 				HttpHeaders filteredResponseHeaders = HttpHeadersFilter.filter(getHeadersFilters(), headers, exchange,
 						Type.RESPONSE);
 
-				if (!filteredResponseHeaders.containsHeader(HttpHeaders.TRANSFER_ENCODING)
-						&& filteredResponseHeaders.containsHeader(HttpHeaders.CONTENT_LENGTH)) {
-					// It is not valid to have both the transfer-encoding header and
-					// the content-length header.
-					// Remove the transfer-encoding header in the response if the
-					// content-length header is present.
-					filteredResponseHeaders.remove(HttpHeaders.TRANSFER_ENCODING);
-				}
-
 				exchange.getAttributes().put(CLIENT_RESPONSE_HEADER_NAMES, filteredResponseHeaders.headerNames());
 
 				if (response.isCommitted()) {
 					// The response was already committed elsewhere in the filter chain
-					// before
-					// routing completed. response.getHeaders() becomes a
-					// ReadOnlyHttpHeaders once
-					// committed (see AbstractServerHttpResponse), so it can no longer be
-					// mutated --
-					// and headers can't reach the client past this point regardless.
+					// before routing completed. response.getHeaders() becomes a
+					// ReadOnlyHttpHeaders once committed (see
+					// AbstractServerHttpResponse),
+					// so it can no longer be mutated -- and headers can't reach the
+					// client
+					// past this point regardless.
 					if (log.isDebugEnabled()) {
 						log.debug("Response already committed, unable to write filtered response headers for "
 								+ exchange.getLogPrefix());
 					}
 				}
 				else {
+					if (!filteredResponseHeaders.containsHeader(HttpHeaders.TRANSFER_ENCODING)
+							&& filteredResponseHeaders.containsHeader(HttpHeaders.CONTENT_LENGTH)) {
+						// It is not valid to have both the transfer-encoding header and
+						// the content-length header.
+						// Remove the transfer-encoding header in the response if the
+						// content-length header is present.
+						response.getHeaders().remove(HttpHeaders.TRANSFER_ENCODING);
+					}
+
 					response.getHeaders().addAll(filteredResponseHeaders);
 				}
 

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterTests.java
@@ -47,6 +47,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.test.util.TestSocketUtils;
@@ -151,6 +152,51 @@ class NettyRoutingFilterTests extends BaseWebClientTests {
 			when(chain.filter(any())).thenReturn(Mono.empty());
 
 			StepVerifier.create(nettyRoutingFilter.filter(exchange, chain)).verifyComplete();
+		}
+		finally {
+			server.disposeNow();
+		}
+	}
+
+	@Test
+	// gh-4270
+	void transferEncodingIsRemovedWhenUpstreamSendsContentLength() {
+		String body = "issue4270";
+		DisposableServer server = HttpServer.create()
+			.port(port)
+			.host("127.0.0.1")
+			.route(routes -> routes.get("/issue4270-content-length", (request, response) -> {
+				response.header(HttpHeaders.CONTENT_LENGTH, String.valueOf(body.length()));
+				return response.sendString(Mono.just(body));
+			}))
+			.bindNow();
+
+		try {
+			Route route = Route.async()
+				.id("issue4270-content-length")
+				.uri(URI.create("http://127.0.0.1:" + port))
+				.predicate(swe -> true)
+				.build();
+
+			ServerWebExchange exchange = MockServerWebExchange
+				.from(MockServerHttpRequest.get("http://localhost/issue4270-content-length").build());
+			exchange.getAttributes()
+				.put(GATEWAY_REQUEST_URL_ATTR, URI.create("http://127.0.0.1:" + port + "/issue4270-content-length"));
+			exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, route);
+
+			// A filter earlier in the chain may already have put Transfer-Encoding on the
+			// response. It is not valid alongside the Content-Length the upstream answers
+			// with, so the stale header has to be scrubbed from the response that is
+			// actually sent downstream, not from the copy of the upstream headers.
+			exchange.getResponse().getHeaders().add(HttpHeaders.TRANSFER_ENCODING, "chunked");
+
+			GatewayFilterChain chain = mock(GatewayFilterChain.class);
+			when(chain.filter(any())).thenReturn(Mono.empty());
+
+			StepVerifier.create(nettyRoutingFilter.filter(exchange, chain)).verifyComplete();
+
+			assertThat(exchange.getResponse().getHeaders().containsHeader(HttpHeaders.CONTENT_LENGTH)).isTrue();
+			assertThat(exchange.getResponse().getHeaders().containsHeader(HttpHeaders.TRANSFER_ENCODING)).isFalse();
 		}
 		finally {
 			server.disposeNow();

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyRoutingFilterTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.cloud.gateway.filter;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -29,6 +30,7 @@ import reactor.netty.DisposableServer;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientConfig;
 import reactor.netty.http.server.HttpServer;
+import reactor.test.StepVerifier;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringBootConfiguration;
@@ -45,10 +47,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.MapPropertySource;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.test.util.TestSocketUtils;
 import org.springframework.test.web.reactive.server.WebTestClient;
+import org.springframework.web.server.ServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_REQUEST_URL_ATTR;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.GATEWAY_ROUTE_ATTR;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class NettyRoutingFilterTests extends BaseWebClientTests {
@@ -98,6 +108,49 @@ class NettyRoutingFilterTests extends BaseWebClientTests {
 					String content = new String(entityExchangeResult.getResponseBody());
 					assertThat(content).isEqualTo("issue2207");
 				});
+		}
+		finally {
+			server.disposeNow();
+		}
+	}
+
+	@Test
+	// gh-4270
+	void routingAfterResponseAlreadyCommittedDoesNotThrow() {
+		DisposableServer server = HttpServer.create()
+			.port(port)
+			.host("127.0.0.1")
+			.route(routes -> routes.get("/issue4270",
+					(request, response) -> response.sendString(Mono.just("issue4270"))))
+			.bindNow();
+
+		try {
+			Route route = Route.async()
+				.id("issue4270")
+				.uri(URI.create("http://127.0.0.1:" + port))
+				.predicate(swe -> true)
+				.build();
+
+			ServerWebExchange exchange = MockServerWebExchange
+				.from(MockServerHttpRequest.get("http://localhost/issue4270").build());
+			exchange.getAttributes()
+				.put(GATEWAY_REQUEST_URL_ATTR, URI.create("http://127.0.0.1:" + port + "/issue4270"));
+			exchange.getAttributes().put(GATEWAY_ROUTE_ATTR, route);
+
+			// Simulate something upstream of NettyRoutingFilter (e.g. a security filter)
+			// already committing the response before routing completes.
+			// response.getHeaders()
+			// becomes a ReadOnlyHttpHeaders once committed (see
+			// AbstractServerHttpResponse),
+			// so the header-copy step in NettyRoutingFilter must tolerate that rather
+			// than
+			// throw UnsupportedOperationException.
+			exchange.getResponse().setComplete().block();
+
+			GatewayFilterChain chain = mock(GatewayFilterChain.class);
+			when(chain.filter(any())).thenReturn(Mono.empty());
+
+			StepVerifier.create(nettyRoutingFilter.filter(exchange, chain)).verifyComplete();
 		}
 		finally {
 			server.disposeNow();


### PR DESCRIPTION
Fixes gh-4270

## Problem

`NettyRoutingFilter` copies filtered response headers back onto the
client response near the end of `filter()`:

```java
response.getHeaders().remove(HttpHeaders.TRANSFER_ENCODING);
...
response.getHeaders().addAll(filteredResponseHeaders);
```

If the response has already been committed elsewhere in the filter
chain before routing completes, `AbstractServerHttpResponse#getHeaders()`
returns a cached `ReadOnlyHttpHeaders` wrapper instead of the mutable
headers map. Calling `remove(...)` or `addAll(...)` on that wrapper
throws `UnsupportedOperationException`, which surfaces as an error
signal on the filter chain instead of the response completing
normally.

## Fix

Guard the header-copy step with `response.isCommitted()`. Once a
response is committed, headers can no longer reach the client
regardless, so skipping the copy is safe and matches an existing
precedent already in the test codebase
(`BaseWebClientTests#modifyResponseFilter`, which uses the same
`isCommitted()` check before touching response headers).

## Testing

- Added `NettyRoutingFilterTests#routingAfterResponseAlreadyCommittedDoesNotThrow`,
  which pre-commits a `MockServerWebExchange` and asserts
  `nettyRoutingFilter.filter(...)` completes normally instead of
  erroring.
- Full `NettyRoutingFilterTests` suite passes.
- Verified with a negative control: reverting only the fix (keeping
  the new test) reproduces the exact reported
  `UnsupportedOperationException` at
  `ReadOnlyHttpHeaders.remove(ReadOnlyHttpHeaders.java:166)`, matching
  the original issue's stack trace. Restoring the fix passes cleanly.
