### PR TITLE
Return not found for unresolved function routes

### DIFF
--- a/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/HandlerFunctions.java
+++ b/spring-cloud-gateway-server-webmvc/src/main/java/org/springframework/cloud/gateway/server/mvc/handler/HandlerFunctions.java
@@ -30,12 +30,14 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.cloud.function.context.FunctionCatalog;
 import org.springframework.cloud.function.context.FunctionProperties;
+import org.springframework.cloud.function.context.MessageRoutingCallback;
 import org.springframework.cloud.function.context.catalog.SimpleFunctionRegistry.FunctionInvocationWrapper;
 import org.springframework.cloud.function.context.config.RoutingFunction;
 import org.springframework.cloud.gateway.server.mvc.GatewayMvcClassPathWarningAutoConfiguration;
 import org.springframework.cloud.gateway.server.mvc.common.MvcUtils;
 import org.springframework.cloud.gateway.server.mvc.config.RouteProperties;
 import org.springframework.cloud.stream.function.StreamOperations;
+import org.springframework.context.ApplicationContext;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
@@ -57,7 +59,8 @@ public abstract class HandlerFunctions {
 	public static HandlerFunction<ServerResponse> fn(String functionName) {
 		Assert.hasText(functionName, "'functionName' must not be empty");
 		return request -> {
-			FunctionCatalog functionCatalog = MvcUtils.getApplicationContext(request).getBean(FunctionCatalog.class);
+			ApplicationContext applicationContext = MvcUtils.getApplicationContext(request);
+			FunctionCatalog functionCatalog = applicationContext.getBean(FunctionCatalog.class);
 			String expandedFunctionName = MvcUtils.expand(request, functionName);
 			FunctionInvocationWrapper function;
 			Object body = null;
@@ -83,6 +86,17 @@ public abstract class HandlerFunctions {
 			 */
 			Map<String, String> additionalRequestHeaders = new HashMap<>();
 			if (function == null) {
+				FunctionInvocationWrapper routingTarget = functionCatalog.lookup(expandedFunctionName);
+				FunctionInvocationWrapper defaultRouteHandler = functionCatalog
+					.lookup(RoutingFunction.DEFAULT_ROUTE_HANDLER);
+				MessageRoutingCallback routingCallback = applicationContext
+					.getBeanProvider(MessageRoutingCallback.class)
+					.getIfAvailable();
+
+				if (routingTarget == null && defaultRouteHandler == null && routingCallback == null) {
+					return ServerResponse.notFound().build();
+				}
+
 				additionalRequestHeaders.put(FunctionProperties.FUNCTION_DEFINITION, expandedFunctionName);
 
 				function = functionCatalog.lookup(RoutingFunction.FUNCTION_NAME,

--- a/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/config/FunctionHandlerConfigTests.java
+++ b/spring-cloud-gateway-server-webmvc/src/test/java/org/springframework/cloud/gateway/server/mvc/config/FunctionHandlerConfigTests.java
@@ -78,6 +78,24 @@ public class FunctionHandlerConfigTests {
 			.isEqualTo("hello");
 	}
 
+	@Test
+	void unmatchedRouteReturnsNotFound() {
+		restClient.get().uri("/does-not-exist").exchange().expectStatus().isNotFound();
+	}
+
+	@Test
+	void automaticallyConfiguredFunctionRouteWorks() {
+		restClient.post()
+			.uri("/upper")
+			.accept(MediaType.TEXT_PLAIN)
+			.body("hello")
+			.exchange()
+			.expectStatus()
+			.isOk()
+			.expectBody(String.class)
+			.isEqualTo("HELLO");
+	}
+
 	@SpringBootConfiguration
 	@EnableAutoConfiguration
 	@Import(PermitAllSecurityConfiguration.class)


### PR DESCRIPTION
### Summary

Return `404 Not Found` when a default WebMVC function route cannot resolve a target function.

Previously, an unmatched request could fall through to Spring Cloud Function's `RoutingFunction` and fail during request processing, resulting in `415 Unsupported Media Type` instead of the expected `404 Not Found`.

The change preserves the existing `RoutingFunction` fallback when a routing target, default route handler, or `MessageRoutingCallback` is available.

### Changes

* Return `404 Not Found` when no function routing target can be resolved.
* Preserve the existing Spring Cloud Function `RoutingFunction` fallback behavior.
* Preserve automatic function routing for valid functions.
* Add regression coverage for unmatched routes.
* Add coverage verifying automatically configured function routes continue to work.

### Testing

Before the fix:

`GET /does-not-exist`

Expected: `404 NOT_FOUND`
Actual: `415 UNSUPPORTED_MEDIA_TYPE`

After the fix:

`GET /does-not-exist` → `404 NOT_FOUND`

Validation completed:

* `FunctionHandlerConfigTests`: 5 tests passed.
* `DefaultRouteFunctionHandlerTests`: 5 tests passed.
* Combined focused tests: 10 tests passed.
* `git diff --check`: clean.

A later full Maven reactor validation attempt was blocked before compilation because the upstream `spring-cloud-stream-dependencies:5.1.0-SNAPSHOT` BOM could not be resolved from the Spring snapshot repository.

Fixes #4170
