### PR TITLE
Dispose upstream connection when the response is already committed in `NettyWriteResponseFilter`

### DIFF
--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilter.java
@@ -45,6 +45,7 @@ import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.C
 
 /**
  * @author Spencer Gibb
+ * @author Seungbin Ko
  */
 public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 
@@ -92,12 +93,21 @@ public class NettyWriteResponseFilter implements GlobalFilter, Ordered {
 					if (connection == null) {
 						return Mono.empty();
 					}
+					ServerHttpResponse response = exchange.getResponse();
+					if (response.isCommitted()) {
+						if (log.isDebugEnabled()) {
+							log.debug("NettyWriteResponseFilter response already committed, discarding inbound: "
+									+ connection.channel().id().asShortText() + ", outbound: "
+									+ exchange.getLogPrefix());
+						}
+						cleanup(exchange);
+						return Mono.empty();
+					}
 					if (log.isTraceEnabled()) {
 						log.trace("NettyWriteResponseFilter start inbound: "
 								+ connection.channel().id().asShortText() + ", outbound: "
 								+ exchange.getLogPrefix());
 					}
-					ServerHttpResponse response = exchange.getResponse();
 
 					// TODO: needed?
 					final Flux<DataBuffer> body = connection

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilterTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/NettyWriteResponseFilterTests.java
@@ -21,17 +21,26 @@ import java.util.ArrayList;
 
 import io.netty.buffer.ByteBuf;
 import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import reactor.netty.Connection;
 
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.NettyDataBufferFactory;
 import org.springframework.core.io.buffer.PooledDataBuffer;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.http.server.reactive.MockServerHttpResponse;
+import org.springframework.mock.web.server.MockServerWebExchange;
 
 import static io.netty.buffer.PooledByteBufAllocator.DEFAULT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.cloud.gateway.support.ServerWebExchangeUtils.CLIENT_RESPONSE_CONN_ATTR;
 
 /**
  * @author Violeta Georgieva
+ * @author Seungbin Ko
  */
 public class NettyWriteResponseFilterTests {
 
@@ -43,6 +52,20 @@ public class NettyWriteResponseFilterTests {
 	@Test
 	public void testWrap_DefaultDataBufferFactory() {
 		doTestWrap(new MockServerHttpResponse());
+	}
+
+	@Test
+	public void committedResponseDisposesConnectionWithoutWriting() {
+		NettyWriteResponseFilter filter = new NettyWriteResponseFilter(new ArrayList<>(), null);
+		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/").build());
+		exchange.getResponse().setComplete().block();
+		Connection connection = mock(Connection.class);
+		exchange.getAttributes().put(CLIENT_RESPONSE_CONN_ATTR, connection);
+
+		filter.filter(exchange, ex -> Mono.empty()).block();
+
+		verify(connection).dispose();
+		verify(connection, never()).inbound();
 	}
 
 	private void doTestWrap(MockServerHttpResponse response) {


### PR DESCRIPTION
## Motivation

`NettyWriteResponseFilter` calls `response.writeWith(...)` with the upstream body even if the client response is already committed.
In that case nothing is written. The body stays in the Reactor Netty inbound queue and the chain completes normally.
The current cleanup runs only on `CANCEL` and `ON_ERROR`, so the queued buffers are never released.

Our gateway receives many client cancellations (HTTP 499). When a request is cancelled after the upstream response was already emitted but before its body was read, the leak reproduces. In production it appears as:

```
LEAK: ByteBuf.release() was not called before it's garbage-collected.
  Hint: [..., R:upstream:80] Buffered ByteBufHolder in the inbound buffer queue
  reactor.netty.channel.FluxReceive.onInboundNext(FluxReceive.java:397)
```

## Key changed

* Check `response.isCommitted()` before writing the upstream body.
* If already committed, skip the write and dispose the upstream connection with the existing `cleanup(exchange)`.
* Log at `DEBUG` level to help find what committed the response.
* Add `NettyWriteResponseFilterTests#committedResponseDisposesConnectionWithoutWriting`.

No behavior change for uncommitted responses. Writing to a committed response was already a no-op.