### PR TITLE
Do not propagate forwarded body Content-Type to the real response

### DIFF
--- a/spring-cloud-gateway-proxyexchange-webmvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
+++ b/spring-cloud-gateway-proxyexchange-webmvc/src/main/java/org/springframework/cloud/gateway/mvc/ProxyExchange.java
@@ -643,6 +643,28 @@ class ServletOutputToInputConverter extends HttpServletResponseWrapper {
 	}
 
 	@Override
+	public void setContentType(String type) {
+	}
+
+	@Override
+	public void setCharacterEncoding(String charset) {
+	}
+
+	@Override
+	public void setHeader(String name, String value) {
+		if (!HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
+			super.setHeader(name, value);
+		}
+	}
+
+	@Override
+	public void addHeader(String name, String value) {
+		if (!HttpHeaders.CONTENT_TYPE.equalsIgnoreCase(name)) {
+			super.addHeader(name, value);
+		}
+	}
+
+	@Override
 	public ServletOutputStream getOutputStream() throws IOException {
 		return new ServletOutputStream() {
 

--- a/spring-cloud-gateway-proxyexchange-webmvc/src/test/java/org/springframework/cloud/gateway/mvc/ProductionConfigurationTests.java
+++ b/spring-cloud-gateway-proxyexchange-webmvc/src/test/java/org/springframework/cloud/gateway/mvc/ProductionConfigurationTests.java
@@ -189,6 +189,24 @@ public class ProductionConfigurationTests {
 	}
 
 	@Test
+	public void postForwardBodyWithoutAcceptHeader() {
+		ResponseEntity<String> result = rest
+			.exchange(RequestEntity.post(rest.getRestTemplate().getUriTemplateHandler().expand("/forward/body/bars"))
+				.body(Collections.singletonList(Collections.singletonMap("name", "foo"))), String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).contains("foo");
+	}
+
+	@Test
+	public void postForwardForgetBodyWithoutAcceptHeader() {
+		ResponseEntity<String> result = rest
+			.exchange(RequestEntity.post(rest.getRestTemplate().getUriTemplateHandler().expand("/forward/forget/bars"))
+				.body(Collections.singletonList(Collections.singletonMap("name", "foo"))), String.class);
+		assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(result.getBody()).contains("foo");
+	}
+
+	@Test
 	public void postForwardBodyFoo() {
 		ResponseEntity<List<Bar>> result = rest.exchange(
 				RequestEntity.post(rest.getRestTemplate().getUriTemplateHandler().expand("/forward/body/bars"))


### PR DESCRIPTION
`ProxyExchange.forward()` returns HTTP 500 for any request whose client sends no `Accept` header on recent Tomcat versions.

### Cause

`ProxyExchange.forward()` renders the request body through a `HttpServletResponseWrapper` that captures the rendered bytes so they can be replayed as the forwarded request's input.

The wrapper does not intercept `Content-Type`, so it delegates to the real response. The type written there is the one negotiated for the outer request. A body rendered as `String` for a client that sent no `Accept` header negotiates `text/plain`. That value stays on the real response when the forward is dispatched.

Historically this was harmless. `Response.getHeader("Content-Type")` returned `null`, so the forwarded handler re-negotiated and picked its own type. Tomcat changed `getHeader` to return the content type (https://bz.apache.org/bugzilla/show_bug.cgi?id=69967, released in 9.0.116, 10.1.53 and 11.0.19). The forwarded handler now sees `Content-Type` as already set, skips re-negotiation, finds no `text/plain` converter for its return type, and fails with HTTP 500.

### Why existing tests did not catch this

`postForwardBody` and `postForwardForgetBody` are the two tests that exercise this path, and both send `Accept: applicati on/json` , which negotiates a type the forwarded handler can also produce, so the propagated `Content-Type` is one the handler can satisfy.