### PR TITLE
Add option to disable all secure headers

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/secureheaders-factory.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-gateway-server-webflux/gatewayfilter-factories/secureheaders-factory.adoc
@@ -40,6 +40,25 @@ spring:
           disable: x-frame-options,strict-transport-security
 ----
 
+To disable all secure headers, set the `disable` property to `all`:
+
+.application.yml
+[source,yaml]
+----
+spring:
+  cloud:
+    gateway:
+      server:
+        webflux:
+          filter:
+            secure-headers:
+              disable: all
+----
+
+This also disables explicitly enabled headers, such as `Permissions-Policy`.
+Headers already present in the response are preserved.
+The same `disable: all` value can be used in route filter arguments.
+
 To apply the `SecureHeaders` filter to a specific route, add the filter to the list of filters of that route.
 You can customize the route filter using arguments. Route configuration overrides the global default configuration for this route.
 

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactory.java
@@ -175,14 +175,19 @@ public class SecureHeadersGatewayFilterFactory
 	 */
 	private Set<String> assembleHeaders(Config config, SecureHeadersProperties properties) {
 		Set<String> headersToAddToResponse = new HashSet<>(properties.getDefaultHeaders());
+		Set<String> disabledHeaders;
 		if (config.isRouteFilterConfigProvided()) {
 			headersToAddToResponse.addAll(config.getRouteEnabledHeaders());
-			headersToAddToResponse.removeAll(config.getRouteDisabledHeaders());
+			disabledHeaders = config.getRouteDisabledHeaders();
 		}
 		else {
 			headersToAddToResponse.addAll(properties.getEnabledHeaders());
-			headersToAddToResponse.removeAll(properties.getDisabledHeaders());
+			disabledHeaders = properties.getDisabledHeaders();
 		}
+		if (disabledHeaders.contains(SecureHeadersProperties.ALL_HEADERS)) {
+			return Set.of();
+		}
+		headersToAddToResponse.removeAll(disabledHeaders);
 		return headersToAddToResponse;
 	}
 
@@ -362,7 +367,7 @@ public class SecureHeadersGatewayFilterFactory
 			if (enable != null) {
 				this.routeFilterConfigProvided = true;
 				this.routeEnabledHeaders = enable.stream()
-					.map(String::toLowerCase)
+					.map(SecureHeadersProperties::normalizeHeaderName)
 					.collect(Collectors.toUnmodifiableSet());
 			}
 		}
@@ -381,7 +386,7 @@ public class SecureHeadersGatewayFilterFactory
 			if (disable != null) {
 				this.routeFilterConfigProvided = true;
 				this.routeDisabledHeaders = disable.stream()
-					.map(String::toLowerCase)
+					.map(SecureHeadersProperties::normalizeHeaderName)
 					.collect(Collectors.toUnmodifiableSet());
 			}
 		}

--- a/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersProperties.java
+++ b/spring-cloud-gateway-server-webflux/src/main/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersProperties.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.gateway.filter.factory;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,6 +30,11 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties("spring.cloud.gateway.server.webflux.filter.secure-headers")
 public class SecureHeadersProperties {
+
+	/**
+	 * Value that disables all secure headers.
+	 */
+	public static final String ALL_HEADERS = "all";
 
 	/**
 	 * Xss-Protection header name.
@@ -139,7 +145,7 @@ public class SecureHeadersProperties {
 				SecureHeadersProperties.REFERRER_POLICY_HEADER, SecureHeadersProperties.CONTENT_SECURITY_POLICY_HEADER,
 				SecureHeadersProperties.X_DOWNLOAD_OPTIONS_HEADER,
 				SecureHeadersProperties.X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER)
-			.map(String::toLowerCase)
+			.map(SecureHeadersProperties::normalizeHeaderName)
 			.collect(Collectors.toUnmodifiableSet());
 
 	}
@@ -254,7 +260,9 @@ public class SecureHeadersProperties {
 	 */
 	public void setDisable(List<String> disable) {
 		if (disable != null) {
-			disabledHeaders = disable.stream().map(String::toLowerCase).collect(Collectors.toUnmodifiableSet());
+			disabledHeaders = disable.stream()
+				.map(SecureHeadersProperties::normalizeHeaderName)
+				.collect(Collectors.toUnmodifiableSet());
 		}
 	}
 
@@ -272,7 +280,9 @@ public class SecureHeadersProperties {
 	 */
 	public void setEnable(List<String> enable) {
 		if (enable != null) {
-			enabledHeaders = enable.stream().map(String::toLowerCase).collect(Collectors.toUnmodifiableSet());
+			enabledHeaders = enable.stream()
+				.map(SecureHeadersProperties::normalizeHeaderName)
+				.collect(Collectors.toUnmodifiableSet());
 		}
 	}
 
@@ -288,6 +298,10 @@ public class SecureHeadersProperties {
 	 */
 	public Set<String> getDefaultHeaders() {
 		return defaultHeaders;
+	}
+
+	static String normalizeHeaderName(String headerName) {
+		return headerName.toLowerCase(Locale.ROOT);
 	}
 
 	@Override

--- a/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
+++ b/spring-cloud-gateway-server-webflux/src/test/java/org/springframework/cloud/gateway/filter/factory/SecureHeadersGatewayFilterFactoryUnitTests.java
@@ -18,14 +18,19 @@ package org.springframework.cloud.gateway.filter.factory;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import reactor.core.publisher.Mono;
 
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.server.reactive.ServerHttpResponse;
@@ -104,6 +109,73 @@ public class SecureHeadersGatewayFilterFactoryUnitTests {
 				REFERRER_POLICY_HEADER, CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER,
 				X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER);
 
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "all", "ALL", "aLl" })
+	public void doNotAddAnyHeaderWhenAllHeadersAreDisabled(String disabledHeaders) {
+		String prefix = "spring.cloud.gateway.server.webflux.filter.secure-headers";
+		SecureHeadersProperties properties = new Binder(new MapConfigurationPropertySource(
+				Map.of(prefix + ".enable", "permissions-policy", prefix + ".disable", disabledHeaders)))
+			.bindOrCreate(prefix, SecureHeadersProperties.class);
+
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
+		filter = filterFactory.apply(new Config());
+
+		filter.filter(exchange, filterChain).block();
+
+		ServerHttpResponse response = captor.getValue().getResponse();
+		assertThat(response.getHeaders().headerNames()).isEmpty();
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "all", "ALL", "aLl" })
+	public void routeConfigCanDisableAllHeaders(String disabledHeaders) {
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(
+				new SecureHeadersProperties());
+
+		Config config = new Binder(
+				new MapConfigurationPropertySource(Map.of("enable", "permissions-policy", "disable", disabledHeaders)))
+			.bindOrCreate("", Config.class);
+
+		filter = filterFactory.apply(config);
+
+		filter.filter(exchange, filterChain).block();
+
+		ServerHttpResponse response = captor.getValue().getResponse();
+		assertThat(response.getHeaders().headerNames()).isEmpty();
+	}
+
+	@Test
+	public void routeConfigOverridesGloballyDisabledAllHeaders() {
+		SecureHeadersProperties properties = new SecureHeadersProperties();
+		properties.setDisable(List.of("all"));
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
+		Config config = new Config();
+		config.setDisable(Set.of("strict-transport-security"));
+		config.setEnable(Set.of("permissions-policy"));
+		filter = filterFactory.apply(config);
+
+		filter.filter(exchange, filterChain).block();
+
+		assertThat(exchange.getResponse().getHeaders().headerNames()).containsOnly(X_XSS_PROTECTION_HEADER,
+				X_FRAME_OPTIONS_HEADER, X_CONTENT_TYPE_OPTIONS_HEADER, REFERRER_POLICY_HEADER,
+				CONTENT_SECURITY_POLICY_HEADER, X_DOWNLOAD_OPTIONS_HEADER, X_PERMITTED_CROSS_DOMAIN_POLICIES_HEADER,
+				PERMISSIONS_POLICY_HEADER);
+	}
+
+	@Test
+	public void disablingAllHeadersPreservesExistingResponseHeaders() {
+		SecureHeadersProperties properties = new SecureHeadersProperties();
+		properties.setDisable(List.of("all"));
+		SecureHeadersGatewayFilterFactory filterFactory = new SecureHeadersGatewayFilterFactory(properties);
+		filter = filterFactory.apply(new Config());
+		exchange.getResponse().getHeaders().set(X_FRAME_OPTIONS_HEADER, "SAMEORIGIN");
+
+		filter.filter(exchange, filterChain).block();
+
+		assertThat(exchange.getResponse().getHeaders().headerNames()).containsOnly(X_FRAME_OPTIONS_HEADER);
+		assertThat(exchange.getResponse().getHeaders().get(X_FRAME_OPTIONS_HEADER)).containsExactly("SAMEORIGIN");
 	}
 
 	@Test


### PR DESCRIPTION
Adds `disable: all` support for the SecureHeaders filter so every secure header can be disabled without listing them individually.

This applies to both global configuration and route filter arguments. The setting also takes precedence over explicitly enabled optional headers, while preserving any headers already present on the response.

Fixes gh-2932.